### PR TITLE
[PATCH V2 0/7] MegaRAID Plugin bug fixes and code tidy up.

### DIFF
--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -27,9 +27,6 @@ from lsm import (uri_parse, search_property, size_human_2_size_bytes,
 
 from lsm.plugin.megaraid.utils import cmd_exec, ExecError
 
-_FLAG_RSVD = Client.FLAG_RSVD
-
-
 # Naming scheme
 #   mega_sys_path   /c0
 #   mega_disk_path  /c0/e64/s0
@@ -246,7 +243,7 @@ class MegaRAID(IPlugin):
         raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
 
     @_handle_errors
-    def capabilities(self, system, flags=_FLAG_RSVD):
+    def capabilities(self, system, flags=Client.FLAG_RSVD):
         cur_lsm_syss = self.systems()
         if system.id not in list(s.id for s in cur_lsm_syss):
             raise LsmError(
@@ -328,7 +325,7 @@ class MegaRAID(IPlugin):
             return ctrl_show_all_output['Basics']['Serial Number']
 
     @_handle_errors
-    def systems(self, flags=0):
+    def systems(self, flags=Client.FLAG_RSVD):
         rc_lsm_syss = []
         for ctrl_num in range(self._ctrl_count()):
             ctrl_show_all_output = self._storcli_exec(
@@ -352,7 +349,8 @@ class MegaRAID(IPlugin):
         return rc_lsm_syss
 
     @_handle_errors
-    def disks(self, search_key=None, search_value=None, flags=_FLAG_RSVD):
+    def disks(self, search_key=None, search_value=None,
+              flags=Client.FLAG_RSVD):
         rc_lsm_disks = []
         mega_disk_path_regex = re.compile(
             r"^Drive (\/c[0-9]+\/e[0-9]+\/s[0-9]+) - Detailed Information$")
@@ -470,7 +468,8 @@ class MegaRAID(IPlugin):
             sys_id, pool_id, plugin_data)
 
     @_handle_errors
-    def volumes(self, search_key=None, search_value=None, flags=0):
+    def volumes(self, search_key=None, search_value=None,
+                flags=Client.FLAG_RSVD):
         lsm_vols = []
         for ctrl_num in range(self._ctrl_count()):
             vol_show_output = self._storcli_exec(

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -22,7 +22,7 @@ import errno
 
 from lsm import (uri_parse, search_property, size_human_2_size_bytes,
                  Capabilities, LsmError, ErrorNumber, System, Client,
-                 Disk, VERSION, search_property, IPlugin, Pool, Volume)
+                 Disk, VERSION, IPlugin, Pool, Volume)
 
 from lsm.plugin.megaraid.utils import cmd_exec, ExecError
 

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -255,6 +255,7 @@ class MegaRAID(IPlugin):
         cap = Capabilities()
         cap.set(Capabilities.DISKS)
         cap.set(Capabilities.VOLUMES)
+        cap.set(Capabilities.VOLUME_RAID_INFO)
         return cap
 
     def _storcli_exec(self, storcli_cmds, flag_json=True):

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -182,7 +182,7 @@ def _mega_raid_type_to_lsm(vd_basic_info, vd_prop_info):
 
 
 class MegaRAID(IPlugin):
-    _DEFAULT_MDADM_BIN_PATHS = [
+    _DEFAULT_BIN_PATHS = [
         "/opt/MegaRAID/storcli/storcli64", "/opt/MegaRAID/storcli/storcli"]
     _CMD_JSON_OUTPUT_SWITCH = 'J'
 
@@ -191,9 +191,9 @@ class MegaRAID(IPlugin):
 
     def _find_storcli(self):
         """
-        Try _DEFAULT_MDADM_BIN_PATHS
+        Try _DEFAULT_BIN_PATHS
         """
-        for cur_path in MegaRAID._DEFAULT_MDADM_BIN_PATHS:
+        for cur_path in MegaRAID._DEFAULT_BIN_PATHS:
             if os.path.lexists(cur_path):
                 self._storcli_bin = cur_path
 

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -117,7 +117,7 @@ def _mega_size_to_lsm(mega_size):
     LSI Using 'TB, GB, MB, KB' and etc, for LSM, they are 'TiB' and etc.
     Return int of block bytes
     """
-    re_regex = re.compile("^([0-9\.]+) ([EPTGMK])B$")
+    re_regex = re.compile("^([0-9.]+) ([EPTGMK])B$")
     re_match = re_regex.match(mega_size)
     if re_match:
         return size_human_2_size_bytes(

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -17,7 +17,6 @@
 
 import os
 import json
-from string import strip
 import re
 import errno
 


### PR DESCRIPTION
 * Bug fixes patches:
  * MegaRAID Plugin: Add missing capability VOLUME_RAID_INFO
  * MegaRAID Plugin: Fix incorrect system status query.

 * Code tidy up patches:
  * MegaRAID Plugin: Use Client.FLAG_RSVD instead of flags=0.
  * MegaRAID Plugin: Fix incorrect internal constant name:
    _DEFAULT_MDADM_BIN_PATHS
  * MegaRAID Plugin: Remove unused import of strip.
  * MegaRAID Plugin: Fix Anomalous backslash in string of regex.

Changes in V2:
 * Patch 4/7: Use _DEFAULT_BIN_PATHS instead.
 * Patch 7/7: New patch: Remove duplicate import  'search_property'.