### PR TITLE
[PATCH V4 0/6] Add new disk status: STATUS_FREE

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -237,6 +237,16 @@ typedef enum {
 #define LSM_DISK_STATUS_MAINTENANCE_MODE            0x0000000000000400
 #define LSM_DISK_STATUS_SPARE_DISK                  0x0000000000000800
 #define LSM_DISK_STATUS_RECONSTRUCT                 0x0000000000001000
+#define LSM_DISK_STATUS_FREE                        0x0000000000002000
+/**^
+ * New in version 1.2, New in version 1.2, indicate the whole disk is not
+ * holding any data or acting as a dedicate spare disk.
+ * This disk could be assigned as a dedicated spare disk or used for creating
+ * pool.
+ * If any spare disk(like those on NetApp ONTAP) does not require any explicit
+ * action when assigning to pool, it should be treated as free disk and marked
+ * as LSM_DISK_STATUS_FREE|LSM_DISK_STATUS_SPARE_DISK.
+ * */
 
 #define LSM_DISK_BLOCK_SIZE_NOT_FOUND               -1
 #define LSM_DISK_BLOCK_COUNT_NOT_FOUND              -1

--- a/plugin/sim/simarray.py
+++ b/plugin/sim/simarray.py
@@ -194,7 +194,7 @@ class BackStore(object):
 
     DISK_KEY_LIST = [
         'id', 'name', 'total_space', 'disk_type', 'status',
-        'owner_pool_id']
+        'owner_pool_id', 'role']
 
     VOL_KEY_LIST = [
         'id', 'vpd83', 'name', 'total_space', 'consumed_size',
@@ -1762,12 +1762,16 @@ class SimArray(object):
 
     @staticmethod
     def _sim_disk_2_lsm(sim_disk):
+        disk_status = Disk.STATUS_OK
+        if sim_disk['role'] is None:
+            disk_status |= Disk.STATUS_FREE
+
         return Disk(
             SimArray._sim_id_to_lsm_id(sim_disk['id'], 'DISK'),
             sim_disk['name'],
             sim_disk['disk_type'], BackStore.BLK_SIZE,
             int(sim_disk['total_space'] / BackStore.BLK_SIZE),
-            Disk.STATUS_OK, BackStore.SYS_ID)
+            disk_status, BackStore.SYS_ID)
 
     @_handle_errors
     def disks(self):

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -199,6 +199,14 @@ class Disk(IData):
     # Indicate disk is a spare disk.
     STATUS_RECONSTRUCT = 1 << 12
     # Indicate disk is reconstructing data.
+    STATUS_FREE = 1 << 13
+    # New in version 1.2, indicate the whole disk is not holding any data or
+    # acting as a dedicate spare disk.
+    # This disk could be assigned as a dedicated spare disk or used for
+    # creating pool.
+    # If any spare disk(like those on NetApp ONTAP) does not require
+    # any explicit action when assigning to pool, it should be treated as
+    # free disk and marked as STATUS_FREE|STATUS_SPARE_DISK.
 
     def __init__(self, _id, _name, _disk_type, _block_size, _num_of_blocks,
                  _status, _system_id, _plugin_data=None):

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -201,6 +201,7 @@ _DISK_STATUS_CONV = {
     Disk.STATUS_MAINTENANCE_MODE: 'Maintenance',
     Disk.STATUS_SPARE_DISK: 'Spare',
     Disk.STATUS_RECONSTRUCT: 'Reconstruct',
+    Disk.STATUS_FREE: 'Free',
 }
 
 


### PR DESCRIPTION
 * This patch set introduced new disk status -- STATUS_FREE to indicate
   disk could be used for pool or assign as dedicated spare disk.

Changes in V2:

 * Patch 6/7: Fix incorrect data assignment in MegaRAID plugin.
 * Patch 5/7: Don't mark partner's disks as free disk in ONTAP plugin..
 * Patch 7/7: Include SMI-S plugin support for STATUS_FREE using
              vendor specific ways. Also come with STATUS_SPARE_DISK support.

Changes in V3:
 * Patch 6/9: Remove the debug print line in simulator plugin.
 * Patch 1/9: New patch. Change currnt git tree version as 1.2.
 * Patch 2/9: New patch. Fix missing VOLUME_RAID_INFO capability of megaraid
              plugin.

Changes in V4:
 * Removed unrelated patches and submitted them in separate patch sets.
 * Removed LSI MegaRAID SMI-S Disk.STATUS_FREE code as we have dedicate
   MegaRAID plugin now.