### PR TITLE
[PATCH V5 0/7] New HP SmartArray Plugin.

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -11,3 +11,8 @@ if WITH_MEGARAID
 pluginconf_DATA += pluginconf.d/megaraid.conf
 EXTRA_DIST += pluginconf.d/megaraid.conf
 endif
+
+if WITH_HPSA
+pluginconf_DATA += pluginconf.d/hpsa.conf
+EXTRA_DIST += pluginconf.d/hpsa.conf
+endif

--- a/config/pluginconf.d/hpsa.conf
+++ b/config/pluginconf.d/hpsa.conf
@@ -1,0 +1,1 @@
+require-root-privilege = true;

--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,18 @@ AC_ARG_WITH([megaraid],
 AM_CONDITIONAL([WITH_MEGARAID], [test "x$with_megaraid" = "xyes"])
 
 dnl ==========================================================================
+dnl Add option '--without-hpsa' to exclude hpsa plugin.
+dnl ==========================================================================
+
+AC_ARG_WITH([hpsa],
+    [AS_HELP_STRING([--without-hpsa],
+        [Do not build the HP SmartArray plugin])],
+    [],
+    [with_hpsa=yes])
+
+AM_CONDITIONAL([WITH_HPSA], [test "x$with_hpsa" = "xyes"])
+
+dnl ==========================================================================
 dnl Check for libconfig as it is needed for lsmd daemon
 dnl ==========================================================================
 PKG_CHECK_MODULES(
@@ -221,6 +233,7 @@ AC_OUTPUT(libstoragemgmt.pc \
           plugin/Makefile \
           plugin/simc/Makefile \
           plugin/megaraid/Makefile \
+          plugin/hpsa/Makefile \
           daemon/Makefile \
           config/Makefile \
           doc/Makefile \
@@ -229,6 +242,7 @@ AC_OUTPUT(libstoragemgmt.pc \
           doc/doxygen.conf \
           doc/man/lsmd.conf.5 \
           doc/man/megaraid_lsmplugin.1 \
+          doc/man/hpsa_lsmplugin.1 \
           tools/Makefile \
           tools/udev/Makefile \
           tools/lsmcli/Makefile \

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -4,4 +4,8 @@ if WITH_MEGARAID
 notrans_dist_man1_MANS += megaraid_lsmplugin.1
 endif
 
+if WITH_HPSA
+notrans_dist_man1_MANS += hpsa_lsmplugin.1
+endif
+
 notrans_dist_man5_MANS = lsmd.conf.5.in

--- a/doc/man/hpsa_lsmplugin.1.in
+++ b/doc/man/hpsa_lsmplugin.1.in
@@ -1,0 +1,50 @@
+.TH hpsa_lsmplugin "1" "March 2015" "hpsa_lsmplugin @VERSION@" "libStorageMgmt"
+.SH NAME
+hpsa_lsmplugin -- LibstorageMgmt HP SmartArray plugin
+
+.SH DESCRIPTION
+LibstorageMgmt hpsa plugin allows user to manage HP SmartArray via vendor
+tool \fBhpssacli\fR[1].
+The 'hpsa_lsmplugin' executable file is for libStorageMgmt
+daemon to execute when client user specifies hpsa plugin in the URI.
+
+.SH URI
+To use this plugin, users should set their URI to this format:
+.nf
+
+    \fBhpsa://\fR
+        or
+    \fBhpsa://?hpssacli=<path_of_hpssacli>\fR
+
+.fi
+
+.TP hpssacli
+The 'hpssacli' URI parameter is used to specified the path of hpssacli tool.
+By default, this plugin will try these paths used by hpssacli rpm:
+\fB/usr/sbin/hpssacli\fR and \fB/opt/hp/hpssacli/bld/hpssacli\fR.
+
+.SH ROOT PRIVILEGE
+This plugin requires both \fBlsmd\fR daemon and API client running as root
+user. Please check manpage \fIlsmd.conf (5)\fR for detail.
+
+.SH SUPPORTED HARDWARES
+Please refer to HP website for hardware support status of hpssacli.
+Detailed support status can be queried via:
+
+ * \fBlsm.Client.capabilities()\fR  (Python API)
+ * \fBlsm_capabilities()\fR         (C API)
+ * \fBlsmcli capabilities\fR        (lsmcli command line).
+
+.SH FIREWALL RULES
+This plugin only execute \fBhpssacli\fR on localhost. No network connection
+required.
+
+.SH SEE ALSO
+\fIlsmcli\fR(1), \fIlsmd\fR(1), [1]http://downloads.linux.hp.com/SDR/project/spp/
+
+.SH BUGS
+Please report bugs to
+\fI<libstoragemgmt-devel@lists.sourceforge.net>\fR
+
+.SH AUTHOR
+Gris Ge \fI<fge@redhat.com>\fR

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -597,6 +597,7 @@ fi
 %dir %{python_sitelib}/lsm/plugin/hpsa
 %{python_sitelib}/lsm/plugin/hpsa/__init__.*
 %{python_sitelib}/lsm/plugin/hpsa/hpsa.*
+%{python_sitelib}/lsm/plugin/hpsa/utils.*
 %{_bindir}/hpsa_lsmplugin
 %{_sysconfdir}/lsm/pluginconf.d/hpsa.conf
 %{_mandir}/man1/hpsa_lsmplugin.1*

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -1,5 +1,6 @@
 %bcond_with rest_api
 %bcond_without megaraid
+%bcond_without hpsa
 
 # Use one-line macro for OBS workaround:
 #   https://bugzilla.novell.com/show_bug.cgi?id=864323
@@ -8,6 +9,9 @@
 
 %{?_with_megaraid: %global with_megaraid 1 }
 %{?_without_megaraid: %global with_megaraid 0 }
+
+%{?_with_hpsa: %global with_hpsa 1 }
+%{?_without_hpsa: %global with_hpsa 0 }
 
 %define libsoname libstoragemgmt
 
@@ -224,6 +228,17 @@ The %{libstoragemgmt}-megaraid-plugin package contains the plugin for LSI
 MegaRAID storage management via storcli.
 %endif
 
+%if 0%{?with_hpsa}
+%package        -n %{libstoragemgmt}-hpsa-plugin
+Summary:        Files for HP SmartArray support for %{libstoragemgmt}
+Group:          System Environment/Libraries
+Requires:       %{libstoragemgmt}%{?_isa} = %{version}-%{release}
+BuildArch:      noarch
+
+%description    -n %{libstoragemgmt}-hpsa-plugin
+The %{libstoragemgmt}-hpsa-plugin package contains the plugin for HP
+SmartArray storage management via hpssacli.
+%endif
 
 %prep
 %setup -q
@@ -237,6 +252,9 @@ MegaRAID storage management via storcli.
 %endif
 %if 0%{?with_megaraid} != 1
     --without-megaraid \
+%endif
+%if 0%{?with_hpsa} != 1
+    --without-hpsa \
 %endif
     --disable-static
 
@@ -450,6 +468,22 @@ if [ $1 -eq 0 ]; then
 fi
 %endif
 
+%if 0%{?with_hpsa}
+# Need to restart lsmd if plugin is new installed or removed.
+%post -n %{libstoragemgmt}-hpsa-plugin
+if [ $1 -eq 1 ]; then
+    # New install.
+    /usr/bin/systemctl try-restart libstoragemgmt.service \
+        >/dev/null 2>&1 || :
+fi
+%postun -n %{libstoragemgmt}-hpsa-plugin
+if [ $1 -eq 0 ]; then
+    # Remove
+    /usr/bin/systemctl try-restart libstoragemgmt.service \
+        >/dev/null 2>&1 || :
+fi
+%endif
+
 %files -n %{libstoragemgmt}
 %defattr(-,root,root,-)
 %doc README COPYING.LIB
@@ -555,6 +589,17 @@ fi
 %{_bindir}/megaraid_lsmplugin
 %{_sysconfdir}/lsm/pluginconf.d/megaraid.conf
 %{_mandir}/man1/megaraid_lsmplugin.1*
+%endif
+
+%if 0%{?with_hpsa}
+%files -n %{libstoragemgmt}-hpsa-plugin
+%defattr(-,root,root,-)
+%dir %{python_sitelib}/lsm/plugin/hpsa
+%{python_sitelib}/lsm/plugin/hpsa/__init__.*
+%{python_sitelib}/lsm/plugin/hpsa/hpsa.*
+%{_bindir}/hpsa_lsmplugin
+%{_sysconfdir}/lsm/pluginconf.d/hpsa.conf
+%{_mandir}/man1/hpsa_lsmplugin.1*
 %endif
 
 %files udev

--- a/plugin/Makefile.am
+++ b/plugin/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS=simc megaraid
+SUBDIRS=simc megaraid hpsa
 
 plugindir = $(pythondir)/lsm/plugin
 

--- a/plugin/hpsa/Makefile.am
+++ b/plugin/hpsa/Makefile.am
@@ -1,0 +1,8 @@
+if WITH_HPSA
+plugindir = $(pythondir)/lsm/plugin
+hpsadir = $(plugindir)/hpsa
+
+hpsa_PYTHON = __init__.py hpsa.py
+
+dist_bin_SCRIPTS= hpsa_lsmplugin
+endif

--- a/plugin/hpsa/Makefile.am
+++ b/plugin/hpsa/Makefile.am
@@ -2,7 +2,7 @@ if WITH_HPSA
 plugindir = $(pythondir)/lsm/plugin
 hpsadir = $(plugindir)/hpsa
 
-hpsa_PYTHON = __init__.py hpsa.py
+hpsa_PYTHON = __init__.py hpsa.py utils.py
 
 dist_bin_SCRIPTS= hpsa_lsmplugin
 endif

--- a/plugin/hpsa/__init__.py
+++ b/plugin/hpsa/__init__.py
@@ -1,0 +1,1 @@
+from lsm.plugin.hpsa.hpsa import SmartArray

--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -15,38 +15,230 @@
 #
 # Author: Gris Ge <fge@redhat.com>
 
+import os
+import errno
+
 from lsm import (
-    IPlugin, Client, Capabilities, VERSION, LsmError, ErrorNumber)
+    IPlugin, Client, Capabilities, VERSION, LsmError, ErrorNumber, uri_parse,
+    System)
+
+from lsm.plugin.hpsa.utils import cmd_exec, ExecError
+
+
+def _handle_errors(method):
+    def _wrapper(*args, **kwargs):
+        try:
+            return method(*args, **kwargs)
+        except LsmError:
+            raise
+        except KeyError as key_error:
+            raise LsmError(
+                ErrorNumber.PLUGIN_BUG,
+                "Expected key missing from SmartArray hpssacli output:%s" %
+                key_error)
+        except ExecError as exec_error:
+            if 'No controllers detected' in exec_error.stdout:
+                raise LsmError(
+                    ErrorNumber.NOT_FOUND_SYSTEM,
+                    "No HP SmartArray deteceted by hpssacli.")
+            else:
+                raise LsmError(ErrorNumber.PLUGIN_BUG, str(exec_error))
+        except Exception as common_error:
+            raise LsmError(
+                ErrorNumber.PLUGIN_BUG,
+                "Got unexpected error %s" % common_error)
+
+    return _wrapper
+
+
+def _sys_status_of(hp_ctrl_status):
+    """
+    Base on data of "hpssacli ctrl all show status"
+    """
+    status_info = ''
+    status = System.STATUS_UNKNOWN
+    check_list = [
+        'Controller Status', 'Cache Status', 'Battery/Capacitor Status']
+    for key_name in check_list:
+        if key_name in hp_ctrl_status and hp_ctrl_status[key_name] != 'OK':
+            # TODO(Gris Ge): Beg HP for possible values
+            status = System.STATUS_OTHER
+            status_info += hp_ctrl_status[key_name]
+
+    if status != System.STATUS_OTHER:
+        status = System.STATUS_OK
+
+    return status, status_info
+
+
+def _parse_hpssacli_output(output):
+    """
+    Got a output string of hpssacli to dictionary(nested).
+    """
+    output_lines = [
+        l for l in output.split("\n") if l and not l.startswith('Note:')]
+
+    data = {}
+
+    # Detemine indention level
+    top_indention_level = sorted(
+        set(
+            len(line) - len(line.lstrip())
+            for line in output_lines))[0]
+
+    indent_2_data = {
+        top_indention_level: data
+    }
+
+    for line_num in range(len(output_lines)):
+        cur_line = output_lines[line_num]
+        if cur_line.strip() == 'None attached':
+            continue
+        if line_num + 1 == len(output_lines):
+            nxt_line = ''
+        else:
+            nxt_line = output_lines[line_num + 1]
+
+        cur_indent_count = len(cur_line) - len(cur_line.lstrip())
+        nxt_indent_count = len(nxt_line) - len(nxt_line.lstrip())
+
+        cur_line_splitted = cur_line.split(": ")
+        cur_data_pointer = indent_2_data[cur_indent_count]
+
+        if nxt_indent_count > cur_indent_count:
+            nxt_line_splitted = nxt_line.split(": ")
+            if len(nxt_line_splitted) == 1:
+                new_data = []
+            else:
+                new_data = {}
+
+            if cur_line.lstrip() not in cur_data_pointer:
+                cur_data_pointer[cur_line.lstrip()] = new_data
+                indent_2_data[nxt_indent_count] = new_data
+            elif type(cur_data_pointer[cur_line.lstrip()]) != type(new_data):
+                raise LsmError(
+                    ErrorNumber.PLUGIN_BUG,
+                    "_parse_hpssacli_output(): Unexpected line '%s%s\n'" %
+                    (cur_line, nxt_line))
+        else:
+            if len(cur_line_splitted) == 1:
+                if type(indent_2_data[cur_indent_count]) != list:
+                    raise Exception("not a list: '%s'" % cur_line)
+                cur_data_pointer.append(cur_line.lstrip())
+            else:
+                cur_data_pointer[cur_line_splitted[0].lstrip()] = \
+                    ": ".join(cur_line_splitted[1:]).strip()
+    return data
 
 
 class SmartArray(IPlugin):
-    def plugin_register(self, uri, password, timeout, flags=Client.FLAG_RSVD):
-        pass
+    _DEFAULT_BIN_PATHS = [
+        "/usr/sbin/hpssacli", "/opt/hp/hpssacli/bld/hpssacli"]
 
+    def __init__(self):
+        self._sacli_bin = None
+
+    def _find_sacli(self):
+        """
+        Try _DEFAULT_MDADM_BIN_PATHS
+        """
+        for cur_path in SmartArray._DEFAULT_BIN_PATHS:
+            if os.path.lexists(cur_path):
+                self._sacli_bin = cur_path
+
+        if not self._sacli_bin:
+            raise LsmError(
+                ErrorNumber.INVALID_ARGUMENT,
+                "SmartArray sacli is not installed correctly")
+
+    @_handle_errors
+    def plugin_register(self, uri, password, timeout, flags=Client.FLAG_RSVD):
+        if os.geteuid() != 0:
+            raise LsmError(
+                ErrorNumber.INVALID_ARGUMENT,
+                "This plugin requires root privilege both daemon and client")
+        uri_parsed = uri_parse(uri)
+        self._sacli_bin = uri_parsed.get('parameters', {}).get('hpssacli')
+        if not self._sacli_bin:
+            self._find_sacli()
+
+        self._sacli_exec(['version'], flag_convert=False)
+
+    @_handle_errors
     def plugin_unregister(self, flags=Client.FLAG_RSVD):
         pass
 
+    @_handle_errors
     def job_status(self, job_id, flags=Client.FLAG_RSVD):
         raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
 
+    @_handle_errors
     def job_free(self, job_id, flags=Client.FLAG_RSVD):
         pass
 
+    @_handle_errors
     def plugin_info(self, flags=Client.FLAG_RSVD):
         return "HP SmartArray Plugin", VERSION
 
+    @_handle_errors
     def time_out_set(self, ms, flags=Client.FLAG_RSVD):
         raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
 
+    @_handle_errors
     def time_out_get(self, flags=Client.FLAG_RSVD):
         raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
 
+    @_handle_errors
     def capabilities(self, system, flags=Client.FLAG_RSVD):
         return Capabilities()
 
-    def systems(self, flags=Client.FLAG_RSVD):
-        raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
+    def _sacli_exec(self, sacli_cmds, flag_convert=True):
+        """
+        If flag_convert is True, convert data into dict.
+        """
+        sacli_cmds.insert(0, self._sacli_bin)
+        try:
+            output = cmd_exec(sacli_cmds)
+        except OSError as os_error:
+            if os_error.errno == errno.ENOENT:
+                raise LsmError(
+                    ErrorNumber.INVALID_ARGUMENT,
+                    "hpssacli binary '%s' is not exist or executable." %
+                    self._sacli_bin)
+            else:
+                raise
 
+        if flag_convert:
+            return _parse_hpssacli_output(output)
+        else:
+            return output
+
+    @_handle_errors
+    def systems(self, flags=0):
+        """
+        Depend on command:
+            hpssacli ctrl all show detail
+            hpssacli ctrl all show status
+        """
+        rc_lsm_syss = []
+        ctrl_all_show = self._sacli_exec(
+            ["ctrl", "all", "show", "detail"])
+        ctrl_all_status = self._sacli_exec(
+            ["ctrl", "all", "show", "status"])
+
+        for ctrl_name in ctrl_all_show.keys():
+            ctrl_data = ctrl_all_show[ctrl_name]
+            sys_id = ctrl_data['Serial Number']
+            (status, status_info) = _sys_status_of(ctrl_all_status[ctrl_name])
+
+            plugin_data = "%s" % ctrl_data['Slot']
+
+            rc_lsm_syss.append(
+                System(sys_id, ctrl_name, status, status_info, plugin_data))
+
+        return rc_lsm_syss
+
+    @_handle_errors
     def pools(self, search_key=None, search_value=None,
               flags=Client.FLAG_RSVD):
         raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")

--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2015 Red Hat, Inc.
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Author: Gris Ge <fge@redhat.com>
+
+from lsm import (
+    IPlugin, Client, Capabilities, VERSION, LsmError, ErrorNumber)
+
+
+class SmartArray(IPlugin):
+    def plugin_register(self, uri, password, timeout, flags=Client.FLAG_RSVD):
+        pass
+
+    def plugin_unregister(self, flags=Client.FLAG_RSVD):
+        pass
+
+    def job_status(self, job_id, flags=Client.FLAG_RSVD):
+        raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
+
+    def job_free(self, job_id, flags=Client.FLAG_RSVD):
+        pass
+
+    def plugin_info(self, flags=Client.FLAG_RSVD):
+        return "HP SmartArray Plugin", VERSION
+
+    def time_out_set(self, ms, flags=Client.FLAG_RSVD):
+        raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
+
+    def time_out_get(self, flags=Client.FLAG_RSVD):
+        raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
+
+    def capabilities(self, system, flags=Client.FLAG_RSVD):
+        return Capabilities()
+
+    def systems(self, flags=Client.FLAG_RSVD):
+        raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
+
+    def pools(self, search_key=None, search_value=None,
+              flags=Client.FLAG_RSVD):
+        raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")

--- a/plugin/hpsa/hpsa_lsmplugin
+++ b/plugin/hpsa/hpsa_lsmplugin
@@ -1,0 +1,37 @@
+#!/usr/bin/env python2
+# Copyright (C) 2015 Red Hat, Inc.
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+#
+# Author: tasleson
+#         Gris Ge <fge@redhat.com>
+
+import sys
+import syslog
+import traceback
+
+try:
+    from lsm import PluginRunner
+    from lsm.plugin.hpsa import SmartArray
+
+    if __name__ == '__main__':
+        PluginRunner(SmartArray, sys.argv).run()
+except Exception:
+    #This should be quite rare, but when it does happen this is pretty
+    #key in understanding what happened, especially when it happens when
+    #running from the daemon.
+    msg = str(traceback.format_exc())
+    syslog.syslog(syslog.LOG_ERR, msg)
+    sys.stderr.write(msg)
+    sys.exit(1)

--- a/plugin/hpsa/utils.py
+++ b/plugin/hpsa/utils.py
@@ -1,0 +1,48 @@
+## Copyright (C) 2015 Red Hat, Inc.
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Author: Gris Ge <fge@redhat.com>
+
+import subprocess
+import os
+
+
+def cmd_exec(cmds):
+    """
+    Execute provided command and return the STDOUT as string.
+    Raise ExecError if command return code is not zero
+    """
+    cmd_popen = subprocess.Popen(
+        cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env={"PATH": os.getenv("PATH")})
+    str_stdout = "".join(list(cmd_popen.stdout)).strip()
+    str_stderr = "".join(list(cmd_popen.stderr)).strip()
+    errno = cmd_popen.wait()
+    if errno != 0:
+        raise ExecError(" ".join(cmds), errno, str_stdout, str_stderr)
+    return str_stdout
+
+
+class ExecError(Exception):
+    def __init__(self, cmd, errno, stdout, stderr, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+        self.cmd = cmd
+        self.errno = errno
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __str__(self):
+        return "cmd: '%s', errno: %d, stdout: '%s', stderr: '%s'" % \
+            (self.cmd, self.errno, self.stdout, self.stderr)

--- a/plugin/hpsa/utils.py
+++ b/plugin/hpsa/utils.py
@@ -35,6 +35,16 @@ def cmd_exec(cmds):
     return str_stdout
 
 
+def file_read(file_path):
+    """
+    Read file and return string of file content.
+    """
+    fd = open(file_path, 'r')
+    content = fd.read()
+    fd.close()
+    return content
+
+
 class ExecError(Exception):
     def __init__(self, cmd, errno, stdout, stderr, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)


### PR DESCRIPTION
 * The new hpsa plugin is based on HP binary tool -- hpssacli which
   could be downloaded from:
    http://downloads.linux.hp.com/SDR/project/spp/

 * This patch set introduced these methods support to hpsa plugin:
    * lsm.Client.systems()
    * lsm.Client.pools()
    * lsm.Client.volumes()
    * lsm.Client.disks()
      # With Disk.STATUS_FREE support also.
    * lsm.Client.volume_raid_info()

 * This patch set only coded and tested on 2 servers(Tony's and mine), a
   automatic tests is running in our internal lab to test this plugin on more
   HP SmartArray cards, will provide subsequent patch if found any bug.

Changes in V2:

 * Patch 2/6:
  * Fix missing '()' in _parse_hpssacli_output().
  * Handle 'No controllers detected' error.

 * Patch 6/6:
  * Fix uninitialized variables in volume_raid_info().
  * Add an extra check to raise PLUGIN_BUG when LD found with no PD found.

 * Please be informed, on RHEL 7.1, you need to manually run 'modprobe sg' 
   command before using this plugin.

Changes in V3:

* Moved 'utils.py' to patch 2/6.

* Patch 2/6:

    Fixed a bug in _parse_hpssacli_output() when 'hpssacli' have this kind of
    message in output:

    ``` 
    Note: Predictive Spare Activation Mode is enabled, physical drives that
    are in predictive failure state will not be available for use as data
    or spare drives.
    ```

    We filter out all line start with 'Note:'

* Patch 4/6: Changed file_read() to use python fileIO(open,read,close).

* Tested on HP SmartArray P420i with plugin_test.py(only got expected failure
  for test_timeout).

Changes in V4:
* Add new patch 7/7: Fix bug of parsing free disks.

Changes in V5:
* Patch 1/7: RPM spec: restart lsmd on plugin package installation.