### PR TITLE
Migration V2: git moved to github, maillist to fedorahosted

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 
 libStorageMgmt : A library for storage management
 
-More information available: https://sourceforge.net/projects/libstoragemgmt/
-Wiki: https://sourceforge.net/p/libstoragemgmt/wiki/Home/
+Full documentation can be found at:
+http://libstorage.github.io/libstoragemgmt-doc/

--- a/c_binding/include/libstoragemgmt/libstoragemgmt.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt.h
@@ -49,7 +49,7 @@
  *  \section additional Additional documentation
  *
  * Full documentation can be found at:
- * http://sourceforge.net/p/libstoragemgmt/wiki/Home/
+ * http://libstorage.github.io/libstoragemgmt-doc/
  *
  */
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,9 @@ dnl Process this file with autoconf to produce a configure script.
 dnl Copyright (C) 2011 Red Hat, Inc.
 dnl See COPYING.LIB for the License of this software
 
-AC_INIT([libstoragemgmt], [1.2.0], [libstoragemgmt-devel@lists.sourceforge.net], [], [http://sourceforge.net/projects/libstoragemgmt/])
+AC_INIT(
+    [libstoragemgmt], [1.2.0], [libstoragemgmt-devel@lists.fedorahosted.org], 
+    [], [https://github.com/libstorage/libstoragemgmt/])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/doc/man/hpsa_lsmplugin.1.in
+++ b/doc/man/hpsa_lsmplugin.1.in
@@ -44,7 +44,7 @@ required.
 
 .SH BUGS
 Please report bugs to
-\fI<libstoragemgmt-devel@lists.sourceforge.net>\fR
+\fI<libstoragemgmt-devel@lists.fedorahosted.org>\fR
 
 .SH AUTHOR
 Gris Ge \fI<fge@redhat.com>\fR

--- a/doc/man/lsmcli.1.in
+++ b/doc/man/lsmcli.1.in
@@ -720,7 +720,7 @@ at the end of URI, for example:
 
 .SH BUGS
 Please report bugs to
-\fI<libstoragemgmt-devel@lists.sourceforge.net>\fR
+\fI<libstoragemgmt-devel@lists.fedorahosted.org>\fR
 .SH AUTHOR
 Tony Asleson \fI<tasleson@redhat.com>\fR
 .br

--- a/doc/man/lsmd.1.in
+++ b/doc/man/lsmd.1.in
@@ -3,7 +3,7 @@
 Daemon \- lsmd
 .SH DESCRIPTION
 libStorageMgmt plug\-in daemon.  Plug-ins execute in their own process space
-for fault isolation and to accommodate different plug\-in licensing 
+for fault isolation and to accommodate different plug\-in licensing
 requirements.  Runs as an unprivileged user.
 
 .SH OPTIONS
@@ -20,7 +20,7 @@ requirements.  Runs as an unprivileged user.
 
 .SH BUGS
 Please report bugs to
-<libstoragemgmt\-devel@lists.sourceforge.net>
+<libstoragemgmt-devel@lists.fedorahosted.org>
 .SH AUTHOR
 Tony Asleson <tasleson@redhat.com>
 

--- a/doc/man/lsmd.conf.5.in
+++ b/doc/man/lsmd.conf.5.in
@@ -51,6 +51,6 @@ detail.
 
 .SH BUGS
 Please report bugs to
-<libstoragemgmt\-devel@lists.sourceforge.net>
+<libstoragemgmt-devel@lists.fedorahosted.org>
 .SH AUTHOR
 Gris Ge <fge@redhat.com>

--- a/doc/man/megaraid_lsmplugin.1.in
+++ b/doc/man/megaraid_lsmplugin.1.in
@@ -46,7 +46,7 @@ required.
 
 .SH BUGS
 Please report bugs to
-\fI<libstoragemgmt-devel@lists.sourceforge.net>\fR
+\fI<libstoragemgmt-devel@lists.fedorahosted.org>\fR
 
 .SH AUTHOR
 Gris Ge \fI<fge@redhat.com>\fR

--- a/examples/plugin_example.c
+++ b/examples/plugin_example.c
@@ -1,6 +1,6 @@
 /*
  * Web example.
- * https://sourceforge.net/p/libstoragemgmt/wiki/WritingPlugins/
+ * http://libstorage.github.io/libstoragemgmt-doc/doc/c_plugin_dev_guide.html
  *
  *
   gcc -Wall -g -O0 plugin_example.c -I../include/ -L../src/.libs \

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -52,8 +52,8 @@ License:        LGPL-2.1+
 %else
 License:        LGPLv2+
 %endif
-URL:            http://sourceforge.net/projects/libstoragemgmt/
-Source0:        http://sourceforge.net/projects/libstoragemgmt/files/libstoragemgmt-%{version}.tar.gz
+URL:            https://github.com/libstorage/libstoragemgmt/
+Source0:        https://github.com/libstorage/libstoragemgmt/releases/download/%{version}/libstoragemgmt-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:       %{libstoragemgmt}-python
 BuildRequires:  autoconf automake libtool libxml2-devel check-devel perl

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -772,9 +772,9 @@ class CmdLine:
         parser = ArgumentParser(
             description='The libStorageMgmt command line interface.'
                         ' Run %(prog)s <command> -h for more on each command.',
-            epilog='Copyright 2012-2014 Red Hat, Inc.\n'
+            epilog='Copyright 2012-2015 Red Hat, Inc.\n'
                    'Please report bugs to '
-                   '<libstoragemgmt-devel@lists.sourceforge.net>\n',
+                   '<libstoragemgmt-devel@lists.fedorahosted.org>\n',
             formatter_class=RawTextHelpFormatter,
             parents=[parent_parser])
 


### PR DESCRIPTION
 * Update all maillist link to:
    libstoragemgmt-devel@lists.fedorahosted.org
    libstoragemgmt-users@lists.fedorahosted.org

 * Update all upstream link to:
    https://github.com/libstorage/libstoragemgmt/

Changes in V2:
* Use https://github.com/libstorage/libstoragemgmt/ as upstream link.

Signed-off-by: Gris Ge <fge@redhat.com>