### PR TITLE
[PATCH V6 00/18] Pool RAID info query and hardware RAID volume creation.

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt.h
@@ -864,6 +864,33 @@ int LSM_DLL_EXPORT lsm_volume_raid_info(
     uint32_t *strip_size, uint32_t *disk_count,
     uint32_t *min_io_size, uint32_t *opt_io_size, lsm_flag flags);
 
+/**
+ * Retrieves the membership of given pool. New in version 1.2.
+ * @param[in] c     Valid connection
+ * @param[in] pool  The lsm_pool ptr.
+ * @param[out] raid_type
+ *                  Enum of lsm_volume_raid_type.
+ * @param[out] member_type
+ *                  Enum of lsm_pool_member_type.
+ * @param[out] member_ids
+ *                  The pointer to lsm_string_list pointer.
+ *                  When 'member_type' is LSM_POOL_MEMBER_TYPE_POOL,
+ *                  the 'member_ids' will contain a list of parent Pool
+ *                  IDs.
+ *                  When 'member_type' is LSM_POOL_MEMBER_TYPE_DISK,
+ *                  the 'member_ids' will contain a list of disk IDs.
+ *                  When 'member_type' is LSM_POOL_MEMBER_TYPE_OTHER or
+ *                  LSM_POOL_MEMBER_TYPE_UNKNOWN, the member_ids should
+ *                  be NULL.
+ *                  Need to use lsm_string_list_free() to free this memory.
+ * @param[in] flags         Reserved, set to 0
+ * @return LSM_ERR_OK on success else error reason.
+ */
+int LSM_DLL_EXPORT lsm_pool_member_info(
+    lsm_connect *c, lsm_pool *pool, lsm_volume_raid_type *raid_type,
+    lsm_pool_member_type *member_type, lsm_string_list **member_ids,
+    lsm_flag flags);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/c_binding/include/libstoragemgmt/libstoragemgmt.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt.h
@@ -891,6 +891,68 @@ int LSM_DLL_EXPORT lsm_pool_member_info(
     lsm_pool_member_type *member_type, lsm_string_list **member_ids,
     lsm_flag flags);
 
+/**
+ * Query all supported RAID types and strip sizes which could be used
+ * in lsm_volume_raid_create() functions.
+ * New in version 1.2, only available for hardware RAID cards.
+ * @param[in] c     Valid connection
+ * @param[in] system
+ *                  The lsm_sys type.
+ * @param[out] supported_raid_types
+ *                  The pointer of uint32_t array. Containing
+ *                  lsm_volume_raid_type values.
+ *                  You need to free this memory by yourself.
+ * @param[out] supported_raid_type_count
+ *                  The pointer of uint32_t. Indicate the item count of
+ *                  supported_raid_types array.
+ * @param[out] supported_strip_sizes
+ *                  The pointer of uint32_t array. Containing
+ *                  all supported strip sizes.
+ *                  You need to free this memory by yourself.
+ * @param[out] supported_strip_size_count
+ *                  The pointer of uint32_t. Indicate the item count of
+ *                  supported_strip_sizes array.
+ * @param[in] flags         Reserved, set to 0
+ * @return LSM_ERR_OK on success else error reason.
+ */
+int LSM_DLL_EXPORT lsm_volume_raid_create_cap_get(
+    lsm_connect *c, lsm_system *system,
+    uint32_t **supported_raid_types, uint32_t *supported_raid_type_count,
+    uint32_t **supported_strip_sizes, uint32_t *supported_strip_size_count,
+    lsm_flag flags);
+
+/**
+ * Create a disk RAID pool and allocate entire full space to new volume.
+ * New in version 1.2, only available for hardware RAID cards.
+ * @param[in] c     Valid connection
+ * @param[in] name  String. Name for the new volume. It might be ignored or
+ *                  altered on some hardwardware raid cards in order to fit
+ *                  their limitation.
+ * @param[in] raid_type
+ *                  Enum of lsm_volume_raid_type. Please refer to the returns
+ *                  of lsm_volume_raid_create_cap_get() function for
+ *                  supported strip sizes.
+ * @param[in] disks
+ *                  An array of lsm_disk types
+ * @param[in] disk_count
+ *                  The count of lsm_disk in 'disks' argument.
+ *                  Count starts with 1.
+ * @param[in] strip_size
+ *                  uint32_t. The strip size in bytes. Please refer to
+ *                  the returns of lsm_volume_raid_create_cap_get() function
+ *                  for supported strip sizes.
+ * @param[out] new_volume
+ *                  Newly created volume, Pointer to the lsm_volume type
+ *                  pointer.
+ * @param[in] flags         Reserved, set to 0
+ * @return LSM_ERR_OK on success else error reason.
+ */
+int LSM_DLL_EXPORT lsm_volume_raid_create(
+    lsm_connect *c, const char *name, lsm_volume_raid_type raid_type,
+    lsm_disk *disks[], uint32_t disk_count,
+    uint32_t strip_size, lsm_volume **new_volume,
+    lsm_flag flags);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
@@ -113,7 +113,9 @@ typedef enum {
     LSM_CAP_TARGET_PORTS                            = 216,      /**< List target ports */
     LSM_CAP_TARGET_PORTS_QUICK_SEARCH               = 217,      /**< Filtering occurs on array */
 
-    LSM_CAP_DISKS                                   = 220       /**< List disk drives */
+    LSM_CAP_DISKS                                   = 220,      /**< List disk drives */
+    LSM_CAP_POOL_MEMBER_INFO                        = 221,
+    /**^ Query pool member information */
 
 } lsm_capability_type;
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
@@ -117,6 +117,7 @@ typedef enum {
     LSM_CAP_POOL_MEMBER_INFO                        = 221,
     /**^ Query pool member information */
 
+    LSM_CAP_VOLUME_RAID_CREATE                      = 222,
 } lsm_capability_type;
 
 /**

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_error.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_error.h
@@ -63,6 +63,7 @@ typedef enum {
     LSM_ERR_NOT_FOUND_VOLUME = 205,     /**< Specified volume not found */
     LSM_ERR_NOT_FOUND_NFS_EXPORT = 206, /**< NFS export not found */
     LSM_ERR_NOT_FOUND_SYSTEM = 208,     /**< System not found */
+    LSM_ERR_NOT_FOUND_DISK = 209,
 
     LSM_ERR_NOT_LICENSED = 226,         /**< Need license for feature */
 
@@ -90,6 +91,7 @@ typedef enum {
 
     LSM_ERR_EMPTY_ACCESS_GROUP = 511,
     LSM_ERR_POOL_NOT_READY = 512,
+    LSM_ERR_DISK_NOT_FREE = 513,
 
 } lsm_error_number;
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
@@ -827,6 +827,32 @@ typedef int (*lsm_plug_volume_raid_info)(lsm_plugin_ptr c, lsm_volume *volume,
     uint32_t *disk_count, uint32_t *min_io_size, uint32_t *opt_io_size,
     lsm_flag flags);
 
+/**
+ * Retrieves the membership of given pool. New in version 1.2.
+ * @param[in] c               Valid lsm plug-in pointer
+ * @param[in] pool  The lsm_pool ptr.
+ * @param[out] raid_type
+ *                  Enum of lsm_volume_raid_type.
+ * @param[out] member_type
+ *                  Enum of lsm_pool_member_type.
+ * @param[out] member_ids
+ *                  The pointer of lsm_string_list pointer.
+ *                  When 'member_type' is LSM_POOL_MEMBER_TYPE_POOL,
+ *                  the 'member_ids' will contain a list of parent Pool
+ *                  IDs.
+ *                  When 'member_type' is LSM_POOL_MEMBER_TYPE_DISK,
+ *                  the 'member_ids' will contain a list of disk IDs.
+ *                  When 'member_type' is LSM_POOL_MEMBER_TYPE_OTHER or
+ *                  LSM_POOL_MEMBER_TYPE_UNKNOWN, the member_ids should
+ *                  be NULL.
+ * @param[in] flags         Reserved, set to 0
+ * @return LSM_ERR_OK on success else error reason.
+ */
+typedef int (*lsm_plug_pool_member_info)(
+    lsm_plugin_ptr c, lsm_pool *pool, lsm_volume_raid_type *raid_type,
+    lsm_pool_member_type *member_type, lsm_string_list **member_ids,
+    lsm_flag flags);
+
 /** \struct lsm_ops_v1_2
  * \brief Functions added in version 1.2
  * NOTE: This structure will change during the developement util version 1.2
@@ -835,6 +861,7 @@ typedef int (*lsm_plug_volume_raid_info)(lsm_plugin_ptr c, lsm_volume *volume,
 struct lsm_ops_v1_2 {
     lsm_plug_volume_raid_info vol_raid_info;
     /**^ Query volume RAID information*/
+    lsm_plug_pool_member_info pool_member_info;
 };
 
 /**

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
@@ -853,6 +853,61 @@ typedef int (*lsm_plug_pool_member_info)(
     lsm_pool_member_type *member_type, lsm_string_list **member_ids,
     lsm_flag flags);
 
+/**
+ * Query all supported RAID types and strip sizes which could be used
+ * in lsm_volume_raid_create() functions.
+ * New in version 1.2, only available for hardware RAID cards.
+ * @param[in] c     Valid lsm plug-in pointer
+ * @param[in] system
+ *                  The lsm_sys type.
+ * @param[out] supported_raid_types
+ *                  The pointer of uint32_t array. Containing
+ *                  lsm_volume_raid_type values.
+ * @param[out] supported_raid_type_count
+ *                  The pointer of uint32_t. Indicate the item count of
+ *                  supported_raid_types array.
+ * @param[out] supported_strip_sizes
+ *                  The pointer of uint32_t array. Containing
+ *                  all supported strip sizes.
+ * @param[out] supported_strip_size_count
+ *                  The pointer of uint32_t. Indicate the item count of
+ *                  supported_strip_sizes array.
+ * @param[in] flags         Reserved, set to 0
+ * @return LSM_ERR_OK on success else error reason.
+ */
+typedef int (*lsm_plug_volume_raid_create_cap_get)(
+    lsm_plugin_ptr c, lsm_system *system,
+    uint32_t **supported_raid_types, uint32_t *supported_raid_type_count,
+    uint32_t **supported_strip_sizes, uint32_t *supported_strip_size_count,
+    lsm_flag flags);
+
+/**
+ * Create a disk RAID pool and allocate entire full space to new volume.
+ * New in version 1.2, only available for hardware RAID cards.
+ * @param[in] c     Valid lsm plug-in pointer
+ * @param[in] name  String. Name for the new volume. It might be ignored or
+ *                  altered on some hardwardware raid cards in order to fit
+ *                  their limitation.
+ * @param[in] raid_type
+ *                  Enum of lsm_volume_raid_type.
+ * @param[in] disks
+ *                  An array of lsm_disk types
+ * @param[in] disk_count
+ *                  The count of lsm_disk in 'disks' argument.
+ * @param[in] strip_size
+ *                  uint32_t. The strip size in bytes.
+ * @param[out] new_volume
+ *                  Newly created volume, Pointer to the lsm_volume type
+ *                  pointer.
+ * @param[in] flags         Reserved, set to 0
+ * @return LSM_ERR_OK on success else error reason.
+ */
+typedef int (*lsm_plug_volume_raid_create)(
+    lsm_plugin_ptr c, const char *name, lsm_volume_raid_type raid_type,
+    lsm_disk *disks[], uint32_t disk_count,
+    uint32_t strip_size, lsm_volume **new_volume,
+    lsm_flag flags);
+
 /** \struct lsm_ops_v1_2
  * \brief Functions added in version 1.2
  * NOTE: This structure will change during the developement util version 1.2
@@ -862,6 +917,8 @@ struct lsm_ops_v1_2 {
     lsm_plug_volume_raid_info vol_raid_info;
     /**^ Query volume RAID information*/
     lsm_plug_pool_member_info pool_member_info;
+    lsm_plug_volume_raid_create_cap_get vol_create_raid_cap_get;
+    lsm_plug_volume_raid_create vol_create_raid;
 };
 
 /**

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -297,6 +297,9 @@ typedef enum {
     LSM_TARGET_PORT_TYPE_ISCSI = 4
 } lsm_target_port_type;
 
+#define LSM_VOLUME_VCR_STRIP_SIZE_DEFAULT           0
+/** ^ Plugin and hardware RAID will use their default strip size */
+
 #ifdef  __cplusplus
 }
 #endif

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -169,6 +169,23 @@ typedef enum {
     /**^ Vendor specific RAID type */
 } lsm_volume_raid_type;
 
+/**< \enum lsm_pool_member_type Different types of Pool member*/
+typedef enum {
+    LSM_POOL_MEMBER_TYPE_UNKNOWN = 0,
+    /**^ Plugin failed to detect the RAID member type. */
+    LSM_POOL_MEMBER_TYPE_OTHER = 1,
+    /**^ Vendor specific RAID member type. */
+    LSM_POOL_MEMBER_TYPE_DISK = 2,
+    /**^ Pool is created from RAID group using whole disks. */
+    LSM_POOL_MEMBER_TYPE_POOL = 3,
+    /**^
+     * Current pool(also known as sub-pool) is allocated from other
+     * pool(parent pool).
+     * The 'raid_type' will set to RAID_TYPE_OTHER unless certain RAID system
+     * support RAID using space of parent pools.
+     */
+} lsm_pool_member_type;
+
 #define LSM_VOLUME_STRIP_SIZE_UNKNOWN       0
 #define LSM_VOLUME_DISK_COUNT_UNKNOWN       0
 #define LSM_VOLUME_MIN_IO_SIZE_UNKNOWN      0

--- a/c_binding/lsm_convert.cpp
+++ b/c_binding/lsm_convert.cpp
@@ -617,3 +617,44 @@ Value target_port_to_value(lsm_target_port *tp)
     }
     return Value();
 }
+
+int values_to_uint32_array(
+    Value &value, uint32_t **uint32_array, uint32_t *count)
+{
+    int rc = LSM_ERR_OK;
+    try {
+        std::vector<Value> data = value.asArray();
+        *count = data.size();
+        if (*count){
+            *uint32_array = (uint32_t *)malloc(sizeof(uint32_t) * *count);
+            if (*uint32_array){
+                uint32_t i;
+                for( i = 0; i < *count; i++ ){
+                    (*uint32_array)[i] = data[i].asUint32_t();
+                }
+            }else{
+                rc = LSM_ERR_NO_MEMORY;
+            }
+        }
+    } catch( const ValueException &ve) {
+        if( *count ) {
+            free(*uint32_array);
+            *uint32_array = NULL;
+            *count = 0;
+        }
+        rc = LSM_ERR_LIB_BUG;
+    }
+    return rc;
+}
+
+Value uint32_array_to_value(uint32_t *uint32_array, uint32_t count)
+{
+    std::vector<Value> rc;
+    if( uint32_array && count ) {
+        uint32_t i;
+        for( i = 0; i < count; i++ ) {
+            rc.push_back(uint32_array[i]);
+        }
+    }
+    return rc;
+}

--- a/c_binding/lsm_convert.hpp
+++ b/c_binding/lsm_convert.hpp
@@ -284,4 +284,16 @@ lsm_target_port LSM_DLL_LOCAL *value_to_target_port(Value &tp);
  */
 Value LSM_DLL_LOCAL target_port_to_value(lsm_target_port *tp);
 
+/**
+ * Converts a value to array of uint32.
+ */
+int LSM_DLL_LOCAL values_to_uint32_array(
+    Value &value, uint32_t **uint32_array, uint32_t *count);
+
+/**
+ * Converts an array of uint32 to a value.
+ */
+Value LSM_DLL_LOCAL uint32_array_to_value(
+    uint32_t *uint32_array, uint32_t count);
+
 #endif

--- a/c_binding/lsm_mgmt.cpp
+++ b/c_binding/lsm_mgmt.cpp
@@ -2268,3 +2268,131 @@ int lsm_nfs_export_delete( lsm_connect *c, lsm_nfs_export *e, lsm_flag flags)
     int rc = rpc(c, "export_remove", parameters, response);
     return rc;
 }
+
+int lsm_volume_raid_create_cap_get(
+    lsm_connect *c, lsm_system *system,
+    uint32_t **supported_raid_types, uint32_t *supported_raid_type_count,
+    uint32_t **supported_strip_sizes, uint32_t *supported_strip_size_count,
+    lsm_flag flags)
+{
+    CONN_SETUP(c);
+
+    if( !supported_raid_types || !supported_raid_type_count ||
+        !supported_strip_sizes || !supported_strip_size_count) {
+         return LSM_ERR_INVALID_ARGUMENT;
+    }
+
+    std::map<std::string, Value> p;
+    p["system"] = system_to_value(system);
+    p["flags"] = Value(flags);
+
+    Value parameters(p);
+    Value response;
+
+    int rc = rpc(c, "volume_raid_create_cap_get", parameters, response);
+    try {
+        std::vector<Value> j = response.asArray();
+
+        rc = values_to_uint32_array(
+            j[0], supported_raid_types, supported_raid_type_count);
+
+        if( rc != LSM_ERR_OK ){
+            *supported_raid_types = NULL;
+            *supported_raid_type_count = 0;
+            *supported_strip_sizes = NULL;
+            *supported_strip_size_count = 0;
+            return rc;
+        }
+
+        rc = values_to_uint32_array(
+            j[1], supported_strip_sizes, supported_strip_size_count);
+        if( rc != LSM_ERR_OK ){
+            free(*supported_raid_types);
+            *supported_raid_types = NULL;
+            *supported_raid_type_count = 0;
+            *supported_strip_sizes = NULL;
+            *supported_strip_size_count = 0;
+        }
+    } catch( const ValueException &ve ) {
+        rc = logException(c, LSM_ERR_LIB_BUG, "Unexpected type",
+                            ve.what());
+    }
+    return rc;
+}
+
+int lsm_volume_raid_create(
+    lsm_connect *c, const char *name, lsm_volume_raid_type raid_type,
+    lsm_disk *disks[], uint32_t disk_count,
+    uint32_t strip_size, lsm_volume **new_volume,
+    lsm_flag flags)
+{
+    CONN_SETUP(c);
+
+    if (disk_count == 0){
+        return logException(
+            c, LSM_ERR_INVALID_ARGUMENT, "Require at least one disks", NULL);
+    }
+
+    if (raid_type == LSM_VOLUME_RAID_TYPE_RAID1 && disk_count != 2){
+        return logException(
+            c, LSM_ERR_INVALID_ARGUMENT, "RAID 1 only allows two disks", NULL);
+    }
+
+    if (raid_type == LSM_VOLUME_RAID_TYPE_RAID5 && disk_count < 3){
+        return logException(
+            c, LSM_ERR_INVALID_ARGUMENT, "RAID 5 require 3 or more disks",
+            NULL);
+    }
+
+    if (raid_type == LSM_VOLUME_RAID_TYPE_RAID6 && disk_count < 4){
+        return logException(
+            c, LSM_ERR_INVALID_ARGUMENT, "RAID 5 require 4 or more disks",
+            NULL);
+    }
+
+    if ( disk_count % 2 ){
+        if (raid_type == LSM_VOLUME_RAID_TYPE_RAID10 && disk_count < 4){
+            return logException(
+                c, LSM_ERR_INVALID_ARGUMENT,
+                "RAID 10 require even disks count and 4 or more disks",
+                NULL);
+        }
+        if (raid_type == LSM_VOLUME_RAID_TYPE_RAID50 && disk_count < 6){
+            return logException(
+                c, LSM_ERR_INVALID_ARGUMENT,
+                "RAID 50 require even disks count and 6 or more disks",
+                NULL);
+        }
+        if (raid_type == LSM_VOLUME_RAID_TYPE_RAID60 && disk_count < 8){
+            return logException(
+                c, LSM_ERR_INVALID_ARGUMENT,
+                "RAID 60 require even disks count and 8 or more disks",
+                NULL);
+        }
+    }
+
+    if (CHECK_RP(new_volume)){
+        return LSM_ERR_INVALID_ARGUMENT;
+    }
+
+    std::map<std::string, Value> p;
+    p["name"] = Value(name);
+    p["raid_type"] = Value((int32_t)raid_type);
+    p["strip_size"] = Value((int32_t)strip_size);
+    p["flags"] = Value(flags);
+    std::vector<Value> disks_value;
+    for (uint32_t i = 0; i < disk_count; i++){
+        disks_value.push_back(disk_to_value(disks[i]));
+    }
+    p["disks"] = disks_value;
+
+    Value parameters(p);
+    Value response;
+
+    int rc = rpc(c, "volume_raid_create", parameters, response);
+    if( LSM_ERR_OK == rc ) {
+        *new_volume = value_to_volume(response);
+    }
+    return rc;
+
+}

--- a/doc/man/lsmcli.1.in
+++ b/doc/man/lsmcli.1.in
@@ -232,6 +232,34 @@ Optional. Provisioning type. Valid values are: DEFAULT, THIN, FULL.
 Provisioning enabled volume. \fBFULL\fR means requiring a fully allocated
 volume.
 
+.SS volume-raid-create
+Creates a volume on hardware RAID on given disks.
+.TP 15
+\fB--name\fR \fI<NAME>\fR
+Required. Volume name. Might be altered or ignored due to hardware RAID card
+vendor limitation.
+.TP
+\fB--raid-type\fR \fI<RAID_TYPE>\fR
+Required. Could be one of these values: \fBRAID0\fR, \fBRAID1\fR, \fBRAID5\fR,
+\fBRAID6\fR, \fBRAID10\fR, \fBRAID50\fR, \fBRAID60\fR. The supported RAID
+types of current RAID card could be queried via command
+"\fBvolume-raid-create-cap\fR".
+.TP
+\fB--disk\fR \fI<DISK_ID>\fR
+Required. Repeatable. The disk ID for new RAID group.
+.TP
+\fB--strip-size\fR \fI<STRIP_SIZE>\fR
+Optional. The size in bytes of strip on each disks. If not defined, will let
+hardware card to use the vendor default value. The supported stripe size of
+current RAID card could be queried via command "\fBvolume-raid-create-cap\fR".
+
+.SS volume-raid-create-cap
+Query support status of volume-raid-create command for current hardware RAID
+card.
+.TP 15
+\fB--sys\fR \fI<SYS_ID>\fR
+Required. ID of the system to query for capabilities.
+
 .SS volume-delete
 .TP 15
 Delete a volume given its ID
@@ -586,6 +614,10 @@ Alias of 'list --type target_ports'
  Alias of 'plugin-info'
 .SS vc
 Alias of 'volume-create'
+.SS vrc
+Alias of 'volume-raid-create'
+.SS vrcc
+Alias of 'volume-raid-create-cap'
 .SS vd
 Alias of 'volume-delete'
 .SS vr

--- a/doc/man/lsmcli.1.in
+++ b/doc/man/lsmcli.1.in
@@ -351,6 +351,13 @@ Query RAID information for given volume.
 \fB--vol\fR \fI<VOL_ID>\fR
 Required. The ID of volume to query.
 
+.SS pool-member-info
+.TP 15
+Query RAID information for given pool.
+.TP
+\fB--pool\fR \fI<POOL_ID>\fR
+Required. The ID of pool to query.
+
 .SS access-group-create
 .TP 15
 Create an access group.
@@ -589,6 +596,8 @@ Alias of 'volume-mask'
 Alias of 'volume-unmask'
 .SS vri
 Alias of 'volume-raid-info'
+.SS pmi
+Alias of 'pool-member-info'
 .SS ac
 Alias of 'access-group-create'
 .SS aa

--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -195,26 +195,46 @@ def _disk_status_of(hp_disk, flag_free):
     return disk_status
 
 
-def _hp_raid_type_to_lsm(hp_ld):
+_HP_RAID_LEVEL_CONV = {
+    '0': Volume.RAID_TYPE_RAID0,
+    # TODO(Gris Ge): Investigate whether HP has 4 disks RAID 1.
+    #                In LSM, that's RAID10.
+    '1': Volume.RAID_TYPE_RAID1,
+    '5': Volume.RAID_TYPE_RAID5,
+    '6': Volume.RAID_TYPE_RAID6,
+    '1+0': Volume.RAID_TYPE_RAID10,
+    '50': Volume.RAID_TYPE_RAID50,
+    '60': Volume.RAID_TYPE_RAID60,
+}
+
+
+_HP_VENDOR_RAID_LEVELS = ['1adm', '1+0adm']
+
+
+_LSM_RAID_TYPE_CONV = dict(
+    zip(_HP_RAID_LEVEL_CONV.values(), _HP_RAID_LEVEL_CONV.keys()))
+
+
+def _hp_raid_level_to_lsm(hp_ld):
     """
     Based on this property:
         Fault Tolerance: 0/1/5/6/1+0
     """
     hp_raid_level = hp_ld['Fault Tolerance']
-    if hp_raid_level == '0':
-        return Volume.RAID_TYPE_RAID0
-    elif hp_raid_level == '1':
-        # TODO(Gris Ge): Investigate whether HP has 4 disks RAID 1.
-        #                In LSM, that's RAID10.
-        return Volume.RAID_TYPE_RAID1
-    elif hp_raid_level == '5':
-        return Volume.RAID_TYPE_RAID5
-    elif hp_raid_level == '6':
-        return Volume.RAID_TYPE_RAID6
-    elif hp_raid_level == '1+0':
-        return Volume.RAID_TYPE_RAID10
 
-    return Volume.RAID_TYPE_UNKNOWN
+    if hp_raid_level in _HP_VENDOR_RAID_LEVELS:
+        return Volume.RAID_TYPE_OTHER
+
+    return _HP_RAID_LEVEL_CONV.get(hp_raid_level, Volume.RAID_TYPE_UNKNOWN)
+
+
+def _lsm_raid_type_to_hp(raid_type):
+    try:
+        return _LSM_RAID_TYPE_CONV[raid_type]
+    except KeyError:
+        raise LsmError(
+            ErrorNumber.NO_SUPPORT,
+            "Not supported raid type %d" % raid_type)
 
 
 class SmartArray(IPlugin):
@@ -286,6 +306,7 @@ class SmartArray(IPlugin):
         cap.set(Capabilities.DISKS)
         cap.set(Capabilities.VOLUME_RAID_INFO)
         cap.set(Capabilities.POOL_MEMBER_INFO)
+        cap.set(Capabilities.VOLUME_RAID_CREATE)
         return cap
 
     def _sacli_exec(self, sacli_cmds, flag_convert=True):
@@ -511,7 +532,7 @@ class SmartArray(IPlugin):
             for array_key_name in ctrl_data[key_name].keys():
                 if array_key_name == "Logical Drive: %s" % ld_num:
                     hp_ld = ctrl_data[key_name][array_key_name]
-                    raid_type = _hp_raid_type_to_lsm(hp_ld)
+                    raid_type = _hp_raid_level_to_lsm(hp_ld)
                     strip_size = _hp_size_to_lsm(hp_ld['Strip Size'])
                     stripe_size = _hp_size_to_lsm(hp_ld['Full Stripe Size'])
                 elif array_key_name.startswith("physicaldrive"):
@@ -556,7 +577,7 @@ class SmartArray(IPlugin):
                 for array_key_name in ctrl_data[key_name].keys():
                     if array_key_name.startswith("Logical Drive: ") and \
                        raid_type == Volume.RAID_TYPE_UNKNOWN:
-                        raid_type = _hp_raid_type_to_lsm(
+                        raid_type = _hp_raid_level_to_lsm(
                             ctrl_data[key_name][array_key_name])
                     elif array_key_name.startswith("physicaldrive"):
                         hp_disk = ctrl_data[key_name][array_key_name]
@@ -570,3 +591,150 @@ class SmartArray(IPlugin):
                 "Pool not found")
 
         return raid_type, Pool.MEMBER_TYPE_DISK, disk_ids
+
+    def _vrc_cap_get(self, ctrl_num):
+        supported_raid_types = [
+            Volume.RAID_TYPE_RAID0, Volume.RAID_TYPE_RAID1,
+            Volume.RAID_TYPE_RAID5, Volume.RAID_TYPE_RAID50,
+            Volume.RAID_TYPE_RAID10]
+
+        supported_strip_sizes = [
+            8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024,
+            128 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024]
+
+        ctrl_conf = self._sacli_exec([
+            "ctrl", "slot=%s" % ctrl_num, "show", "config", "detail"]
+            ).values()[0]
+
+        if 'RAID 6 (ADG) Status' in ctrl_conf and \
+           ctrl_conf['RAID 6 (ADG) Status'] == 'Enabled':
+            supported_raid_types.extend(
+                [Volume.RAID_TYPE_RAID6, Volume.RAID_TYPE_RAID60])
+
+        return supported_raid_types, supported_strip_sizes
+
+    @_handle_errors
+    def volume_raid_create_cap_get(self, system, flags=Client.FLAG_RSVD):
+        """
+        Depends on this command:
+            hpssacli ctrl slot=0 show config detail
+        All hpsa support RAID 1, 10, 5, 50.
+        If "RAID 6 (ADG) Status: Enabled", it will support RAID 6 and 60.
+        For HP tribile mirror(RAID 1adm and RAID10adm), LSM does support
+        that yet.
+        No command output or document indication special or exceptional
+        support of strip size, assuming all hpsa cards support documented
+        strip sizes.
+        """
+        if not system.plugin_data:
+            raise LsmError(
+                ErrorNumber.INVALID_ARGUMENT,
+                "Ilegal input system argument: missing plugin_data property")
+        return self._vrc_cap_get(system.plugin_data)
+
+    @_handle_errors
+    def volume_raid_create(self, name, raid_type, disks, strip_size,
+                           flags=Client.FLAG_RSVD):
+        """
+        Depends on these commands:
+            1. Create LD
+                hpssacli ctrl slot=0 create type=ld \
+                    drives=1i:1:13,1i:1:14 size=max raid=1+0 ss=64
+
+            2. Find out the system ID.
+
+            3. Find out the pool fist disk belong.
+                hpssacli ctrl slot=0 pd 1i:1:13 show
+
+            4. List all volumes for this new pool.
+                self.volumes(search_key='pool_id', search_value=pool_id)
+
+        The 'name' argument will be ignored.
+        TODO(Gris Ge): These code only tested for creating 1 disk RAID 0.
+        """
+        hp_raid_level = _lsm_raid_type_to_hp(raid_type)
+        hp_disk_ids = []
+        ctrl_num = None
+        for disk in disks:
+            if not disk.plugin_data:
+                raise LsmError(
+                    ErrorNumber.INVALID_ARGUMENT,
+                    "Illegal input disks argument: missing plugin_data "
+                    "property")
+            (cur_ctrl_num, hp_disk_id) = disk.plugin_data.split(':', 1)
+            if ctrl_num and cur_ctrl_num != ctrl_num:
+                raise LsmError(
+                    ErrorNumber.INVALID_ARGUMENT,
+                    "Illegal input disks argument: disks are not from the "
+                    "same controller/system.")
+
+            ctrl_num = cur_ctrl_num
+            hp_disk_ids.append(hp_disk_id)
+
+        cmds = [
+            "ctrl", "slot=%s" % ctrl_num, "create", "type=ld",
+            "drives=%s" % ','.join(hp_disk_ids), 'size=max',
+            'raid=%s' % hp_raid_level]
+
+        if strip_size != Volume.VCR_STRIP_SIZE_DEFAULT:
+            cmds.append("ss=%d" % int(strip_size / 1024))
+
+        try:
+            self._sacli_exec(cmds, flag_convert=False)
+        except ExecError:
+            # Check whether disk is free
+            requested_disk_ids = [d.id for d in disks]
+            for cur_disk in self.disks():
+                if cur_disk.id in requested_disk_ids and \
+                   not cur_disk.status & Disk.STATUS_FREE:
+                    raise LsmError(
+                        ErrorNumber.DISK_NOT_FREE,
+                        "Disk %s is not in STATUS_FREE state" % cur_disk.id)
+
+            # Check whether got unsupported raid type or strip size
+            supported_raid_types, supported_strip_sizes = \
+                self._vrc_cap_get(ctrl_num)
+
+            if raid_type not in supported_raid_types:
+                raise LsmError(
+                    ErrorNumber.NO_SUPPORT,
+                    "Provided raid_type is not supported")
+
+            if strip_size != Volume.VCR_STRIP_SIZE_DEFAULT and \
+               strip_size not in supported_strip_sizes:
+                raise LsmError(
+                    ErrorNumber.NO_SUPPORT,
+                    "Provided strip_size is not supported")
+
+            raise
+
+        # Find out the system id to gernerate pool_id
+        sys_output = self._sacli_exec(
+            ['ctrl', "slot=%s" % ctrl_num, 'show'])
+
+        sys_id = sys_output.values()[0]['Serial Number']
+        # API code already checked empty 'disks', we will for sure get
+        # valid 'ctrl_num' and 'hp_disk_ids'.
+
+        pd_output = self._sacli_exec(
+            ['ctrl', "slot=%s" % ctrl_num, 'pd', hp_disk_ids[0], 'show'])
+
+        if pd_output.values()[0].keys()[0].lower().startswith("array "):
+            hp_array_id = pd_output.values()[0].keys()[0][len("array "):]
+            hp_array_id = "Array:%s" % hp_array_id
+        else:
+            raise LsmError(
+                ErrorNumber.PLUGIN_BUG,
+                "volume_raid_create(): Failed to find out the array ID of "
+                "new array: %s" % pd_output.items())
+
+        pool_id = _pool_id_of(sys_id, hp_array_id)
+
+        lsm_vols = self.volumes(search_key='pool_id', search_value=pool_id)
+
+        if len(lsm_vols) != 1:
+            raise LsmError(
+                ErrorNumber.PLUGIN_BUG,
+                "volume_raid_create(): Got unexpected count(not 1) of new "
+                "volumes: %s" % lsm_vols)
+        return lsm_vols[0]

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -29,6 +29,7 @@ from lsm.plugin.megaraid.utils import cmd_exec, ExecError
 # Naming scheme
 #   mega_sys_path   /c0
 #   mega_disk_path  /c0/e64/s0
+#   lsi_disk_id    0:64:0
 
 
 def _handle_errors(method):
@@ -393,7 +394,8 @@ class MegaRAID(IPlugin):
                 status = _disk_status_of(
                     disk_show_basic_dict, disk_show_stat_dict)
 
-                plugin_data = mega_disk_path
+                plugin_data = "%s:%s" % (
+                    ctrl_num, disk_show_basic_dict['EID:Slt'])
 
                 rc_lsm_disks.append(
                     Disk(
@@ -576,15 +578,14 @@ class MegaRAID(IPlugin):
             lsm_disk_map[lsm_disk.plugin_data] = lsm_disk.id
 
         for dg_disk_info in dg_show_all_output['DG Drive LIST']:
-            cur_lsi_disk_path = "/c%s" % ctrl_num + "/e%s/s%s" % tuple(
-                dg_disk_info['EID:Slt'].split(':'))
-            if cur_lsi_disk_path in lsm_disk_map.keys():
-                disk_ids.append(lsm_disk_map[cur_lsi_disk_path])
+            cur_lsi_disk_id = "%s:%s" % (ctrl_num, dg_disk_info['EID:Slt'])
+            if cur_lsi_disk_id in lsm_disk_map.keys():
+                disk_ids.append(lsm_disk_map[cur_lsi_disk_id])
             else:
                 raise LsmError(
                     ErrorNumber.PLUGIN_BUG,
                     "pool_member_info(): Failed to find disk id of %s" %
-                    cur_lsi_disk_path)
+                    cur_lsi_disk_id)
 
         raid_type = Volume.RAID_TYPE_UNKNOWN
         dg_num = lsi_dg_path.split('/')[2][1:]

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -19,6 +19,7 @@ import os
 import json
 import re
 import errno
+import math
 
 from lsm import (uri_parse, search_property, size_human_2_size_bytes,
                  Capabilities, LsmError, ErrorNumber, System, Client,
@@ -175,6 +176,16 @@ _RAID_TYPE_MAP = {
     'RAID60': Volume.RAID_TYPE_RAID60,
 }
 
+_LSM_RAID_TYPE_CONV = {
+    Volume.RAID_TYPE_RAID0: 'RAID0',
+    Volume.RAID_TYPE_RAID1: 'RAID1',
+    Volume.RAID_TYPE_RAID5: 'RAID5',
+    Volume.RAID_TYPE_RAID6: 'RAID6',
+    Volume.RAID_TYPE_RAID50: 'RAID50',
+    Volume.RAID_TYPE_RAID60: 'RAID60',
+    Volume.RAID_TYPE_RAID10: 'RAID10',
+}
+
 
 def _mega_raid_type_to_lsm(vd_basic_info, vd_prop_info):
     raid_type = _RAID_TYPE_MAP.get(
@@ -186,6 +197,15 @@ def _mega_raid_type_to_lsm(vd_basic_info, vd_prop_info):
         raid_type = Volume.RAID_TYPE_RAID10
 
     return raid_type
+
+
+def _lsm_raid_type_to_mega(lsm_raid_type):
+    try:
+        return _LSM_RAID_TYPE_CONV[lsm_raid_type]
+    except KeyError:
+        raise LsmError(
+            ErrorNumber.NO_SUPPORT,
+            "RAID type %d not supported" % lsm_raid_type)
 
 
 class MegaRAID(IPlugin):
@@ -261,6 +281,7 @@ class MegaRAID(IPlugin):
         cap.set(Capabilities.VOLUMES)
         cap.set(Capabilities.VOLUME_RAID_INFO)
         cap.set(Capabilities.POOL_MEMBER_INFO)
+        cap.set(Capabilities.VOLUME_RAID_CREATE)
         return cap
 
     def _storcli_exec(self, storcli_cmds, flag_json=True):
@@ -347,7 +368,7 @@ class MegaRAID(IPlugin):
                 )
             (status, status_info) = self._lsm_status_of_ctrl(
                 ctrl_show_all_output)
-            plugin_data = "/c%d"
+            plugin_data = "/c%d" % ctrl_num
             # Since PCI slot sequence might change.
             # This string just stored for quick system verification.
 
@@ -601,3 +622,155 @@ class MegaRAID(IPlugin):
             raid_type = Volume.RAID_TYPE_RAID10
 
         return raid_type, Pool.MEMBER_TYPE_DISK, disk_ids
+
+    def _vcr_cap_get(self, mega_sys_path):
+        cap_output = self._storcli_exec(
+            [mega_sys_path, "show", "all"])['Capabilities']
+
+        mega_raid_types = \
+            cap_output['RAID Level Supported'].replace(', \n', '').split(', ')
+
+        supported_raid_types = []
+        for cur_mega_raid_type in _RAID_TYPE_MAP.keys():
+            if cur_mega_raid_type in mega_raid_types:
+                supported_raid_types.append(
+                    _RAID_TYPE_MAP[cur_mega_raid_type])
+
+        supported_raid_types = sorted(list(set(supported_raid_types)))
+
+        min_strip_size = _mega_size_to_lsm(cap_output['Min Strip Size'])
+        max_strip_size = _mega_size_to_lsm(cap_output['Max Strip Size'])
+
+        supported_strip_sizes = list(
+            min_strip_size * (2 ** i)
+            for i in range(
+                0, int(math.log(max_strip_size / min_strip_size, 2) + 1)))
+
+        # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        # The math above is to generate a list like:
+        #   min_strip_size, ... n^2 , max_strip_size
+
+        return supported_raid_types, supported_strip_sizes
+
+    @_handle_errors
+    def volume_raid_create_cap_get(self, system, flags=Client.FLAG_RSVD):
+        """
+        Depend on the 'Capabilities' section of "storcli /c0 show all" output.
+        """
+        cur_lsm_syss = list(s for s in self.systems() if s.id == system.id)
+        if len(cur_lsm_syss) != 1:
+            raise LsmError(
+                ErrorNumber.NOT_FOUND_SYSTEM,
+                "System not found")
+
+        lsm_sys = cur_lsm_syss[0]
+        return self._vcr_cap_get(lsm_sys.plugin_data)
+
+    @_handle_errors
+    def volume_raid_create(self, name, raid_type, disks, strip_size,
+                           flags=Client.FLAG_RSVD):
+        """
+        Work flow:
+            1. Create RAID volume
+                storcli /c0 add vd RAID10 drives=252:1-4 pdperarray=2 J
+            2. Find out pool/DG base on one disk.
+                storcli /c0/e252/s1 show J
+            3. Find out the volume/VD base on pool/DG using self.volumes()
+        """
+        mega_raid_type = _lsm_raid_type_to_mega(raid_type)
+        ctrl_num = None
+        slot_nums = []
+        enclosure_num = None
+
+        for disk in disks:
+            if not disk.plugin_data:
+                raise LsmError(
+                    ErrorNumber.INVALID_ARGUMENT,
+                    "Illegal input disks argument: missing plugin_data "
+                    "property")
+            # Disk should from the same controller.
+            (cur_ctrl_num, cur_enclosure_num, slot_num) = \
+                disk.plugin_data.split(':')
+
+            if ctrl_num and cur_ctrl_num != ctrl_num:
+                raise LsmError(
+                    ErrorNumber.INVALID_ARGUMENT,
+                    "Illegal input disks argument: disks are not from the "
+                    "same controller/system.")
+
+            if enclosure_num and cur_enclosure_num != enclosure_num:
+                raise LsmError(
+                    ErrorNumber.INVALID_ARGUMENT,
+                    "Illegal input disks argument: disks are not from the "
+                    "same disk enclosure.")
+
+            ctrl_num = int(cur_ctrl_num)
+            enclosure_num = cur_enclosure_num
+            slot_nums.append(slot_num)
+
+        # Handle request volume name, LSI only allow 15 characters.
+        name = re.sub('[^0-9a-zA-Z_\-]+', '', name)[:15]
+
+        cmds = [
+            "/c%s" % ctrl_num, "add", "vd", mega_raid_type,
+            'size=all', "name=%s" % name,
+            "drives=%s:%s" % (enclosure_num, ','.join(slot_nums))]
+
+        if raid_type == Volume.RAID_TYPE_RAID10 or \
+           raid_type == Volume.RAID_TYPE_RAID50 or \
+           raid_type == Volume.RAID_TYPE_RAID60:
+            cmds.append("pdperarray=%d" % int(len(disks) / 2))
+
+        if strip_size != Volume.VCR_STRIP_SIZE_DEFAULT:
+            cmds.append("strip=%d" % int(strip_size / 1024))
+
+        try:
+            self._storcli_exec(cmds)
+        except ExecError:
+            req_disk_ids = [d.id for d in disks]
+            for cur_disk in self.disks():
+                if cur_disk.id in req_disk_ids and \
+                   not cur_disk.status & Disk.STATUS_FREE:
+                    raise LsmError(
+                        ErrorNumber.DISK_NOT_FREE,
+                        "Disk %s is not in STATUS_FREE state" % cur_disk.id)
+            # Check whether got unsupported RAID type or stripe size
+            supported_raid_types, supported_strip_sizes = \
+                self._vcr_cap_get("/c%s" % ctrl_num)
+
+            if raid_type not in supported_raid_types:
+                raise LsmError(
+                    ErrorNumber.NO_SUPPORT,
+                    "Provided 'raid_type' is not supported")
+
+            if strip_size != Volume.VCR_STRIP_SIZE_DEFAULT and \
+               strip_size not in supported_strip_sizes:
+                raise LsmError(
+                    ErrorNumber.NO_SUPPORT,
+                    "Provided 'strip_size' is not supported")
+
+            raise
+
+        # Find out the DG ID from one disk.
+        dg_show_output = self._storcli_exec(
+            ["/c%s/e%s/s%s" % tuple(disks[0].plugin_data.split(":")), "show"])
+
+        dg_id = dg_show_output['Drive Information'][0]['DG']
+        if dg_id == '-':
+            raise LsmError(
+                ErrorNumber.PLUGIN_BUG,
+                "volume_raid_create(): No error found in output, "
+                "but RAID is not created: %s" % dg_show_output.items())
+        else:
+            dg_id = int(dg_id)
+
+        pool_id = _pool_id_of(dg_id, self._sys_id_of_ctrl_num(ctrl_num))
+
+        lsm_vols = self.volumes(search_key='pool_id', search_value=pool_id)
+        if len(lsm_vols) != 1:
+            raise LsmError(
+                ErrorNumber.PLUGIN_BUG,
+                "volume_raid_create(): Got unexpected volume count(not 1) "
+                "when creating RAID volume")
+
+        return lsm_vols[0]

--- a/plugin/sim/simarray.py
+++ b/plugin/sim/simarray.py
@@ -123,7 +123,7 @@ class PoolRAID(object):
 
 
 class BackStore(object):
-    VERSION = "3.3"
+    VERSION = "3.4"
     VERSION_SIGNATURE = 'LSM_SIMULATOR_DATA_%s_%s' % (VERSION, md5(VERSION))
     JOB_DEFAULT_DURATION = 1
     JOB_DATA_TYPE_VOL = 1
@@ -133,7 +133,7 @@ class BackStore(object):
     SYS_ID = "sim-01"
     SYS_NAME = "LSM simulated storage plug-in"
     BLK_SIZE = 512
-    STRIP_SIZE = 131072     # 128 KiB
+    DEFAULT_STRIP_SIZE = 128 * 1024 # 128 KiB
 
     _LIST_SPLITTER = '#'
 
@@ -142,7 +142,8 @@ class BackStore(object):
     POOL_KEY_LIST = [
         'id', 'name', 'status', 'status_info',
         'element_type', 'unsupported_actions', 'raid_type',
-        'member_type', 'parent_pool_id', 'total_space', 'free_space']
+        'member_type', 'parent_pool_id', 'total_space', 'free_space',
+        'strip_size']
 
     DISK_KEY_LIST = [
         'id', 'name', 'total_space', 'disk_type', 'status',
@@ -150,7 +151,7 @@ class BackStore(object):
 
     VOL_KEY_LIST = [
         'id', 'vpd83', 'name', 'total_space', 'consumed_size',
-        'pool_id', 'admin_state', 'thinp']
+        'pool_id', 'admin_state', 'thinp', 'is_hw_raid_vol']
 
     TGT_KEY_LIST = [
         'id', 'port_type', 'service_address', 'network_address',
@@ -171,6 +172,16 @@ class BackStore(object):
         'id', 'fs_id', 'exp_path', 'auth_type', 'anon_uid', 'anon_gid',
         'options', 'exp_root_hosts_str', 'exp_rw_hosts_str',
         'exp_ro_hosts_str']
+
+    SUPPORTED_VCR_RAID_TYPES = [
+        Volume.RAID_TYPE_RAID0, Volume.RAID_TYPE_RAID1,
+        Volume.RAID_TYPE_RAID5, Volume.RAID_TYPE_RAID6,
+        Volume.RAID_TYPE_RAID10, Volume.RAID_TYPE_RAID50,
+        Volume.RAID_TYPE_RAID60]
+
+    SUPPORTED_VCR_STRIP_SIZES = [
+        8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024, 128 * 1024, 256 * 1024,
+        512 * 1024, 1024 * 1024]
 
     def __init__(self, statefile, timeout):
         if not os.path.exists(statefile):
@@ -218,6 +229,7 @@ class BackStore(object):
             "parent_pool_id INTEGER, "  # Indicate this pool is allocated from
                                         # other pool
             "member_type INTEGER, "
+            "strip_size INTEGER, "
             "total_space LONG);\n")     # total_space here is only for
                                         # sub-pool (pool from pool)
 
@@ -244,6 +256,10 @@ class BackStore(object):
                                                 # support.
             "admin_state INTEGER, "
             "thinp INTEGER NOT NULL, "
+            "is_hw_raid_vol INTEGER, " # Once its volume deleted, pool will
+                                        # be delete also. For HW RAID
+                                        # simulation only.
+
             "pool_id INTEGER NOT NULL, "
             "FOREIGN KEY(pool_id) "
             "REFERENCES pools(id) ON DELETE CASCADE);\n")
@@ -362,6 +378,7 @@ class BackStore(object):
                     pool0.raid_type,
                     pool0.member_type,
                     pool0.parent_pool_id,
+                    pool0.strip_size,
                     pool1.total_space total_space,
                     pool1.total_space -
                     pool2.vol_consumed_size  -
@@ -450,6 +467,7 @@ class BackStore(object):
                     vol.pool_id,
                     vol.admin_state,
                     vol.thinp,
+                    vol.is_hw_raid_vol,
                     vol_mask.ag_id ag_id
                 FROM
                     volumes vol
@@ -926,7 +944,11 @@ class BackStore(object):
             ErrorNumber.NOT_FOUND_POOL, "Pool")
 
     def sim_pool_create_from_disk(self, name, sim_disk_ids, raid_type,
-                                  element_type, unsupported_actions=0):
+                                  element_type, unsupported_actions=0,
+                                  strip_size=0):
+        if strip_size == 0:
+            strip_size = BackStore.DEFAULT_STRIP_SIZE
+
         self._data_add(
             'pools',
             {
@@ -937,6 +959,7 @@ class BackStore(object):
                 'unsupported_actions': unsupported_actions,
                 'raid_type': raid_type,
                 'member_type': Pool.MEMBER_TYPE_DISK,
+                'strip_size': strip_size,
             })
 
         data_disk_count = PoolRAID.data_disk_count(
@@ -1029,7 +1052,9 @@ class BackStore(object):
         return (size_bytes + BackStore.BLK_SIZE - 1) / \
             BackStore.BLK_SIZE * BackStore.BLK_SIZE
 
-    def sim_vol_create(self, name, size_bytes, sim_pool_id, thinp):
+    def sim_vol_create(self, name, size_bytes, sim_pool_id, thinp,
+                       is_hw_raid_vol=0):
+
         size_bytes = BackStore._block_rounding(size_bytes)
         self._check_pool_free_space(sim_pool_id, size_bytes)
         sim_vol = dict()
@@ -1040,6 +1065,7 @@ class BackStore(object):
         sim_vol['total_space'] = size_bytes
         sim_vol['consumed_size'] = size_bytes
         sim_vol['admin_state'] = Volume.ADMIN_STATE_ENABLED
+        sim_vol['is_hw_raid_vol'] = is_hw_raid_vol
 
         try:
             self._data_add("volumes", sim_vol)
@@ -1055,7 +1081,7 @@ class BackStore(object):
         This does not check whether volume exist or not.
         """
         # Check existence.
-        self.sim_vol_of_id(sim_vol_id)
+        sim_vol = self.sim_vol_of_id(sim_vol_id)
 
         if self._sim_ag_ids_of_masked_vol(sim_vol_id):
             raise LsmError(
@@ -1070,8 +1096,11 @@ class BackStore(object):
                     raise LsmError(
                         ErrorNumber.PLUGIN_BUG,
                         "Requested volume is a replication source")
-
-        self._data_delete("volumes", 'id="%s"' % sim_vol_id)
+        if sim_vol['is_hw_raid_vol']:
+            # Delete the parent pool instead if found a HW RAID volume.
+            self._data_delete("pools", 'id="%s"' % sim_vol['pool_id'])
+        else:
+            self._data_delete("volumes", 'id="%s"' % sim_vol_id)
 
     def sim_vol_mask(self, sim_vol_id, sim_ag_id):
         self.sim_vol_of_id(sim_vol_id)
@@ -1759,7 +1788,7 @@ class SimArray(object):
 
     @_handle_errors
     def volume_create(self, pool_id, vol_name, size_bytes, thinp, flags=0,
-                      _internal_use=False):
+                      _internal_use=False, _is_hw_raid_vol=0):
         """
         The '_internal_use' parameter is only for SimArray internal use.
         This method will return the new sim_vol id instead of job_id when
@@ -1769,7 +1798,8 @@ class SimArray(object):
             self.bs_obj.trans_begin()
 
         new_sim_vol_id = self.bs_obj.sim_vol_create(
-            vol_name, size_bytes, SimArray._sim_pool_id_of(pool_id), thinp)
+            vol_name, size_bytes, SimArray._sim_pool_id_of(pool_id),
+            thinp, is_hw_raid_vol=_is_hw_raid_vol)
 
         if _internal_use:
             return new_sim_vol_id
@@ -2251,9 +2281,9 @@ class SimArray(object):
             min_io_size = BackStore.BLK_SIZE
             opt_io_size = BackStore.BLK_SIZE
         else:
-            strip_size = BackStore.STRIP_SIZE
-            min_io_size = BackStore.STRIP_SIZE
-            opt_io_size = int(data_disk_count * BackStore.STRIP_SIZE)
+            strip_size = sim_pool['strip_size']
+            min_io_size = strip_size
+            opt_io_size = int(data_disk_count * strip_size)
 
         return [raid_type, strip_size, disk_count, min_io_size, opt_io_size]
 
@@ -2278,3 +2308,64 @@ class SimArray(object):
             member_type = Pool.MEMBER_TYPE_UNKNOWN
 
         return sim_pool['raid_type'], member_type, member_ids
+
+    @_handle_errors
+    def volume_raid_create_cap_get(self, system):
+        if system.id != BackStore.SYS_ID:
+            raise LsmError(
+                ErrorNumber.NOT_FOUND_SYSTEM,
+                "System not found")
+        return (
+            BackStore.SUPPORTED_VCR_RAID_TYPES,
+            BackStore.SUPPORTED_VCR_STRIP_SIZES)
+
+    @_handle_errors
+    def volume_raid_create(self, name, raid_type, disks, strip_size):
+        if raid_type not in BackStore.SUPPORTED_VCR_RAID_TYPES:
+            raise LsmError(
+                ErrorNumber.NO_SUPPORT,
+                "Provided 'raid_type' is not supported")
+
+        if strip_size == Volume.VCR_STRIP_SIZE_DEFAULT:
+            strip_size = BackStore.DEFAULT_STRIP_SIZE
+        elif strip_size not in BackStore.SUPPORTED_VCR_STRIP_SIZES:
+            raise LsmError(
+                ErrorNumber.NO_SUPPORT,
+                "Provided 'strip_size' is not supported")
+
+        self.bs_obj.trans_begin()
+        pool_name =  "Pool for volume %s" % name
+        sim_disk_ids = [
+            SimArray._lsm_id_to_sim_id(
+                d.id,
+                LsmError(ErrorNumber.NOT_FOUND_DISK, "Disk not found"))
+            for d in disks]
+
+        for disk in disks:
+            if not disk.status & Disk.STATUS_FREE:
+                raise LsmError(
+                    ErrorNumber.DISK_NOT_FREE,
+                    "Disk %s is not in DISK.STATUS_FREE mode" % disk.id)
+        try:
+            sim_pool_id = self.bs_obj.sim_pool_create_from_disk(
+                    name=pool_name,
+                    raid_type=raid_type,
+                    sim_disk_ids=sim_disk_ids,
+                    element_type=Pool.ELEMENT_TYPE_VOLUME,
+                    unsupported_actions=Pool.UNSUPPORTED_VOLUME_GROW |
+                    Pool.UNSUPPORTED_VOLUME_SHRINK,
+                    strip_size=strip_size)
+        except sqlite3.IntegrityError as sql_error:
+            raise LsmError(
+                ErrorNumber.NAME_CONFLICT,
+                "Name '%s' is already in use by other volume" % name)
+
+
+        sim_pool = self.bs_obj.sim_pool_of_id(sim_pool_id)
+        sim_vol_id = self.volume_create(
+            SimArray._sim_id_to_lsm_id(sim_pool_id, 'POOL'), name,
+            sim_pool['free_space'], Volume.PROVISION_FULL,
+            _internal_use=True, _is_hw_raid_vol=1)
+        sim_vol = self.bs_obj.sim_vol_of_id(sim_vol_id)
+        self.bs_obj.trans_commit()
+        return SimArray._sim_vol_2_lsm(sim_vol)

--- a/plugin/sim/simulator.py
+++ b/plugin/sim/simulator.py
@@ -292,3 +292,6 @@ class SimPlugin(INfs, IStorageAreaNetwork):
 
     def volume_raid_info(self, volume, flags=0):
         return self.sim_array.volume_raid_info(volume)
+
+    def pool_member_info(self, pool, flags=0):
+        return self.sim_array.pool_member_info(pool)

--- a/plugin/sim/simulator.py
+++ b/plugin/sim/simulator.py
@@ -295,3 +295,11 @@ class SimPlugin(INfs, IStorageAreaNetwork):
 
     def pool_member_info(self, pool, flags=0):
         return self.sim_array.pool_member_info(pool)
+
+    def volume_raid_create_cap_get(self, system, flags=0):
+        return self.sim_array.volume_raid_create_cap_get(system)
+
+    def volume_raid_create(self, name, raid_type, disks, strip_size,
+                           flags=0):
+        return self.sim_array.volume_raid_create(
+            name, raid_type, disks, strip_size)

--- a/plugin/simc/simc_lsmplugin.c
+++ b/plugin/simc/simc_lsmplugin.c
@@ -392,6 +392,7 @@ static int cap(lsm_plugin_ptr c, lsm_system *system,
             LSM_CAP_EXPORT_FS,
             LSM_CAP_EXPORT_REMOVE,
             LSM_CAP_VOLUME_RAID_INFO,
+            LSM_CAP_POOL_MEMBER_INFO,
             -1
             );
 
@@ -980,8 +981,29 @@ static int volume_raid_info(lsm_plugin_ptr c, lsm_volume *volume,
     return rc;
 }
 
+static int pool_member_info(
+    lsm_plugin_ptr c, lsm_pool *pool,
+    lsm_volume_raid_type *raid_type, lsm_pool_member_type *member_type,
+    lsm_string_list **member_ids, lsm_flag flags)
+{
+    int rc = LSM_ERR_OK;
+    struct plugin_data *pd = (struct plugin_data*)lsm_private_data_get(c);
+    lsm_pool *p = find_pool(pd, lsm_pool_id_get(pool));
+
+    if( !p) {
+        rc = lsm_log_error_basic(c, LSM_ERR_NOT_FOUND_POOL,
+                                    "Pool not found!");
+    }
+
+    *raid_type = LSM_VOLUME_RAID_TYPE_UNKNOWN;
+    *member_type = LSM_POOL_MEMBER_TYPE_UNKNOWN;
+    *member_ids = NULL;
+    return rc;
+}
+
 static struct lsm_ops_v1_2 ops_v1_2 = {
-    volume_raid_info
+    volume_raid_info,
+    pool_member_info,
 };
 
 static int volume_enable_disable(lsm_plugin_ptr c, lsm_volume *v,

--- a/plugin/simc/simc_lsmplugin.c
+++ b/plugin/simc/simc_lsmplugin.c
@@ -1001,9 +1001,29 @@ static int pool_member_info(
     return rc;
 }
 
+static int volume_raid_create_cap_get(
+    lsm_plugin_ptr c, lsm_system *system,
+    uint32_t **supported_raid_types, uint32_t *supported_raid_type_count,
+    uint32_t **supported_strip_sizes, uint32_t *supported_strip_size_count,
+    lsm_flag flags)
+{
+    return LSM_ERR_NO_SUPPORT;
+}
+
+static int volume_raid_create(
+    lsm_plugin_ptr c, const char *name, lsm_volume_raid_type raid_type,
+    lsm_disk *disks[], uint32_t disk_count,
+    uint32_t strip_size, lsm_volume **new_volume,
+    lsm_flag flags)
+{
+    return LSM_ERR_NO_SUPPORT;
+}
+
 static struct lsm_ops_v1_2 ops_v1_2 = {
     volume_raid_info,
     pool_member_info,
+    volume_raid_create_cap_get,
+    volume_raid_create,
 };
 
 static int volume_enable_disable(lsm_plugin_ptr c, lsm_volume *v,

--- a/python_binding/lsm/_client.py
+++ b/python_binding/lsm/_client.py
@@ -1074,3 +1074,101 @@ class Client(INetworkAttachedStorage):
                     No support.
         """
         return self._tp.rpc('volume_raid_info', _del_self(locals()))
+
+    @_return_requires([int, int, [unicode]])
+    def pool_member_info(self, pool, flags=FLAG_RSVD):
+        """
+        lsm.Client.pool_member_info(self, pool, flags=lsm.Client.FLAG_RSVD)
+
+        Version:
+            1.2
+        Usage:
+            Query the membership information of certain pool:
+                RAID type, member type and member ids.
+            Currently, LibStorageMgmt supports two types of pool:
+                * Sub-pool -- Pool.MEMBER_TYPE_POOL
+                    Pool space is allocated from parent pool.
+                    Example:
+                        * NetApp ONTAP volume
+
+                * Disk RAID pool -- Pool.MEMBER_TYPE_DISK
+                    Pool is a RAID group assembled by disks.
+                    Example:
+                        * LSI MegaRAID disk group
+                        * EMC VNX pool
+                        * NetApp ONTAP aggregate
+        Parameters:
+            pool (lsm.Pool object)
+                Pool to query
+            flags (int)
+                Optional. Reserved for future use.
+                Should be set as lsm.Client.FLAG_RSVD.
+        Returns:
+            [raid_type, member_type, member_ids]
+
+            raid_type (int)
+                RAID Type of requested pool.
+                    Could be one of these values:
+                        Volume.RAID_TYPE_RAID0
+                            Stripe
+                        Volume.RAID_TYPE_RAID1
+                            Two disks Mirror
+                        Volume.RAID_TYPE_RAID3
+                            Byte-level striping with dedicated parity
+                        Volume.RAID_TYPE_RAID4
+                            Block-level striping with dedicated parity
+                        Volume.RAID_TYPE_RAID5
+                            Block-level striping with distributed parity
+                        Volume.RAID_TYPE_RAID6
+                            Block-level striping with two distributed parities,
+                            aka, RAID-DP
+                        Volume.RAID_TYPE_RAID10
+                            Stripe of mirrors
+                        Volume.RAID_TYPE_RAID15
+                            Parity of mirrors
+                        Volume.RAID_TYPE_RAID16
+                            Dual parity of mirrors
+                        Volume.RAID_TYPE_RAID50
+                            Stripe of parities Volume.RAID_TYPE_RAID60
+                            Stripe of dual parities
+                        Volume.RAID_TYPE_RAID51
+                            Mirror of parities
+                        Volume.RAID_TYPE_RAID61
+                            Mirror of dual parities
+                        Volume.RAID_TYPE_JBOD
+                            Just bunch of disks, no parity, no striping.
+                        Volume.RAID_TYPE_UNKNOWN
+                            The plugin failed to detect the volume's RAID type.
+                        Volume.RAID_TYPE_MIXED
+                            This pool contains multiple RAID settings.
+                        Volume.RAID_TYPE_OTHER
+                            Vendor specific RAID type
+            member_type (int)
+                Could be one of these values:
+                    Pool.MEMBER_TYPE_POOL
+                        Current pool(also known as sub-pool) is allocated from
+                        other pool(parent pool). The 'raid_type' will set to
+                        RAID_TYPE_OTHER unless certain RAID system support RAID
+                        using space of parent pools.
+                    Pool.MEMBER_TYPE_DISK
+                        Pool is created from RAID group using whole disks.
+                    Pool.MEMBER_TYPE_OTHER
+                        Vendor specific RAID member type.
+                    Pool.MEMBER_TYPE_UNKNOWN
+                        Plugin failed to detect the RAID member type.
+            member_ids (list of strings)
+                When 'member_type' is Pool.MEMBER_TYPE_POOL,
+                the 'member_ids' will contain a list of parent Pool IDs.
+                When 'member_type' is Pool.MEMBER_TYPE_DISK,
+                the 'member_ids' will contain a list of disk IDs.
+                When 'member_type' is Pool.MEMBER_TYPE_OTHER or
+                Pool.MEMBER_TYPE_UNKNOWN, the member_ids should be an empty
+                list.
+        SpecialExceptions:
+            LsmError
+                ErrorNumber.NO_SUPPORT
+                ErrorNumber.NOT_FOUND_POOL
+        Capability:
+            lsm.Capabilities.POOL_MEMBER_INFO
+        """
+        return self._tp.rpc('pool_member_info', _del_self(locals()))

--- a/python_binding/lsm/_common.py
+++ b/python_binding/lsm/_common.py
@@ -447,6 +447,7 @@ class ErrorNumber(object):
     NOT_FOUND_VOLUME = 205
     NOT_FOUND_NFS_EXPORT = 206
     NOT_FOUND_SYSTEM = 208
+    NOT_FOUND_DISK = 209
 
     NOT_LICENSED = 226
 
@@ -477,6 +478,8 @@ class ErrorNumber(object):
                                 # has no member/initiator.
 
     POOL_NOT_READY = 512        # Pool is not ready for create/resize/etc
+
+    DISK_NOT_FREE = 513     # Disk is not in DISK.STATUS_FREE status.
 
     _LOCALS = locals()
 

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -306,6 +306,8 @@ class Volume(IData):
     MIN_IO_SIZE_UNKNOWN = 0
     OPT_IO_SIZE_UNKNOWN = 0
 
+    VCR_STRIP_SIZE_DEFAULT = 0
+
     def __init__(self, _id, _name, _vpd83, _block_size, _num_of_blocks,
                  _admin_state, _system_id, _pool_id, _plugin_data=None):
         self._id = _id                        # Identifier
@@ -760,6 +762,7 @@ class Capabilities(IData):
 
     DISKS = 220
     POOL_MEMBER_INFO = 221
+    VOLUME_RAID_CREATE = 222
 
     def _to_dict(self):
         return {'class': self.__class__.__name__,

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -412,6 +412,11 @@ class Pool(IData):
     STATUS_INITIALIZING = 1 << 14
     STATUS_GROWING = 1 << 15
 
+    MEMBER_TYPE_UNKNOWN = 0
+    MEMBER_TYPE_OTHER = 1
+    MEMBER_TYPE_DISK = 2
+    MEMBER_TYPE_POOL = 3
+
     def __init__(self, _id, _name, _element_type, _unsupported_actions,
                  _total_space, _free_space,
                  _status, _status_info, _system_id, _plugin_data=None):
@@ -754,6 +759,7 @@ class Capabilities(IData):
     TARGET_PORTS_QUICK_SEARCH = 217
 
     DISKS = 220
+    POOL_MEMBER_INFO = 221
 
     def _to_dict(self):
         return {'class': self.__class__.__name__,

--- a/test/cmdtest.py
+++ b/test/cmdtest.py
@@ -696,6 +696,24 @@ def volume_raid_info_test(cap, system_id):
             exit(10)
     return
 
+def pool_member_info_test(cap, system_id):
+    if cap['POOL_MEMBER_INFO']:
+        out = call([cmd, '-t' + sep, 'list', '--type', 'POOLS'])[1]
+        pool_list = parse(out)
+        for pool in pool_list:
+            out = call(
+                [cmd, '-t' + sep, 'pool-member-info', '--pool', pool[0]])[1]
+            r = parse(out)
+            if len(r[0]) != 4:
+                print "pool-member-info got expected output: %s" % out
+                exit(10)
+            if r[0][0] != pool[0]:
+                print "pool-member-info output pool ID is not requested " \
+                      "pool ID %s" % out
+                exit(10)
+    return
+
+
 def run_all_tests(cap, system_id):
     test_display(cap, system_id)
     test_plugin_list(cap, system_id)
@@ -708,6 +726,8 @@ def run_all_tests(cap, system_id):
     search_test(cap, system_id)
 
     volume_raid_info_test(cap, system_id)
+
+    pool_member_info_test(cap,system_id)
 
 if __name__ == "__main__":
     parser = OptionParser()

--- a/test/cmdtest.py
+++ b/test/cmdtest.py
@@ -713,6 +713,59 @@ def pool_member_info_test(cap, system_id):
                 exit(10)
     return
 
+def volume_raid_create_test(cap, system_id):
+    if cap['VOLUME_RAID_CREATE']:
+        out = call(
+            [cmd, '-t' + sep, 'volume-create-raid-cap', '--sys', system_id])[1]
+
+        if 'RAID1' not in [r[1] for r in parse(out)]:
+            return
+
+        out = call([cmd, '-t' + sep, 'list', '--type', 'disks'])[1]
+        free_disk_ids = []
+        disk_list = parse(out)
+        for disk in disk_list:
+            if 'Free' in disk:
+                if len(free_disk_ids) == 2:
+                    break
+                free_disk_ids.append(disk[0])
+
+        if len(free_disk_ids) != 2:
+            print "Require two free disks to test volume-create-raid"
+            exit(10)
+
+        out = call([
+            cmd, '-t' + sep, 'volume-create-raid', '--disk', free_disk_ids[0],
+            '--disk', free_disk_ids[1], '--name', 'test_volume_raid_create',
+            '--raid-type', 'raid1'])[1]
+
+        volume = parse(out)
+        vol_id = volume[0][0]
+        pool_id = volume[0][-2]
+
+        if cap['VOLUME_RAID_INFO']:
+            out = call(
+                [cmd, '-t' + sep, 'volume-raid-info', '--vol', vol_id])[1]
+            if parse(out)[0][1] != 'RAID1':
+                print "New volume is not RAID 1"
+                exit(10)
+
+        if cap['POOL_MEMBER_INFO']:
+            out = call(
+                [cmd, '-t' + sep, 'pool-member-info', '--pool', pool_id])[1]
+            if parse(out)[0][1] != 'RAID1':
+                print "New pool is not RAID 1"
+                exit(10)
+            for disk_id in free_disk_ids:
+                if disk_id not in [p[3] for p in parse(out)]:
+                    print "New pool does not contain requested disks"
+                    exit(10)
+
+        if cap['VOLUME_DELETE']:
+            volume_delete(vol_id)
+
+    return
+
 
 def run_all_tests(cap, system_id):
     test_display(cap, system_id)
@@ -728,6 +781,8 @@ def run_all_tests(cap, system_id):
     volume_raid_info_test(cap, system_id)
 
     pool_member_info_test(cap,system_id)
+
+    volume_raid_create_test(cap, system_id)
 
 if __name__ == "__main__":
     parser = OptionParser()

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -1294,6 +1294,56 @@ class TestPlugin(unittest.TestCase):
                     self.assertTrue(type(member_type) is int)
                     self.assertTrue(type(member_ids) is list)
 
+    def _skip_current_test(self, messsage):
+        """
+        If skipTest is supported, skip this test with provided message.
+        Sliently return if not supported.
+        """
+        if hasattr(unittest.TestCase, 'skipTest') is True:
+            self.skipTest(messsage)
+        return
+
+    def test_volume_raid_create(self):
+        for s in self.systems:
+            cap = self.c.capabilities(s)
+            # TODO(Gris Ge): Add test code for other RAID type and strip size
+            if supported(cap, [Cap.VOLUME_RAID_CREATE]):
+                supported_raid_types, supported_strip_sizes = \
+                    self.c.volume_raid_create_cap_get(s)
+                if lsm.Volume.RAID_TYPE_RAID1 not in supported_raid_types:
+                    self._skip_current_test(
+                        "Skip test: current system does not support "
+                        "creating RAID1 volume")
+
+                # Find two free disks
+                free_disks = []
+                for disk in self.c.disks():
+                    if len(free_disks) == 2:
+                        break
+                    if disk.status & lsm.Disk.STATUS_FREE:
+                        free_disks.append(disk)
+
+                if len(free_disks) != 2:
+                    self._skip_current_test(
+                        "Skip test: Failed to find two free disks for RAID 1")
+                    return
+
+                new_vol = self.c.volume_raid_create(
+                    rs('v'), lsm.Volume.RAID_TYPE_RAID1, free_disks,
+                    lsm.Volume.VCR_STRIP_SIZE_DEFAULT)
+
+                self.assertTrue(new_vol is not None)
+
+                # TODO(Gris Ge): Use volume_raid_info() and pool_member_info()
+                # to verify size, raid_type, member type, member ids.
+
+                if supported(cap, [Cap.VOLUME_DELETE]):
+                    self._volume_delete(new_vol)
+
+            else:
+                self._skip_current_test(
+                    "Skip test: not support of VOLUME_RAID_CREATE")
+
 def dump_results():
     """
     unittest.main exits when done so we need to register this handler to

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -1283,6 +1283,16 @@ class TestPlugin(unittest.TestCase):
                 self.c.export_remove(exp)
                 self._fs_delete(fs)
 
+    def test_pool_member_info(self):
+        for s in self.systems:
+            cap = self.c.capabilities(s)
+            if supported(cap, [Cap.POOL_MEMBER_INFO]):
+                for pool in self.c.pools():
+                    (raid_type, member_type, member_ids) = \
+                        self.c.pool_member_info(pool)
+                    self.assertTrue(type(raid_type) is int)
+                    self.assertTrue(type(member_type) is int)
+                    self.assertTrue(type(member_ids) is list)
 
 def dump_results():
     """

--- a/test/tester.c
+++ b/test/tester.c
@@ -2883,6 +2883,7 @@ START_TEST(test_volume_raid_info)
         &disk_count, &min_io_size, &opt_io_size, LSM_CLIENT_FLAG_RSVD);
 
     G(rc, lsm_volume_record_free, volume);
+    G(rc, lsm_pool_record_free, pool);
     volume = NULL;
 }
 END_TEST

--- a/test/tester.c
+++ b/test/tester.c
@@ -2887,6 +2887,36 @@ START_TEST(test_volume_raid_info)
 }
 END_TEST
 
+START_TEST(test_pool_member_info)
+{
+    int rc;
+    lsm_pool **pools = NULL;
+    uint32_t poolCount = 0;
+    G(rc, lsm_pool_list, c, NULL, NULL, &pools, &poolCount,
+      LSM_CLIENT_FLAG_RSVD);
+
+    lsm_volume_raid_type raid_type;
+    lsm_pool_member_type member_type;
+    lsm_string_list *member_ids = NULL;
+
+    int i;
+    uint32_t y;
+    for (i = 0; i < poolCount; i++) {
+        G(
+            rc, lsm_pool_member_info, c, pools[i], &raid_type, &member_type,
+            &member_ids, LSM_CLIENT_FLAG_RSVD);
+        for(y = 0; y < lsm_string_list_size(member_ids); y++){
+            // Simulator user reading the member id.
+            const char *cur_member_id = lsm_string_list_elem_get(
+                member_ids, y);
+            fail_unless( strlen(cur_member_id) );
+        }
+        lsm_string_list_free(member_ids);
+    }
+    G(rc, lsm_pool_record_array_free, pools, poolCount);
+}
+END_TEST
+
 Suite * lsm_suite(void)
 {
     Suite *s = suite_create("libStorageMgmt");
@@ -2923,6 +2953,7 @@ Suite * lsm_suite(void)
     tcase_add_test(basic, test_nfs_exports);
     tcase_add_test(basic, test_invalid_input);
     tcase_add_test(basic, test_volume_raid_info);
+    tcase_add_test(basic, test_pool_member_info);
 
     suite_add_tcase(s, basic);
     return s;

--- a/tools/bash_completion/lsmcli
+++ b/tools/bash_completion/lsmcli
@@ -125,6 +125,8 @@ function _lsm()
     fs_dependants_args="--fs"
     file_clone_args="--fs --src --dst --backing-snapshot"
     pool_member_info_args="--pool"
+    volume_raid_create_args="--name --disk --raid-type --strip-size"
+    volume_raid_create_cap_args="--sys"
 
     # These operations can potentially be slow and cause hangs depending on plugin and configuration
     if [[ ${NO_VALUE_LOOKUP} -ne 0 ]] ; then
@@ -399,6 +401,17 @@ function _lsm()
             ;;
         pool-member-info|pmi)
             possible_args "${pool_member_info_args}"
+            COMPREPLY=( $(compgen -W "${potential_args}" -- ${cur}) )
+            return 0
+            ;;
+        *)
+        volume-raid-create|vrc)
+            possible_args "${volume_raid_create_args}"
+            COMPREPLY=( $(compgen -W "${potential_args}" -- ${cur}) )
+            return 0
+            ;;
+        volume-raid-create-cap|vrcc)
+            possible_args "${volume_raid_create_cap_args}"
             COMPREPLY=( $(compgen -W "${potential_args}" -- ${cur}) )
             return 0
             ;;

--- a/tools/bash_completion/lsmcli
+++ b/tools/bash_completion/lsmcli
@@ -76,7 +76,7 @@ function _lsm()
                 fs-resize fs-export fs-unexport fs-clone fs-snap-create \
                 fs-snap-delete fs-snap-restore fs-dependants fs-dependants-rm \
                 file-clone ls lp lv ld la lf lt c p vc vd vr vm vi ve vi ac \
-                aa ar ad vri"
+                aa ar ad vri pool-member-info pmi"
 
     list_args="--type"
     list_type_args="volumes pools fs snapshots exports nfs_client_auth \
@@ -124,6 +124,7 @@ function _lsm()
     fs_snap_restore_args="--snap --fs --file --fileas --force"
     fs_dependants_args="--fs"
     file_clone_args="--fs --src --dst --backing-snapshot"
+    pool_member_info_args="--pool"
 
     # These operations can potentially be slow and cause hangs depending on plugin and configuration
     if [[ ${NO_VALUE_LOOKUP} -ne 0 ]] ; then
@@ -393,6 +394,11 @@ function _lsm()
             ;;
         capabilities|c)
             possible_args "${cap_args}"
+            COMPREPLY=( $(compgen -W "${potential_args}" -- ${cur}) )
+            return 0
+            ;;
+        pool-member-info|pmi)
+            possible_args "${pool_member_info_args}"
             COMPREPLY=( $(compgen -W "${potential_args}" -- ${cur}) )
             return 0
             ;;

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -39,7 +39,8 @@ from lsm import (Client, Pool, VERSION, LsmError, Disk,
 
 from lsm.lsmcli.data_display import (
     DisplayData, PlugData, out,
-    vol_provision_str_to_type, vol_rep_type_str_to_type, VolumeRAIDInfo)
+    vol_provision_str_to_type, vol_rep_type_str_to_type, VolumeRAIDInfo,
+    PoolRAIDInfo)
 
 
 ## Wraps the invocation to the command line
@@ -376,6 +377,14 @@ cmds = (
     ),
 
     dict(
+        name='pool-member-info',
+        help='Query Pool membership infomation',
+        args=[
+            dict(pool_id_opt),
+        ],
+    ),
+
+    dict(
         name='access-group-create',
         help='Create an access group',
         args=[
@@ -637,6 +646,7 @@ aliases = (
     ['ar', 'access-group-remove'],
     ['ad', 'access-group-delete'],
     ['vri', 'volume-raid-info'],
+    ['pmi', 'pool-member-info'],
 )
 
 
@@ -1333,6 +1343,13 @@ class CmdLine:
             [
                 VolumeRAIDInfo(
                     lsm_vol.id, *self.c.volume_raid_info(lsm_vol))])
+
+    def pool_member_info(self, args):
+        lsm_pool = _get_item(self.c.pools(), args.pool, "Pool")
+        self.display_data(
+            [
+                PoolRAIDInfo(
+                    lsm_pool.id, *self.c.pool_member_info(lsm_pool))])
 
     ## Displays file system dependants
     def fs_dependants(self, args):

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -279,6 +279,26 @@ class VolumeRAIDInfo(object):
         return _enum_type_to_str(raid_type, VolumeRAIDInfo._RAID_TYPE_MAP)
 
 
+class PoolRAIDInfo(object):
+    _MEMBER_TYPE_MAP = {
+        Pool.MEMBER_TYPE_UNKNOWN: 'Unknown',
+        Pool.MEMBER_TYPE_OTHER: 'Unknown',
+        Pool.MEMBER_TYPE_POOL: 'Pool',
+        Pool.MEMBER_TYPE_DISK: 'Disk',
+    }
+
+    def __init__(self, pool_id, raid_type, member_type, member_ids):
+        self.pool_id = pool_id
+        self.raid_type = raid_type
+        self.member_type = member_type
+        self.member_ids = member_ids
+
+    @staticmethod
+    def member_type_to_str(member_type):
+        return _enum_type_to_str(
+            member_type, PoolRAIDInfo._MEMBER_TYPE_MAP)
+
+
 class DisplayData(object):
 
     def __init__(self):
@@ -555,6 +575,27 @@ class DisplayData(object):
         'column_skip_keys': VOL_RAID_INFO_COLUMN_SKIP_KEYS,
         'value_conv_enum': VOL_RAID_INFO_VALUE_CONV_ENUM,
         'value_conv_human': VOL_RAID_INFO_VALUE_CONV_HUMAN,
+    }
+
+    POOL_RAID_INFO_HEADER = OrderedDict()
+    POOL_RAID_INFO_HEADER['pool_id'] = 'Pool ID'
+    POOL_RAID_INFO_HEADER['raid_type'] = 'RAID Type'
+    POOL_RAID_INFO_HEADER['member_type'] = 'Member Type'
+    POOL_RAID_INFO_HEADER['member_ids'] = 'Member IDs'
+
+    POOL_RAID_INFO_COLUMN_SKIP_KEYS = []
+
+    POOL_RAID_INFO_VALUE_CONV_ENUM = {
+        'raid_type': VolumeRAIDInfo.raid_type_to_str,
+        'member_type': PoolRAIDInfo.member_type_to_str,
+        }
+    POOL_RAID_INFO_VALUE_CONV_HUMAN = []
+
+    VALUE_CONVERT[PoolRAIDInfo] = {
+        'headers': POOL_RAID_INFO_HEADER,
+        'column_skip_keys': POOL_RAID_INFO_COLUMN_SKIP_KEYS,
+        'value_conv_enum': POOL_RAID_INFO_VALUE_CONV_ENUM,
+        'value_conv_human': POOL_RAID_INFO_VALUE_CONV_HUMAN,
     }
 
     @staticmethod


### PR DESCRIPTION
* Putting two patch sets into one. As `pool_member_info()` patch set is
  just preparation for `volume_raid_create()` patch set. It's better to
  explain design choice with both.

* New method `pool_member_info()` to query pool member information:
    * RAID type
    * Member type: disk RAID pool or sub-pool.
    * Members: disks or parent pools.

* New method `volume_raid_create()` to create RAID group volume.

* New method `volume_raid_create_cap_get()` to query RAID group volume create
  supported RAID type and strip sizes.

* Design notes:
    * Why we need pool_member_info() when we already have volume_raid_info()?
        The `pool_member_info()` is focus on RAID disk or sub-pool layout.

        The `volume_raid_info()` is focus on providing information about host
        I/O performance and availability(raid).

    * Why don't create single sharable method for SAN/NAS/DAS about RAID
      creation?
        Please refer to design note of patch 'New feature: Create RAID volume
        on hardware RAID.'

    * Why no RAID creation method for SAN and NAS?
        As we tried before, due to complex RAID settings of SAN and NAS
        storage, I didn't find a simple design to support all of them.

    * Please refer to design note of patch 'New feature: Create RAID volume'
      also.

* Please comment in github page, thank you.
    https://github.com/libstorage/libstoragemgmt/pull/11

Changes in V3:

* Rename pool_raid_info to pool_member_info.
* Rebased patches for the rename.
* Fix C code warning about comparing signed and unsigned integer.
* Initialized pointers in lsm_plugin_ipc.cpp and tester.c.
* Removed unused variables in tester.c.
* volume_create_raid() tested on:
    * MegaRAID: RAID 0/1/5/10.  # No RAID 6 license.
    * HP SmartArray: RAID 0.    # No additional disk.
* Document pull request: https://github.com/libstorage/libstoragemgmt-doc/pull/3

Changes in V4:

* Rename method 'volume_create_raid' to 'volume_raid_create'.
* Fix memory leak in C API.
* Initialize pointers in C code.
* Make sure output pointer is set to sane value if error occurred in C code.
* Add bash auto completion for new lsmcli commands and aliases.
* Fix typo in comments of C and Python library.
* Use hash table to convert vendor RAID string to LSM type in hpsa and
  megaraid plugins.
* Tested MegaRAID for 4 disks RAID 10 with default strip size.
  Query commands is tested on MegaRAID and Smart Array.
* Document updated and C API user guide for these new methods also included:
    https://github.com/libstorage/libstoragemgmt-doc/pull/3

Changes in V5:

* Updated commit message to use current method name:
    * pool_member_info
    * volume_raid_create
    * volume_raid_create_cap_get

Changes in V6:

* Patch 1/18, 8/18:
    Fix memory leaks in C library and C unit test.

* Patch 18/18:
    New patch for fixing volume_raid_create C unit test.