### PR TITLE
[PATCH V5 0/4] Volume VPD 83 Fix.

### DIFF
--- a/c_binding/lsm_mgmt.cpp
+++ b/c_binding/lsm_mgmt.cpp
@@ -117,16 +117,23 @@ int lsm_volume_vpd83_verify( const char *vpd83 )
 {
     int rc = LSM_ERR_INVALID_ARGUMENT;
     int i;
+    size_t vpd83_len;
 
-    if( vpd83 && strlen(vpd83) == 32 ) {
-        for(i = 0; i < 32; ++i) {
-            char v = vpd83[i];
-            //  0-9 || a-f is OK
-            if( !((v >= 48 && v <= 57) || (v >= 97 && v <= 102)) ) {
-                return rc;
+    if( vpd83 ){
+        vpd83_len = strlen(vpd83);
+        if( (vpd83_len == 32 && vpd83[0] == '6' ) ||
+            (vpd83_len == 16 && vpd83[0] == '2' ) ||
+            (vpd83_len == 16 && vpd83[0] == '3' ) ||
+            (vpd83_len == 16 && vpd83[0] == '5' )) {
+            for(i = 0; i < vpd83_len; ++i) {
+                char v = vpd83[i];
+                //  0-9 || a-f is OK
+                if( !((v >= 48 && v <= 57) || (v >= 97 && v <= 102)) ) {
+                    return rc;
+                }
             }
+            rc = LSM_ERR_OK;
         }
-        rc = LSM_ERR_OK;
     }
     return rc;
 }

--- a/plugin/smispy/dmtf.py
+++ b/plugin/smispy/dmtf.py
@@ -201,16 +201,10 @@ REPLICA_MODE_SYNC = Uint16(2)
 REPLICA_MODE_ASYNC = Uint16(3)
 
 # CIM_StorageVolume['NameFormat']
-VOL_NAME_FORMAT_OTHER = 1
 VOL_NAME_FORMAT_NNA = 9
-VOL_NAME_FORMAT_EUI64 = 10
-VOL_NAME_FORMAT_T10VID = 11
 
 # CIM_StorageVolume['NameNamespace']
-VOL_NAME_SPACE_OTHER = 1
 VOL_NAME_SPACE_VPD83_TYPE3 = 2
-VOL_NAME_SPACE_VPD83_TYPE2 = 3
-VOL_NAME_SPACE_VPD83_TYPE1 = 4
 
 # CIM_ReplicationServiceCapabilities['SupportedAsynchronousActions']
 # or CIM_ReplicationServiceCapabilities['SupportedSynchronousActions']

--- a/plugin/smispy/smis_vol.py
+++ b/plugin/smispy/smis_vol.py
@@ -158,8 +158,7 @@ def _vpd83_netapp(cim_vol):
 
 def _vpd83_of_cim_vol(cim_vol):
     """
-    Extract VPD83 string from CIMInstanceName and convert to LSM format:
-        ^6[a-f0-9]{31}$
+    Extract VPD83 NAA string from CIMInstanceName and convert to LSM format.
     """
     vpd_83 = _vpd83_in_cim_vol_name(cim_vol)
     if vpd_83 is None:
@@ -167,8 +166,11 @@ def _vpd83_of_cim_vol(cim_vol):
     if vpd_83 is None:
         vpd_83 = _vpd83_netapp(cim_vol)
 
-    if vpd_83 and re.match('^6[a-fA-F0-9]{31}$', vpd_83):
-        return vpd_83.lower()
+    if vpd_83:
+        vpd_83 = vpd_83.lower()
+
+    if vpd_83 and Volume.vpd83_verify(vpd_83):
+        return vpd_83
     else:
         return ''
 

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -232,7 +232,7 @@ class Disk(IData):
 
 # Lets do this once outside of the class to minimize the number of
 # times it needs to be compiled.
-_vol_regex_vpd83 = re.compile('^[0-9a-f]{32}$')
+_vol_regex_vpd83 = re.compile('(?:^6[0-9a-f]{31})|(?:^[235][0-9a-f]{15})$')
 
 
 @default_property('id', doc="Unique identifier")
@@ -314,8 +314,8 @@ class Volume(IData):
         self._name = _name                    # Human recognisable name
         if _vpd83 and not Volume.vpd83_verify(_vpd83):
             raise LsmError(ErrorNumber.INVALID_ARGUMENT,
-                           "Incorrect format of VPD 0x83 string: '%s', "
-                           "expecting 32 lower case hex characters" %
+                           "Incorrect format of VPD 0x83 NAA(3) string: '%s', "
+                           "expecting 32 or 16 lower case hex characters" %
                            _vpd83)
         self._vpd83 = _vpd83                  # SCSI page 83 unique ID
         self._block_size = _block_size        # Block size

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -321,12 +321,6 @@ class TestPlugin(unittest.TestCase):
         pools_list = self.c.pools()
         self.assertTrue(len(pools_list) > 0, "We need at least 1 pool to test")
 
-    @staticmethod
-    def _vpd_correct(vpd):
-        if vpd and re.match('^[a-f0-9]{32}$', vpd):
-            return True
-        return False
-
     def _find_or_create_volumes(self):
         """
         Find existing volumes, if not found, try to create one.
@@ -357,7 +351,7 @@ class TestPlugin(unittest.TestCase):
         (volumes, flag_created) = self._find_or_create_volumes()
         self.assertTrue(len(volumes) > 0, "We need at least 1 volume to test")
         for v in volumes:
-            self.assertTrue(TestPlugin._vpd_correct(v.vpd83),
+            self.assertTrue(lsm.Volume.vpd83_verify(v.vpd83),
                             "VPD is not as expected '%s' for volume id: '%s'" %
                             (v.vpd83, v.id))
         if flag_created:
@@ -1122,13 +1116,21 @@ class TestPlugin(unittest.TestCase):
                    "012345678901234567890123456789ax",
                    "012345678901234567890123456789ag",
                    "1234567890123456789012345abcdef",
-                   "01234567890123456789012345abcdefa"]
+                   "01234567890123456789012345abcdefa",
+                   "55cd2e404beec32e0", "55cd2e404beec32ex",
+                   "35cd2e404beec32A"]
 
         for f in failing:
             self.assertFalse(lsm.Volume.vpd83_verify(f))
 
         self.assertTrue(
-            lsm.Volume.vpd83_verify("01234567890123456789012345abcdef"))
+            lsm.Volume.vpd83_verify("61234567890123456789012345abcdef"))
+        self.assertTrue(
+            lsm.Volume.vpd83_verify("55cd2e404beec32e"))
+        self.assertTrue(
+            lsm.Volume.vpd83_verify("35cd2e404beec32e"))
+        self.assertTrue(
+            lsm.Volume.vpd83_verify("25cd2e404beec32e"))
 
     def test_available_plugins(self):
         plugins = self.c.available_plugins(':')

--- a/test/tester.c
+++ b/test/tester.c
@@ -2853,8 +2853,16 @@ START_TEST(test_volume_vpd_check)
     F(rc, lsm_volume_vpd83_verify, "012345678901234567890123456789ag");
     F(rc, lsm_volume_vpd83_verify, "1234567890123456789012345abcdef");
     F(rc, lsm_volume_vpd83_verify, "01234567890123456789012345abcdefa");
+    F(rc, lsm_volume_vpd83_verify, "01234567890123456789012345abcdef");
+    F(rc, lsm_volume_vpd83_verify, "55cd2e404beec32e0");
+    F(rc, lsm_volume_vpd83_verify, "55cd2e404beec32ex");
+    F(rc, lsm_volume_vpd83_verify, "55cd2e404beec32A");
+    F(rc, lsm_volume_vpd83_verify, "35cd2e404beec32A");
 
-    G(rc, lsm_volume_vpd83_verify, "01234567890123456789012345abcdef");
+    G(rc, lsm_volume_vpd83_verify, "61234567890123456789012345abcdef");
+    G(rc, lsm_volume_vpd83_verify, "55cd2e404beec32e");
+    G(rc, lsm_volume_vpd83_verify, "35cd2e404beec32e");
+    G(rc, lsm_volume_vpd83_verify, "25cd2e404beec32e");
 }
 END_TEST
 


### PR DESCRIPTION
* After review SPC-3 and SPC-4 document and udev source code, I noticed the
  incorrect definition of our Volume.vpd83.

Changes in V4:

* Patch 4/4: Fix None.lower() error in SMI-S plugin.

Changes in V5:

* Patch 1/4: Remove extra strlen() call by save its return in
  lsm_volume_vpd83_verify() of lsm_mgmt.cpp.