### PR TITLE
lsmd: Fix a possible infinity loop on plugin search.

### DIFF
--- a/daemon/lsm_daemon.c
+++ b/daemon/lsm_daemon.c
@@ -281,7 +281,7 @@ void process_directory( char *dir, void *p, file_op call_back)
                 free(full_name);
                 full_name = path_form(dir, entry->d_name);
 
-                if( stat(full_name, &entry_st ) != 0 ) {
+                if( lstat(full_name, &entry_st ) != 0 ) {
                     continue;
                 }
 


### PR DESCRIPTION
 * On Debian 8, in plugin search path '/usr/bin', there is a symbolic linki

     ```
     [fge@Gris-Laptop daemon]$ ls -l /usr/bin/X11
     lrwxrwxrwx 1 root root 1 May  2 22:52 /usr/bin/X11 -> .
     ```

   The stat() will treat it as an folder and scan it again which create
   a infinity loop scan.

 * Changing stat() to lstat() could fix this as lstat() does not follow
   the symbolic link which skip the scan in it.

Signed-off-by: Gris Ge <fge@redhat.com>