### PR TITLE
Simulator Plugin: Fix incorrect error message on incompatible state file

### DIFF
--- a/plugin/sim/simarray.py
+++ b/plugin/sim/simarray.py
@@ -616,6 +616,11 @@ class BackStore(object):
                 pass
             else:
                 raise sql_error
+        except sqlite3.DatabaseError as sql_error:
+            raise LsmError(
+                ErrorNumber.INVALID_ARGUMENT,
+                "Stored simulator state incompatible with "
+                "simulator, please move or delete %s" % self.statefile)
 
     def _check_version(self):
         sim_syss = self.sim_syss()


### PR DESCRIPTION
Issue:
    When old state file is not an valid sqlite database, user will
    get this confusing error:

        PLUGIN_BUG(2): Got unexpected error: file is encrypted or is not a
        database

Root cause:
    DatabaseError is not well take care when loading state file.

Fix:
    Raise ErrorNumber.INVALID_ARGUMENT error for sqlite3.DatabaseError
    when loading state file.

Test:
    dd if=/dev/urandom of=/tmp/lsm_sim_data bs=1M count=1
    lsmcli ls -u sim://

Signed-off-by: Gris Ge <fge@redhat.com>