### PR TITLE
Fix issue #19: remove unnecessary error string.

### DIFF
--- a/c_binding/lsm_plugin_ipc.cpp
+++ b/c_binding/lsm_plugin_ipc.cpp
@@ -211,7 +211,8 @@ static void error_send(lsm_plugin_ptr p, int error_code)
             p->error = NULL;
         }
     } else {
-        p->tp->errorSend(error_code, "UNA", "UNA");
+        p->tp->errorSend(error_code, "Plugin didn't provide error message",
+                         "");
     }
 }
 

--- a/python_binding/lsm/_common.py
+++ b/python_binding/lsm/_common.py
@@ -379,7 +379,7 @@ class LsmError(Exception):
 
     def __str__(self):
         error_no_str = ErrorNumber.error_number_to_str(self.code)
-        if self.data is not None:
+        if self.data is not None and self.data:
             return "%s: %s Data: %s" % \
                    (error_no_str, self.msg, self.data)
         else:


### PR DESCRIPTION
* For error message like:

  ```
    NO_SUPPORT(153): UNA Data: UNA
                     ^^^^^^^^^^^^^
  ```
  Root cause:
        It is generated by `lsm_plugin_ipc.cpp error_send()`.

  Fix:
        Change to "Plugin didn't provide error message" and empty string to be
        more human friendly.

* For error message like:

  ```
    NO_SUPPORT(153): No support Data:
                                ^^^^^
  ```
  Root cause:
        It is generated by `_common.py LsmError.__str__()`.
  Fix:
        Check whether data string is empty before adding "Data:" prefix.

Signed-off-by: Gris Ge <fge@redhat.com>