### PR TITLE
Fix: selinux dac_override

### DIFF
--- a/packaging/daemon/lsm-tmpfiles.conf
+++ b/packaging/daemon/lsm-tmpfiles.conf
@@ -1,2 +1,2 @@
-D /var/run/lsm 0755 libstoragemgmt libstoragemgmt -
-D /var/run/lsm/ipc 0755 libstoragemgmt libstoragemgmt -
+D /var/run/lsm 0775 root libstoragemgmt -
+D /var/run/lsm/ipc 0775 root libstoragemgmt -


### PR DESCRIPTION
Fixes:
Jun 22 15:04:26 localhost.localdomain systemd[1]: Starting libstoragemgmt plug-in server daemon...
Jun 22 15:04:26 localhost.localdomain audit[1753]: <audit-1400> avc:  denied  { dac_override } for  pid=1753 comm="lsmd" capability=1  scontext=system_u:system_r:lsmd_t:s0 tcontext=system_u:system_r:lsmd_t:s0 tclass=capability permissive=0
Jun 22 15:04:26 localhost.localdomain lsmd[1753]: Unable to access socket directory /var/run/lsm/ipc, errno= 13
Jun 22 15:04:26 localhost.localdomain systemd[1]: libstoragemgmt.service: main process exited, code=exited, status=1/FAILURE

Should allow the daemon to run as root or as libstoragemgmt user.

Signed-off-by: Tony Asleson <tasleson@redhat.com>