### PR TITLE
Enable travis-ci test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: true
+#  python-pywbem and libconfig-dev is not in whitelist yet which stop us using
+#  "sudo : false" new container way:
+#   https://github.com/travis-ci/travis-ci/issues/4332
+#   https://github.com/travis-ci/travis-ci/issues/4329
+
+language: c
+
+install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq gcc tar make g++ libtool autoconf automake
+        libyajl-dev python-pywbem libxml2-dev check
+        libglib2.0-dev python-m2crypto libssl-dev libconfig-dev
+
+
+compiler: gcc
+
+script: ./autogen.sh && ./configure --without-rest-api &&
+        env DISTCHECK_CONFIGURE_FLAGS="--without-rest-api" make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,8 +2,9 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-DISTCHECK_CONFIGURE_FLAGS = --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
-DISTCHECK_CONFIGURE_FLAGS += \
+AM_DISTCHECK_CONFIGURE_FLAGS = \
+	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
+AM_DISTCHECK_CONFIGURE_FLAGS += \
 	--with-bash-completion-dir=$$dc_install_base/$(bashcompletiondir)
 
 SUBDIRS= c_binding python_binding plugin doc tools daemon packaging config


### PR DESCRIPTION
* Patch 1/2 is to allow 'make distcheck' to run without libmicrohttpd.

    The travis-ci.org is using Ubuntu 12.04 which is shipping old libmicrohttpd.