### PR TITLE
Travis-CI: Use container for test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,24 @@
-sudo: true
-#  python-pywbem and libconfig-dev is not in whitelist yet which stop us using
-#  "sudo : false" new container way:
-#   https://github.com/travis-ci/travis-ci/issues/4332
-#   https://github.com/travis-ci/travis-ci/issues/4329
-
+sudo: false
 language: c
 
-install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq gcc tar make g++ libtool autoconf automake
-        libyajl-dev python-pywbem libxml2-dev check
-        libglib2.0-dev python-m2crypto libssl-dev libconfig-dev
-
+addons:
+  apt:
+    packages:
+        - gcc 
+        - tar 
+        - make 
+        - g++ 
+        - libtool 
+        - autoconf 
+        - automake 
+        - libyajl-dev 
+        - python-pywbem 
+        - libxml2-dev 
+        - check 
+        - libglib2.0-dev 
+        - python-m2crypto 
+        - libssl-dev 
+        - libconfig-dev
 
 compiler: gcc
 


### PR DESCRIPTION
* Since required packages has been added to whitelist, we are ready to
  use container(sudo: false) way for test.

Signed-off-by: Gris Ge <fge@redhat.com>