### PR TITLE
New API for retrieving system firmware version.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Patches have also been contributed by:
    Ma Shimiao               <mashimiao.fnst@cn.fujitsu.com>
    Ewan Milne               <emilne@redhat.com>
    Charles Rose             <charles.e.rose@gmail.com>
+   Joe Handzik              <joseph.t.handzik@hpe.com>
 
 
 [....send patches to get your name here....]

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011-2014 Red Hat, Inc.
+ * Copyright (C) 2011-2015 Red Hat, Inc.
+ * (C) Copyright 2015 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -14,6 +15,8 @@
  * License along with this library; If not, see <http://www.gnu.org/licenses/>.
  *
  * Author: tasleson
+ *         Joe Handzik <joseph.t.handzik@hpe.com>
+ *         Gris Ge <fge@redhat.com>
  */
 
 #ifndef LSM_CAPABILITIES_H
@@ -152,6 +155,8 @@ typedef enum {
     LSM_CAP_EXPORT_CUSTOM_PATH = 124,
     /**^ Plug-in allows user to define custome export path */
 
+    LSM_CAP_SYS_FW_VERSION_GET = 160,
+    /**^ Plug-in allows user to retrieve storage firmware version */
     LSM_CAP_POOLS_QUICK_SEARCH = 210,
     /**^ Seach occurs on array */
     LSM_CAP_VOLUMES_QUICK_SEARCH = 211,

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011-2014 Red Hat, Inc.
+ * Copyright (C) 2011-2015 Red Hat, Inc.
+ * (C) Copyright 2015 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -14,6 +15,8 @@
  * License along with this library; If not, see <http://www.gnu.org/licenses/>.
  *
  * Author: tasleson
+ *         Joe Handzik <joseph.t.handzik@hpe.com>
+ *         Gris Ge <fge@redhat.com>
  */
 
 #ifndef LIBSTORAGEMGMT_PLUG_INTERFACE_H
@@ -980,8 +983,6 @@ typedef int (*lsm_plug_volume_raid_create) (lsm_plugin_ptr c,
 
 /** \struct lsm_ops_v1_2
  * \brief Functions added in version 1.2
- * NOTE: This structure will change during the developement util version 1.2
- *       released.
  */
 struct lsm_ops_v1_2 {
     lsm_plug_volume_raid_info vol_raid_info;
@@ -1247,6 +1248,18 @@ lsm_system LSM_DLL_EXPORT *lsm_system_record_alloc(const char *id,
                                                    uint32_t status,
                                                    const char *status_info,
                                                    const char *plugin_data);
+
+/**
+ * New in version 1.3. Set firmware version.
+ * @param[in] id            Id
+ * @param[in] sys           System to update.
+ * @param[in] fw_ver        Firmware version string.
+ *                          Caller will get LSM_ERR_INVALID_ARGUMENT for
+ *                          empty string('\0').
+ * @return LSM_ERR_OK or LSM_ERR_NO_MEMORY or LSM_ERR_INVALID_ARGUMENT.
+ */
+int LSM_DLL_EXPORT lsm_system_fw_version_set(lsm_system *sys,
+                                             const char *fw_ver);
 
 /**
  * Retrieve plugin private data

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_systems.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_systems.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011-2014 Red Hat, Inc.
+ * Copyright (C) 2011-2015 Red Hat, Inc.
+ * (C) Copyright 2015 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -14,6 +15,8 @@
  * License along with this library; If not, see <http://www.gnu.org/licenses/>.
  *
  * Author: tasleson
+ *         Joe Handzik <joseph.t.handzik@hpe.com>
+ *         Gris Ge <fge@redhat.com>
  */
 #ifndef LIBSTORAGEMGMT_SYSTEMS_H
 #define LIBSTORAGEMGMT_SYSTEMS_H
@@ -74,6 +77,17 @@ const char LSM_DLL_EXPORT *lsm_system_name_get(lsm_system *s);
  */
 uint32_t LSM_DLL_EXPORT lsm_system_status_get(lsm_system *s);
 
+/**
+ * New in version 1.3. Retrieves firmware version of the specified system.
+ * Please do not free fw_ver string pointer, resources will get freed when
+ * lsm_system_record_free() or lsm_system_record_array_free() is called.
+ * @param       s       System to retrieve firmware version for.
+ * @param[out]  fw_ver  Firmware version string.
+ * @return LSM_ERR_OK on success, or LSM_ERR_NO_SUPPORT, or
+ *         LSM_ERR_INVALID_ARGUMENT.
+ */
+int LSM_DLL_EXPORT lsm_system_fw_version_get(lsm_system *s,
+                                             const char **fw_ver);
 
 #ifdef  __cplusplus
 }

--- a/c_binding/lsm_datatypes.hpp
+++ b/c_binding/lsm_datatypes.hpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011-2014 Red Hat, Inc.
+ * Copyright (C) 2011-2015 Red Hat, Inc.
+ * (C) Copyright 2015 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -14,6 +15,8 @@
  * License along with this library; If not, see <http://www.gnu.org/licenses/>.
  *
  * Author: tasleson
+ *         Joe Handzik <joseph.t.handzik@hpe.com>
+ *         Gris Ge <fge@redhat.com>
  */
 
 #ifndef LSM_DATATYPES_H
@@ -162,6 +165,7 @@ struct _lsm_system {
     uint32_t status;            /**< Enumerated status value */
     char *status_info;          /**< System status text */
     char *plugin_data;          /**< Reserved for the plugin to use */
+    const char *fw_version;     /**< Firmware version */
 };
 
 #define LSM_CONNECT_MAGIC       0xAA7A000A

--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,9 @@
 dnl Process this file with autoconf to produce a configure script.
-dnl Copyright (C) 2011 Red Hat, Inc.
+dnl Copyright (C) 2011-2015 Red Hat, Inc.
 dnl See COPYING.LIB for the License of this software
 
 AC_INIT(
-    [libstoragemgmt], [1.2.3], [libstoragemgmt-devel@lists.fedorahosted.org],
+    [libstoragemgmt], [1.3.0], [libstoragemgmt-devel@lists.fedorahosted.org],
     [], [https://github.com/libstorage/libstoragemgmt/])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015 Red Hat, Inc.
+# (C) Copyright 2015 Hewlett Packard Enterprise Development LP
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -13,6 +14,7 @@
 # License along with this library; If not, see <http://www.gnu.org/licenses/>.
 #
 # Author: Gris Ge <fge@redhat.com>
+#         Joe Handzik <joseph.t.handzik@hpe.com>
 
 import os
 import errno
@@ -324,6 +326,7 @@ class SmartArray(IPlugin):
         cap.set(Capabilities.VOLUME_RAID_INFO)
         cap.set(Capabilities.POOL_MEMBER_INFO)
         cap.set(Capabilities.VOLUME_RAID_CREATE)
+        cap.set(Capabilities.SYS_FW_VERSION_GET)
         return cap
 
     def _sacli_exec(self, sacli_cmds, flag_convert=True):
@@ -366,9 +369,10 @@ class SmartArray(IPlugin):
             (status, status_info) = _sys_status_of(ctrl_all_status[ctrl_name])
 
             plugin_data = "%s" % ctrl_data['Slot']
+            fw_ver = "%s" % ctrl_data['Firmware Version']
 
-            rc_lsm_syss.append(
-                System(sys_id, ctrl_name, status, status_info, plugin_data))
+            rc_lsm_syss.append(System(sys_id, ctrl_name, status, status_info,
+                                      plugin_data, _fw_version=fw_ver))
 
         return rc_lsm_syss
 

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -366,20 +366,24 @@ class MegaRAID(IPlugin):
             ctrl_show_all_output = self._storcli_exec(
                 ["/c%d" % ctrl_num, "show", "all"])
             sys_id = self._sys_id_of_ctrl_num(ctrl_num, ctrl_show_all_output)
-            sys_name = "%s %s %s ver: %s" % (
+            sys_name = "%s %s %s" % (
                 ctrl_show_all_output['Basics']['Model'],
                 ctrl_show_all_output['Bus']['Host Interface'],
-                ctrl_show_all_output['Basics']['PCI Address'],
-                ctrl_show_all_output['Version']['Firmware Package Build'],
-                )
+                ctrl_show_all_output['Basics']['PCI Address'])
             (status, status_info) = self._lsm_status_of_ctrl(
                 ctrl_show_all_output)
             plugin_data = "/c%d" % ctrl_num
             # Since PCI slot sequence might change.
             # This string just stored for quick system verification.
 
+            fw_ver = "Package: %s, BIOS: %s, FW: %s" % (
+                ctrl_show_all_output["Version"]["Firmware Package Build"],
+                ctrl_show_all_output["Version"]["Bios Version"],
+                ctrl_show_all_output["Version"]["Firmware Version"])
+
             rc_lsm_syss.append(
-                System(sys_id, sys_name, status, status_info, plugin_data))
+                System(sys_id, sys_name, status, status_info, plugin_data,
+                       _fw_version=fw_ver))
 
         return rc_lsm_syss
 

--- a/plugin/sim/simarray.py
+++ b/plugin/sim/simarray.py
@@ -1725,7 +1725,7 @@ class SimArray(object):
     def _sim_sys_2_lsm(sim_sys):
         return System(
             sim_sys['id'], sim_sys['name'], sim_sys['status'],
-            sim_sys['status_info'])
+            sim_sys['status_info'], _fw_version=sim_sys["version"])
 
     @_handle_errors
     def systems(self):

--- a/plugin/sim/simulator.py
+++ b/plugin/sim/simulator.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2014 Red Hat, Inc.
+# Copyright (C) 2011-2015 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/plugin/simc/simc_lsmplugin.c
+++ b/plugin/simc/simc_lsmplugin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2014 Red Hat, Inc.
+ * Copyright (C) 2011-2015 Red Hat, Inc.
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -2285,6 +2285,7 @@ int load(lsm_plugin_ptr c, const char *uri, const char *password,
                                                 "LSM simulated storage plug-in",
                                                 LSM_SYSTEM_STATUS_OK, "",
                                                 NULL);
+        lsm_system_fw_version_set(pd->system[0], version);
 
         p = lsm_pool_record_alloc("POOL_3", "lsm_test_aggr",
                                   LSM_POOL_ELEMENT_TYPE_FS |

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2014 Red Hat, Inc.
+# Copyright (C) 2011-2015 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -357,12 +357,27 @@ class System(IData):
     STATUS_PREDICTIVE_FAILURE = 1 << 4
     STATUS_OTHER = 1 << 5
 
-    def __init__(self, _id, _name, _status, _status_info, _plugin_data=None):
+    def __init__(self, _id, _name, _status, _status_info, _plugin_data=None,
+                 _fw_version=''):
         self._id = _id
         self._name = _name
         self._status = _status
         self._status_info = _status_info
         self._plugin_data = _plugin_data
+        self._fw_version = _fw_version
+
+    @property
+    def fw_version(self):
+        """
+        String. Firmware version string. New in version 1.3.
+        On some system, it might contain multiple version strings, example:
+            "Package: 23.32.0-0009, FW: 3.440.05-3712"
+        """
+        if self._fw_version == '':
+            raise LsmError(ErrorNumber.NO_SUPPORT,
+                           "System.fw_version() is not supported by this "
+                           "plugin yet")
+        return self._fw_version
 
 
 @default_property('id', doc="Unique identifier")
@@ -749,6 +764,8 @@ class Capabilities(IData):
     EXPORT_FS = 122
     EXPORT_REMOVE = 123
     EXPORT_CUSTOM_PATH = 124
+
+    SYS_FW_VERSION_GET = 160
 
     POOLS_QUICK_SEARCH = 210
     VOLUMES_QUICK_SEARCH = 211

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 
-# Copyright (C) 2013-2014 Red Hat, Inc.
+# Copyright (C) 2013-2015 Red Hat, Inc.
+# (C) Copyright 2015 Hewlett Packard Enterprise Development LP
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -13,6 +14,10 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; If not, see <http://www.gnu.org/licenses/>.
+#
+# Author:   tasleson
+#           Joe Handzik <joseph.t.handzik@hpe.com>
+#           Gris Ge <fge@redhat.com>
 
 import lsm
 import functools
@@ -305,6 +310,14 @@ class TestPlugin(unittest.TestCase):
         (desc, version) = self.c.plugin_info()
         self.assertTrue(desc is not None and len(desc) > 0)
         self.assertTrue(version is not None and len(version) > 0)
+
+    def test_fw_version_get(self):
+        for s in self.systems:
+            cap = self.c.capabilities(s)
+            if supported(cap, [Cap.SYS_FW_VERSION_GET]):
+                fw_ver = s.fw_version
+                self.assertTrue(fw_ver is not None and len(fw_ver) > 0,
+                                "Firmware version retrieval failed")
 
     def test_timeout(self):
         tmo = 40000

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) 2011-2014 Red Hat, Inc.
+# Copyright (C) 2011-2015 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -15,6 +15,7 @@
 # License along with this library; If not, see <http://www.gnu.org/licenses/>.
 #
 # Author: tasleson
+#         Gris Ge <fge@redhat.com>
 #
 # Unit test case driver
 
@@ -134,11 +135,11 @@ good "cp $shared_libs/*.so.* $LD_LIBRARY_PATH"
 # user account exists.
 good "cp -av $lsm_py_folder/lsm $PYTHONPATH/"
 # In case the plugin and lsmcli link also copyed.
-if [ -e "$PYTHONPATH/lsm/plugin" ];then
+if [ -e "$PYTHONPATH/lsm/plugin" ] || [ -L "$PYTHONPATH/lsm/plugin" ];then
     good "rm $PYTHONPATH/lsm/plugin"
 fi
 good "cp -av $lsm_plugin_py_folder $PYTHONPATH/lsm/"
-if [ -e "$PYTHONPATH/lsm/lsmcli" ];then
+if [ -e "$PYTHONPATH/lsm/lsmcli" ] || [ -L "$PYTHONPATH/lsm/lsmcli" ];then
     good "rm $PYTHONPATH/lsm/lsmcli"
 fi
 good "cp -av $lsmcli_py_folder $PYTHONPATH/lsm/"

--- a/test/tester.c
+++ b/test/tester.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011-2014 Red Hat, Inc.
+ * Copyright (C) 2011-2015 Red Hat, Inc.
+ * (C) Copyright 2015 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -14,6 +15,8 @@
  * License along with this library; If not, see <http://www.gnu.org/licenses/>.
  *
  * Author: tasleson
+ *         Joe Handzik <joseph.t.handzik@hpe.com>
+ *         Gris Ge <fge@redhat.com>
  */
 
 #include <stdio.h>
@@ -1960,6 +1963,35 @@ START_TEST(test_plugin_info)
 }
 END_TEST
 
+START_TEST(test_system_fw_version)
+{
+    const char *fw_ver = NULL;
+    int rc = 0;
+    lsm_system **sys = NULL;
+    uint32_t sys_count = 0;
+
+    G(rc, lsm_system_list, c, &sys, &sys_count, LSM_CLIENT_FLAG_RSVD);
+    fail_unless( sys_count >= 1, "count = %d", sys_count);
+
+    if(sys_count > 0) {
+
+        G(rc, lsm_system_fw_version_get, sys[0], &fw_ver);
+
+        if( LSM_ERR_OK == rc ) {
+            printf("Firmware version: (%s)\n", fw_ver);
+        }
+
+        rc = lsm_system_fw_version_get(sys[0], NULL);
+        fail_unless(LSM_ERR_INVALID_ARGUMENT == rc, "rc = %d", rc);
+    }
+
+    rc = lsm_system_fw_version_get(NULL, &fw_ver);
+    fail_unless(LSM_ERR_INVALID_ARGUMENT == rc, "rc = %d", rc);
+    lsm_system_record_array_free(sys, sys_count);
+
+}
+END_TEST
+
 START_TEST(test_get_available_plugins)
 {
     int i = 0;
@@ -3045,6 +3077,7 @@ Suite * lsm_suite(void)
     tcase_add_test(basic, test_nfs_export_funcs);
     tcase_add_test(basic, test_disks);
     tcase_add_test(basic, test_plugin_info);
+    tcase_add_test(basic, test_system_fw_version);
     tcase_add_test(basic, test_get_available_plugins);
     tcase_add_test(basic, test_volume_methods);
     tcase_add_test(basic, test_iscsi_auth_in);

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2014 Red Hat, Inc.
+# Copyright (C) 2012-2015 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -331,6 +331,7 @@ class DisplayData(object):
     SYSTEM_HEADER['name'] = 'Name'
     SYSTEM_HEADER['status'] = 'Status'
     SYSTEM_HEADER['status_info'] = 'Info'
+    SYSTEM_HEADER['fw_version'] = "FW Ver"
 
     SYSTEM_COLUMN_SKIP_KEYS = []
     # XXX_COLUMN_SKIP_KEYS contain a list of property should be skipped when
@@ -632,7 +633,14 @@ class DisplayData(object):
     @staticmethod
     def _get_man_pro_value(obj, key, value_conv_enum, value_conv_human,
                            flag_human, flag_enum):
-        value = getattr(obj, key)
+        try:
+            value = getattr(obj, key)
+        except LsmError as lsm_err:
+            if lsm_err.code == ErrorNumber.NO_SUPPORT:
+                value = ''
+            else:
+                raise lsm_err
+
         if not flag_enum:
             if key in value_conv_enum.keys():
                 value = value_conv_enum[key](value)


### PR DESCRIPTION
~~* Please don't commit for these reason, TODO list:
    * Tested on real hardware
    * Check memory leak or etc.
    * Split into small patches.
    * Update license lines.~~
 * Python part:
    * Add new optional argument for `System.__init__()`.
 * C part:
    * ~~Plugin: `lsm_system_record_alloc_v1_3()` with `fw_ver` string.~~
    * Plugin: `lsm_system_fw_version_set()`
    * Client: `lsm_system_fw_version_get()`

 * Misc:
    * Increase version in configure.ac to 1.3.
    * ~~Add empty struct for 1.3 C plugin interface -- `lsm_register_plugin_v1_3()`.~~
    * Fix runtest.sh compatible issue with lsmenv.
    * Included license of Joe@HP Enterprise.

Signed-off-by: Gris Ge <fge@redhat.com>