### PR TITLE
Fixes for MegaRAID disks.

### DIFF
--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -91,6 +91,7 @@ _DISK_STATE_MAP = {
     'UGood': Disk.STATUS_FREE | Disk.STATUS_OK,
     'UBad': Disk.STATUS_FREE | Disk.STATUS_ERROR,
     'Rbld': Disk.STATUS_RECONSTRUCT,
+    'JBOD': Disk.STATUS_OK,
 }
 
 

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -95,18 +95,16 @@ _DISK_STATE_MAP = {
 
 
 def _disk_status_of(disk_show_basic_dict, disk_show_stat_dict):
-    disk_status = _DISK_STATE_MAP.get(
-        disk_show_basic_dict['State'], 0)
+    disk_status = _DISK_STATE_MAP.get(disk_show_basic_dict['State'], 0)
 
     if disk_show_stat_dict['Media Error Count'] or \
        disk_show_stat_dict['Other Error Count'] or \
        disk_show_stat_dict['S.M.A.R.T alert flagged by drive'] != 'No':
-        disk_status -= Disk.STATUS_OK
-        disk_status |= Disk.STATUS_ERROR
+        disk_status = (disk_status & ~Disk.STATUS_OK) | Disk.STATUS_ERROR
 
     elif disk_show_stat_dict['Predictive Failure Count']:
-        disk_status -= Disk.STATUS_OK
-        disk_status |= Disk.STATUS_PREDICTIVE_FAILURE
+        disk_status = (disk_status & ~Disk.STATUS_OK) | \
+            Disk.STATUS_PREDICTIVE_FAILURE
 
     if disk_show_basic_dict['Sp'] == 'D':
         disk_status |= Disk.STATUS_STOPPED

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -99,7 +99,6 @@ def _disk_status_of(disk_show_basic_dict, disk_show_stat_dict):
     disk_status = _DISK_STATE_MAP.get(disk_show_basic_dict['State'], 0)
 
     if disk_show_stat_dict['Media Error Count'] or \
-       disk_show_stat_dict['Other Error Count'] or \
        disk_show_stat_dict['S.M.A.R.T alert flagged by drive'] != 'No':
         disk_status = (disk_status & ~Disk.STATUS_OK) | Disk.STATUS_ERROR
 


### PR DESCRIPTION
Three fixes for MegaRAID plugin on disk querying.
* Remove check on 'Other Error Count' which is not documented and incorrect on disk status.
* Fix incorrect disk status on JBOD disk.
* Fix incorrect disk status query.