### PR TITLE
Add volume-ident-led-* support for volumes

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt.h
@@ -1017,6 +1017,18 @@ int LSM_DLL_EXPORT lsm_volume_ident_led_set(lsm_connect *c,
                                             lsm_volume *volume,
                                             lsm_flag flags);
 
+/**
+ * Disable the IDENT LED for the desired volume.
+ * New in version 1.3, only available for hardware RAID cards.
+ * @param[in] c				Valid connection
+ * @param[in] volume			A single lsm_volume
+ * @param[in] flags			Reserved, set to 0
+ * @return LSM_ERR_OK on success else error reason.
+ */
+int LSM_DLL_EXPORT lsm_volume_ident_led_clear(lsm_connect *c,
+                                              lsm_volume *volume,
+                                              lsm_flag flags);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/c_binding/include/libstoragemgmt/libstoragemgmt.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt.h
@@ -1005,6 +1005,18 @@ int LSM_DLL_EXPORT lsm_volume_raid_create(lsm_connect *c,
                                           lsm_volume **new_volume,
                                           lsm_flag flags);
 
+/**
+ * Enable the IDENT LED for the desired volume.
+ * New in version 1.3, only available for hardware RAID cards.
+ * @param[in] c				Valid connection
+ * @param[in] volume			A single lsm_volume
+ * @param[in] flags			Reserved, set to 0
+ * @return LSM_ERR_OK on success else error reason.
+ */
+int LSM_DLL_EXPORT lsm_volume_ident_led_set(lsm_connect *c,
+                                            lsm_volume *volume,
+                                            lsm_flag flags);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
@@ -159,6 +159,8 @@ typedef enum {
     /**^ Plug-in allows user to retrieve storage firmware version */
     LSM_CAP_SYS_MODE_GET = 161,
     /**^ Plug-in allows user to retrieve storage mode*/
+    LSM_CAP_VOLUME_LED = 171,
+    /**^ Plugin allows user to set and clear volume LEDs */
     LSM_CAP_POOLS_QUICK_SEARCH = 210,
     /**^ Seach occurs on array */
     LSM_CAP_VOLUMES_QUICK_SEARCH = 211,

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
@@ -981,6 +981,18 @@ typedef int (*lsm_plug_volume_raid_create) (lsm_plugin_ptr c,
                                             lsm_volume ** new_volume,
                                             lsm_flag flags);
 
+/**
+ * Enable the IDENT LED for the desired volume.
+ * New in version 1.3, only available for hardware RAID cards.
+ * @param[in] c			Valid lsm plug-in pointer
+ * @param[in] volume		A single lsm_volume
+ * @param[in] flags         	Reserved, set to 0
+ * @return LSM_ERR_OK on success else error reason.
+ */
+typedef int (*lsm_plug_volume_ident_led_set) (lsm_plugin_ptr c,
+                                              lsm_volume * volume,
+                                              lsm_flag flags);
+
 /** \struct lsm_ops_v1_2
  * \brief Functions added in version 1.2
  */
@@ -990,6 +1002,15 @@ struct lsm_ops_v1_2 {
     lsm_plug_pool_member_info pool_member_info;
     lsm_plug_volume_raid_create_cap_get vol_create_raid_cap_get;
     lsm_plug_volume_raid_create vol_create_raid;
+};
+
+/** \struct lsm_ops_v1_3
+ * \brief Functions added in version 1.3
+ * NOTE: This structure will change during the developement util version 1.3
+ *       released.
+ */
+struct lsm_ops_v1_3 {
+    lsm_plug_volume_ident_led_set vol_ident_set;
 };
 
 /**
@@ -1053,6 +1074,28 @@ int LSM_DLL_EXPORT lsm_register_plugin_v1_2(lsm_plugin_ptr plug,
                                             struct lsm_fs_ops_v1 *fs_ops,
                                             struct lsm_nas_ops_v1 *nas_ops,
                                             struct lsm_ops_v1_2 *ops_v1_2);
+
+/**
+ * Used to register version 1.3 APIs plug-in operation.
+ * @param plug              Pointer provided by the framework
+ * @param private_data      Private data to be used for whatever the plug-in
+ *                          needs
+ * @param mgm_ops           Function pointers for struct lsm_mgmt_ops_v1
+ * @param san_ops           Function pointers for struct lsm_san_ops_v1
+ * @param fs_ops            Function pointers for struct lsm_fs_ops_v1
+ * @param nas_ops           Function pointers for struct lsm_nas_ops_v1
+ * @param ops_v1_2          Function pointers for struct lsm_ops_v1_2
+ * @param ops_v1_3          Function pointers for struct lsm_ops_v1_3
+ * @return LSM_ERR_OK on success, else error reason.
+ */
+int LSM_DLL_EXPORT lsm_register_plugin_v1_3(lsm_plugin_ptr plug,
+                                            void *private_data,
+                                            struct lsm_mgmt_ops_v1 *mgm_ops,
+                                            struct lsm_san_ops_v1 *san_ops,
+                                            struct lsm_fs_ops_v1 *fs_ops,
+                                            struct lsm_nas_ops_v1 *nas_ops,
+                                            struct lsm_ops_v1_2 *ops_v1_2,
+                                            struct lsm_ops_v1_3 *ops_v1_3);
 
 /**
  * Used to retrieve private data for plug-in operation.

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
@@ -993,6 +993,18 @@ typedef int (*lsm_plug_volume_ident_led_set) (lsm_plugin_ptr c,
                                               lsm_volume * volume,
                                               lsm_flag flags);
 
+/**
+ * Disable the IDENT LED for the desired volume.
+ * New in version 1.3, only available for hardware RAID cards.
+ * @param[in] c			Valid lsm plug-in pointer
+ * @param[in] volume		A single lsm_volume
+ * @param[in] flags         	Reserved, set to 0
+ * @return LSM_ERR_OK on success else error reason.
+ */
+typedef int (*lsm_plug_volume_ident_led_clear) (lsm_plugin_ptr c,
+                                                lsm_volume * volume,
+                                                lsm_flag flags);
+
 /** \struct lsm_ops_v1_2
  * \brief Functions added in version 1.2
  */
@@ -1011,6 +1023,7 @@ struct lsm_ops_v1_2 {
  */
 struct lsm_ops_v1_3 {
     lsm_plug_volume_ident_led_set vol_ident_set;
+    lsm_plug_volume_ident_led_clear vol_ident_clear;
 };
 
 /**

--- a/c_binding/lsm_datatypes.hpp
+++ b/c_binding/lsm_datatypes.hpp
@@ -193,6 +193,7 @@ struct LSM_DLL_LOCAL _lsm_plugin {
     struct lsm_nas_ops_v1 *nas_ops;    /**< Callbacks for NAS ops */
     struct lsm_fs_ops_v1 *fs_ops;      /**< Callbacks for fs ops */
     struct lsm_ops_v1_2 *ops_v1_2;     /**< Callbacks for v1.2 ops */
+    struct lsm_ops_v1_3 *ops_v1_3;     /**< Callbacks for v1.3 ops */
 };
 
 

--- a/c_binding/lsm_mgmt.cpp
+++ b/c_binding/lsm_mgmt.cpp
@@ -2558,3 +2558,20 @@ int lsm_volume_raid_create(lsm_connect * c, const char *name,
     }
     return rc;
 }
+
+int lsm_volume_ident_led_set(lsm_connect * c, lsm_volume * volume,
+                             lsm_flag flags)
+{
+    CONN_SETUP(c);
+
+    std::map < std::string, Value > p;
+    p["flags"] = Value(flags);
+    p["volume"] = volume_to_value(volume);
+
+    Value parameters(p);
+    Value response;
+
+    int rc = rpc(c, "volume_ident_led_set", parameters, response);
+
+    return rc;
+}

--- a/c_binding/lsm_mgmt.cpp
+++ b/c_binding/lsm_mgmt.cpp
@@ -2575,3 +2575,20 @@ int lsm_volume_ident_led_set(lsm_connect * c, lsm_volume * volume,
 
     return rc;
 }
+
+int lsm_volume_ident_led_clear(lsm_connect * c, lsm_volume * volume,
+                               lsm_flag flags)
+{
+    CONN_SETUP(c);
+
+    std::map < std::string, Value > p;
+    p["flags"] = Value(flags);
+    p["volume"] = volume_to_value(volume);
+
+    Value parameters(p);
+    Value response;
+
+    int rc = rpc(c, "volume_ident_led_clear", parameters, response);
+
+    return rc;
+}

--- a/c_binding/lsm_plugin_ipc.cpp
+++ b/c_binding/lsm_plugin_ipc.cpp
@@ -2385,6 +2385,30 @@ static int handle_volume_ident_led_set(lsm_plugin_ptr p, Value & params,
     return rc;
 }
 
+static int handle_volume_ident_led_clear(lsm_plugin_ptr p, Value & params,
+                                         Value & response)
+{
+    int rc = LSM_ERR_NO_SUPPORT;
+    if (p && p->ops_v1_3 && p->ops_v1_3->vol_ident_clear) {
+        Value v_vol = params["volume"];
+
+        if (Value::object_t == v_vol.valueType() &&
+            LSM_FLAG_EXPECTED_TYPE(params)) {
+
+            lsm_volume *volume = value_to_volume(v_vol);
+
+            rc = p->ops_v1_3->vol_ident_clear(p, volume,
+                                              LSM_FLAG_GET_VALUE(params));
+
+            lsm_volume_record_free(volume);
+
+        } else {
+            rc = LSM_ERR_TRANSPORT_INVALID_ARG;
+        }
+    }
+    return rc;
+}
+
 /**
  * map of function pointers
  */
@@ -2444,7 +2468,8 @@ static std::map < std::string, handler > dispatch =
     ("pool_member_info", handle_pool_member_info)
     ("volume_raid_create", handle_volume_raid_create)
     ("volume_raid_create_cap_get", handle_volume_raid_create_cap_get)
-    ("volume_ident_led_set", handle_volume_ident_led_set);
+    ("volume_ident_led_set", handle_volume_ident_led_set)
+    ("volume_ident_led_clear", handle_volume_ident_led_clear);
 
 static int process_request(lsm_plugin_ptr p, const std::string & method,
                            Value & request, Value & response)

--- a/doc/man/lsmcli.1.in
+++ b/doc/man/lsmcli.1.in
@@ -260,6 +260,12 @@ card.
 \fB--sys\fR \fI<SYS_ID>\fR
 Required. ID of the system to query for capabilities.
 
+.SS volume-ident-led-set
+Enable the IDENT LEDs for all physical disks that compose a logical volume.
+.TP 15
+\fB--vol\fR \fI<VOL_ID>\fR
+Required. ID of the volume being targeted.
+
 .SS volume-delete
 .TP 15
 Delete a volume given its ID
@@ -618,6 +624,8 @@ Alias of 'volume-create'
 Alias of 'volume-raid-create'
 .SS vrcc
 Alias of 'volume-raid-create-cap'
+.SS vils
+Alias of 'volume-ident-led-set'
 .SS vd
 Alias of 'volume-delete'
 .SS vr

--- a/doc/man/lsmcli.1.in
+++ b/doc/man/lsmcli.1.in
@@ -266,6 +266,12 @@ Enable the IDENT LEDs for all physical disks that compose a logical volume.
 \fB--vol\fR \fI<VOL_ID>\fR
 Required. ID of the volume being targeted.
 
+.SS volume-ident-led-clear
+Disable the IDENT LEDs for all physical disks that compose a logical volume.
+.TP 15
+\fB--vol\fR \fI<VOL_ID>\fR
+Required. ID of the volume being targeted.
+
 .SS volume-delete
 .TP 15
 Delete a volume given its ID
@@ -626,6 +632,8 @@ Alias of 'volume-raid-create'
 Alias of 'volume-raid-create-cap'
 .SS vils
 Alias of 'volume-ident-led-set'
+.SS vilc
+Alias of 'volume-ident-led-clear'
 .SS vd
 Alias of 'volume-delete'
 .SS vr

--- a/plugin/sim/simarray.py
+++ b/plugin/sim/simarray.py
@@ -2374,3 +2374,13 @@ class SimArray(object):
         sim_vol = self.bs_obj.sim_vol_of_id(sim_vol_id)
         self.bs_obj.trans_commit()
         return SimArray._sim_vol_2_lsm(sim_vol)
+
+    @_handle_errors
+    def volume_ident_led_set(self, volume, flags=0):
+        sim_volume_id = SimArray._lsm_id_to_sim_id(
+                            volume.id, LsmError(
+                                           ErrorNumber.NOT_FOUND_VOLUME,
+                                           "Volume not found"))
+        sim_vol = self.bs_obj.sim_vol_of_id(sim_volume_id)
+
+        return None

--- a/plugin/sim/simarray.py
+++ b/plugin/sim/simarray.py
@@ -2384,3 +2384,13 @@ class SimArray(object):
         sim_vol = self.bs_obj.sim_vol_of_id(sim_volume_id)
 
         return None
+
+    @_handle_errors
+    def volume_ident_led_clear(self, volume, flags=0):
+        sim_volume_id = SimArray._lsm_id_to_sim_id(
+                            volume.id, LsmError(
+                                           ErrorNumber.NOT_FOUND_VOLUME,
+                                           "Volume not found"))
+        sim_vol = self.bs_obj.sim_vol_of_id(sim_volume_id)
+
+        return None

--- a/plugin/sim/simulator.py
+++ b/plugin/sim/simulator.py
@@ -305,3 +305,6 @@ class SimPlugin(INfs, IStorageAreaNetwork):
 
     def volume_ident_led_set(self, volume, flags=0):
         return self.sim_array.volume_ident_led_set(volume)
+
+    def volume_ident_led_clear(self, volume, flags=0):
+        return self.sim_array.volume_ident_led_clear(volume)

--- a/plugin/sim/simulator.py
+++ b/plugin/sim/simulator.py
@@ -302,3 +302,6 @@ class SimPlugin(INfs, IStorageAreaNetwork):
                            flags=0):
         return self.sim_array.volume_raid_create(
             name, raid_type, disks, strip_size)
+
+    def volume_ident_led_set(self, volume, flags=0):
+        return self.sim_array.volume_ident_led_set(volume)

--- a/plugin/simc/simc_lsmplugin.c
+++ b/plugin/simc/simc_lsmplugin.c
@@ -395,6 +395,7 @@ static int cap(lsm_plugin_ptr c, lsm_system * system,
                                   LSM_CAP_EXPORT_FS,
                                   LSM_CAP_EXPORT_REMOVE,
                                   LSM_CAP_VOLUME_RAID_INFO,
+                                  LSM_CAP_VOLUME_LED,
                                   LSM_CAP_POOL_MEMBER_INFO, -1);
 
         if (LSM_ERR_OK != rc) {
@@ -1042,11 +1043,21 @@ static int volume_raid_create(lsm_plugin_ptr c, const char *name,
     return LSM_ERR_NO_SUPPORT;
 }
 
+static int volume_ident_led_set(lsm_plugin_ptr c, lsm_volume * volume,
+                                lsm_flag flags)
+{
+    return LSM_ERR_OK;
+}
+
 static struct lsm_ops_v1_2 ops_v1_2 = {
     volume_raid_info,
     pool_member_info,
     volume_raid_create_cap_get,
     volume_raid_create,
+};
+
+static struct lsm_ops_v1_3 ops_v1_3 = {
+    volume_ident_led_set,
 };
 
 static int volume_enable_disable(lsm_plugin_ptr c, lsm_volume * v,
@@ -2379,8 +2390,9 @@ int load(lsm_plugin_ptr c, const char *uri, const char *password,
             _unload(pd);
             pd = NULL;
         } else {
-            rc = lsm_register_plugin_v1_2(c, pd, &mgm_ops, &san_ops,
-                                          &fs_ops, &nfs_ops, &ops_v1_2);
+            rc = lsm_register_plugin_v1_3(c, pd, &mgm_ops, &san_ops,
+                                          &fs_ops, &nfs_ops, &ops_v1_2,
+                                          &ops_v1_3);
         }
     }
     return rc;

--- a/plugin/simc/simc_lsmplugin.c
+++ b/plugin/simc/simc_lsmplugin.c
@@ -1049,6 +1049,12 @@ static int volume_ident_led_set(lsm_plugin_ptr c, lsm_volume * volume,
     return LSM_ERR_OK;
 }
 
+static int volume_ident_led_clear(lsm_plugin_ptr c, lsm_volume * volume,
+                                  lsm_flag flags)
+{
+    return LSM_ERR_OK;
+}
+
 static struct lsm_ops_v1_2 ops_v1_2 = {
     volume_raid_info,
     pool_member_info,
@@ -1058,6 +1064,7 @@ static struct lsm_ops_v1_2 ops_v1_2 = {
 
 static struct lsm_ops_v1_3 ops_v1_3 = {
     volume_ident_led_set,
+    volume_ident_led_clear,
 };
 
 static int volume_enable_disable(lsm_plugin_ptr c, lsm_volume * v,

--- a/python_binding/lsm/_client.py
+++ b/python_binding/lsm/_client.py
@@ -1373,3 +1373,30 @@ class Client(INetworkAttachedStorage):
                     "RAID 60 require even disks count and 8 or more disks")
 
         return self._tp.rpc('volume_raid_create', _del_self(locals()))
+
+    ## Set the IDENT LED for a volume.
+    # @param    self            The this pointer
+    # @param    volume          Volume object to target
+    # @param    flags           Flags
+    # @returns None on success, else raises LsmError
+    @_return_requires(None)
+    def volume_ident_led_set(self, volume, flags=FLAG_RSVD):
+        """
+        lsm.Client.volume_ident_led_set(self, volume,
+                                        flags=lsm.Client.FLAG_RSVD)
+
+        Version:
+            1.3
+        Usage:
+            This method enables the IDENT LED on a volume if supported
+        Parameters:
+            disk (lsm.Volume)
+                An lsm.Volume object.
+            flags (int)
+                Optional. Reserved for future use.
+                Should be set as lsm.Client.FLAG_RSVD.
+        Returns:
+            returns None on success, else raises LsmError on errors.
+        SpecialExceptions:
+        """
+        return self._tp.rpc('volume_ident_led_set', _del_self(locals()))

--- a/python_binding/lsm/_client.py
+++ b/python_binding/lsm/_client.py
@@ -1400,3 +1400,30 @@ class Client(INetworkAttachedStorage):
         SpecialExceptions:
         """
         return self._tp.rpc('volume_ident_led_set', _del_self(locals()))
+
+    ## Clear the IDENT LED for a volume.
+    # @param    self            The this pointer
+    # @param    volume          Volume object to target
+    # @param    flags           Flags
+    # @returns None on success, else raises LsmError
+    @_return_requires(None)
+    def volume_ident_led_clear(self, volume, flags=FLAG_RSVD):
+        """
+        lsm.Client.volume_ident_led_clear(self, volume,
+                                          flags=lsm.Client.FLAG_RSVD)
+
+        Version:
+            1.3
+        Usage:
+            This method disables the IDENT LED on a volume if supported
+        Parameters:
+            disk (lsm.Volume)
+                An lsm.Volume object.
+            flags (int)
+                Optional. Reserved for future use.
+                Should be set as lsm.Client.FLAG_RSVD.
+        Returns:
+            returns None on success, else raises LsmError on errors.
+        SpecialExceptions:
+        """
+        return self._tp.rpc('volume_ident_led_clear', _del_self(locals()))

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -796,6 +796,7 @@ class Capabilities(IData):
 
     SYS_FW_VERSION_GET = 160
     SYS_MODE_GET = 161
+    VOLUME_LED = 171
 
     POOLS_QUICK_SEARCH = 210
     VOLUMES_QUICK_SEARCH = 211

--- a/test/cmdtest.py
+++ b/test/cmdtest.py
@@ -787,6 +787,18 @@ def volume_ident_led_set_test(cap):
     return
 
 
+def volume_ident_led_clear_test(cap):
+    if cap['VOLUME_LED']:
+        out = call([cmd, '-t' + sep, 'list', '--type', 'volumes'])[1]
+        volume_list = parse(out)
+        for volume in volume_list:
+            out = call([
+                cmd, '-t' + sep, 'volume-ident-led-clear', '--volume',
+                volume[0]])[1]
+
+    return
+
+
 def run_all_tests(cap, system_id):
 
     test_exit_code(cap, system_id)

--- a/test/cmdtest.py
+++ b/test/cmdtest.py
@@ -776,6 +776,17 @@ def volume_raid_create_test(cap, system_id):
     return
 
 
+def volume_ident_led_set_test(cap):
+    if cap['VOLUME_LED']:
+        out = call([cmd, '-t' + sep, 'list', '--type', 'volumes'])[1]
+        volume_list = parse(out)
+        for volume in volume_list:
+            out = call([
+                cmd, '-t' + sep, 'volume-ident-led-set', '--volume', volume[0]])[1]
+
+    return
+
+
 def run_all_tests(cap, system_id):
 
     test_exit_code(cap, system_id)

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -1423,6 +1423,16 @@ class TestPlugin(unittest.TestCase):
                 raise
 
 
+    def test_volume_ident_led_set(self):
+        for s in self.systems:
+            cap = self.c.capabilities(s)
+            if supported(cap, [Cap.VOLUME_LED]):
+                for volume in self.c.volumes():
+                    volume_led_status = self.c.volume_ident_led_set(volume)
+                    self.assertTrue(volume_led_status is None,
+                                    "Volume ident_led_set"
+                                    "failed")
+
 def dump_results():
     """
     unittest.main exits when done so we need to register this handler to

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -1433,6 +1433,16 @@ class TestPlugin(unittest.TestCase):
                                     "Volume ident_led_set"
                                     "failed")
 
+    def test_volume_ident_led_clear(self):
+        for s in self.systems:
+            cap = self.c.capabilities(s)
+            if supported(cap, [Cap.VOLUME_LED]):
+                for volume in self.c.volumes():
+                    volume_led_status = self.c.volume_ident_led_clear(volume)
+                    self.assertTrue(volume_led_status is None,
+                                    "Volume ident_led_clear"
+                                    "failed")
+
 def dump_results():
     """
     unittest.main exits when done so we need to register this handler to

--- a/test/tester.c
+++ b/test/tester.c
@@ -3083,6 +3083,33 @@ START_TEST(test_volume_raid_create)
 }
 END_TEST
 
+START_TEST(test_volume_ident_led_set)
+{
+    lsm_volume *volume = NULL;
+    char *job = NULL;
+    lsm_pool *pool = get_test_pool(c);
+
+    int rc = lsm_volume_create(
+        c, pool, "volume_raid_info_test", 20000000,
+        LSM_VOLUME_PROVISION_DEFAULT, &volume, &job, LSM_CLIENT_FLAG_RSVD);
+
+    fail_unless( rc == LSM_ERR_OK || rc == LSM_ERR_JOB_STARTED,
+            "lsmVolumeCreate %d (%s)", rc, error(lsm_error_last_get(c)));
+
+    if( LSM_ERR_JOB_STARTED == rc ) {
+        volume = wait_for_job_vol(c, &job);
+    }
+
+    G(rc, lsm_volume_ident_led_set, c, volume, LSM_CLIENT_FLAG_RSVD);
+
+    if (LSM_ERR_OK == rc)
+        printf("Volume IDENT LED set\n");
+
+    G(rc, lsm_volume_record_free, volume);
+    G(rc, lsm_pool_record_free, pool);
+}
+END_TEST
+
 Suite * lsm_suite(void)
 {
     Suite *s = suite_create("libStorageMgmt");
@@ -3124,6 +3151,7 @@ Suite * lsm_suite(void)
     tcase_add_test(basic, test_pool_member_info);
     tcase_add_test(basic, test_volume_raid_create_cap_get);
     tcase_add_test(basic, test_volume_raid_create);
+    tcase_add_test(basic, test_volume_ident_led_set);
 
     suite_add_tcase(s, basic);
     return s;

--- a/test/tester.c
+++ b/test/tester.c
@@ -3110,6 +3110,33 @@ START_TEST(test_volume_ident_led_set)
 }
 END_TEST
 
+START_TEST(test_volume_ident_led_clear)
+{
+    lsm_volume *volume = NULL;
+    char *job = NULL;
+    lsm_pool *pool = get_test_pool(c);
+
+    int rc = lsm_volume_create(
+        c, pool, "volume_raid_info_test", 20000000,
+        LSM_VOLUME_PROVISION_DEFAULT, &volume, &job, LSM_CLIENT_FLAG_RSVD);
+
+    fail_unless( rc == LSM_ERR_OK || rc == LSM_ERR_JOB_STARTED,
+            "lsmVolumeCreate %d (%s)", rc, error(lsm_error_last_get(c)));
+
+    if( LSM_ERR_JOB_STARTED == rc ) {
+        volume = wait_for_job_vol(c, &job);
+    }
+
+    G(rc, lsm_volume_ident_led_clear, c, volume, LSM_CLIENT_FLAG_RSVD);
+
+    if (LSM_ERR_OK == rc)
+        printf("Volume IDENT LED clear\n");
+
+    G(rc, lsm_volume_record_free, volume);
+    G(rc, lsm_pool_record_free, pool);
+}
+END_TEST
+
 Suite * lsm_suite(void)
 {
     Suite *s = suite_create("libStorageMgmt");
@@ -3152,6 +3179,7 @@ Suite * lsm_suite(void)
     tcase_add_test(basic, test_volume_raid_create_cap_get);
     tcase_add_test(basic, test_volume_raid_create);
     tcase_add_test(basic, test_volume_ident_led_set);
+    tcase_add_test(basic, test_volume_ident_led_clear);
 
     suite_add_tcase(s, basic);
     return s;

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -412,6 +412,15 @@ cmds = (
     ),
 
     dict(
+        name='volume-ident-led-set',
+        help='Enable the IDENT LED for a volume',
+        args=[
+            dict(name="--vol", metavar='<VOL_ID>',
+                 help='Targeted volume.\n'),
+        ],
+    ),
+
+    dict(
         name='pool-member-info',
         help='Query Pool membership infomation',
         args=[
@@ -683,6 +692,7 @@ aliases = (
     ['ar', 'access-group-remove'],
     ['ad', 'access-group-delete'],
     ['vri', 'volume-raid-info'],
+    ['vils', 'volume-ident-led-set'],
     ['pmi', 'pool-member-info'],
 )
 
@@ -1420,6 +1430,11 @@ class CmdLine:
         lsm_sys = _get_item(self.c.systems(), args.sys, "System")
         self.display_data([
             VcrCap(lsm_sys.id, *self.c.volume_raid_create_cap_get(lsm_sys))])
+
+    def volume_ident_led_set(self, args):
+        lsm_volume = _get_item(self.c.volumes(), args.vol, "Volume")
+
+        self.c.volume_ident_led_set(lsm_volume)
 
     ## Displays file system dependants
     def fs_dependants(self, args):

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -421,6 +421,15 @@ cmds = (
     ),
 
     dict(
+        name='volume-ident-led-clear',
+        help='Disable the IDENT LED for a volume',
+        args=[
+            dict(name="--vol", metavar='<VOL_ID>',
+                 help='Targeted volume.\n'),
+        ],
+    ),
+
+    dict(
         name='pool-member-info',
         help='Query Pool membership infomation',
         args=[
@@ -693,6 +702,7 @@ aliases = (
     ['ad', 'access-group-delete'],
     ['vri', 'volume-raid-info'],
     ['vils', 'volume-ident-led-set'],
+    ['vilc', 'volume-ident-led-clear'],
     ['pmi', 'pool-member-info'],
 )
 
@@ -1435,6 +1445,11 @@ class CmdLine:
         lsm_volume = _get_item(self.c.volumes(), args.vol, "Volume")
 
         self.c.volume_ident_led_set(lsm_volume)
+
+    def volume_ident_led_clear(self, args):
+        lsm_volume = _get_item(self.c.volumes(), args.vol, "Volume")
+
+        self.c.volume_ident_led_clear(lsm_volume)
 
     ## Displays file system dependants
     def fs_dependants(self, args):


### PR DESCRIPTION
Hopefully this one is less controversial. These two patches allow you to enable and disable LEDs behind logical volumes on a Smart Array (and I assume other controllers, but I don't know the other plugins well enough to implement for them). Take a look lemme know what you think.