### PR TITLE
[PATCH V9] New function for SCSI disk path matching.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ addons:
         - python-m2crypto 
         - libssl-dev 
         - libconfig-dev
+        - libudev-dev
+        - python-dev
 
 compiler: gcc
 

--- a/c_binding/Makefile.am
+++ b/c_binding/Makefile.am
@@ -3,13 +3,15 @@ SUBDIRS = include
 AM_CPPFLAGS = 	-I$(top_srcdir)/c_binding/include \
 				-I$(top_builddir)/c_binding/include \
 				-I@srcdir@/c_binding/include \
-				$(LIBXML_CFLAGS) $(LIBGLIB_CFLAGS)
+				$(LIBXML_CFLAGS) $(LIBGLIB_CFLAGS) \
+				$(LIBUDEV_CFLAGS)
 
 lib_LTLIBRARIES = libstoragemgmt.la
 
-libstoragemgmt_la_LIBADD=$(LIBXML_LIBS) $(YAJL_LIBS) $(LIBGLIB_LIBS)
+libstoragemgmt_la_LIBADD=$(LIBXML_LIBS) $(YAJL_LIBS) $(LIBGLIB_LIBS) \
+			 $(LIBUDEV_LIBS)
 libstoragemgmt_la_LDFLAGS= -version-info $(LIBSM_LIBTOOL_VERSION)
 libstoragemgmt_la_SOURCES= \
 	lsm_mgmt.cpp lsm_datatypes.hpp lsm_datatypes.cpp lsm_convert.hpp \
 	lsm_convert.cpp lsm_ipc.hpp lsm_ipc.cpp lsm_plugin_ipc.hpp \
-	lsm_plugin_ipc.cpp util/qparams.c util/qparams.h
+	lsm_plugin_ipc.cpp util/qparams.c util/qparams.h lsm_scsi.c

--- a/c_binding/include/libstoragemgmt/Makefile.am
+++ b/c_binding/include/libstoragemgmt/Makefile.am
@@ -23,6 +23,7 @@ lsminc_HEADERS =			\
    libstoragemgmt_targetport.h          \
    libstoragemgmt_types.h		\
    libstoragemgmt_version.h             \
+   libstoragemgmt_scsi.h		\
    libstoragemgmt_volumes.h
 
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt.h
@@ -34,6 +34,7 @@
 #include "libstoragemgmt_systems.h"
 #include "libstoragemgmt_targetport.h"
 #include "libstoragemgmt_volumes.h"
+#include "libstoragemgmt_scsi.h"
 
 
 /*! \mainpage libStorageMgmt

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_scsi.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_scsi.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ *
+ */
+
+#ifndef LIBSTORAGEMGMT_SCSI_H
+#define LIBSTORAGEMGMT_SCSI_H
+
+#include "libstoragemgmt_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Find out the scsi disk paths of given SCSI VPD page 0x83 NAA ID.
+ * New in version 1.3.
+ * @param[in] vpd83 String. The VPD83 ID retrieved from LSM volume or disk.
+ *                  for supported strip sizes.
+ * @param[out] sd_path_list
+ *                  Output pointer of lsm_string_list. The format of scsi
+ *                  disk path will be "/dev/sd[a-z]+".
+ *                  NULL if no found or got error.
+ *                  Memory should be freed by lsm_string_list_free().
+ * @param[out] lsm_err
+ *                  Output pointer of lsm_error. Error message could be
+ *                  retrieved via lsm_error_message_get(). Memory should be
+ *                  freed by lsm_error_free().
+ * @return LSM_ERR_OK                   on success.
+ *         LSM_ERR_INVALID_ARGUMENT     when any argument is NULL.
+ *         LSM_ERR_NO_MEMORY            when no memory.
+ *         LSM_ERR_LIB_BUG              when something unexpected happens.
+ */
+int LSM_DLL_EXPORT lsm_scsi_disk_paths_of_vpd83(const char *vpd83,
+                                                lsm_string_list **sd_path_list,
+                                                lsm_error **lsm_err);
+
+#ifdef __cplusplus
+}
+#endif
+#endif                          /* LIBSTORAGEMGMT_SCSI_H */

--- a/c_binding/lsm_scsi.c
+++ b/c_binding/lsm_scsi.c
@@ -1,0 +1,548 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <libudev.h>
+#include <stdbool.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdarg.h>
+
+#include "libstoragemgmt/libstoragemgmt.h"
+#include "libstoragemgmt/libstoragemgmt_error.h"
+#include "libstoragemgmt/libstoragemgmt_plug_interface.h"
+
+#define _MAX_VPD83_PAGE_LEN 0xff + 4
+#define _MAX_VPD83_NAA_ID_LEN 33
+/* Max one is 6h IEEE Registered Extended ID which it 32 bits hex string.
+ */
+#define _SYS_BLOCK_PATH "/sys/block"
+#define _MAX_SD_NAME_STR_LEN 128
+/* The linux kernel support INT_MAX(2147483647) scsi disks at most which will
+ * be named as sd[a-z]{1,7}, the 7 here means `math.log(2147483647, 26) + 1`.
+ * Hence, 128 bits might be enough for a quit a while.
+ */
+
+#define _SD_PATH_FORMAT "/dev/%s"
+#define _MAX_SD_PATH_STR_LEN 128 + _MAX_SD_NAME_STR_LEN
+
+#define _SYSFS_VPD83_PATH_FORMAT "/sys/block/%s/device/vpd_pg83"
+#define _MAX_SYSFS_VPD83_PATH_STR_LEN  128 + _MAX_SD_NAME_STR_LEN
+
+#define _SYSFS_BLK_PATH_FORMAT "/sys/block/%s"
+#define _MAX_SYSFS_BLK_PATH_STR_LEN 128 + _MAX_SD_NAME_STR_LEN
+
+#define _T10_VPD83_NAA_235_ID_LEN 8
+#define _T10_VPD83_NAA_6_ID_LEN 16
+#define _T10_VPD83_PAGE_CODE 0x83
+#define _T10_VPD83_DESIGNATOR_TYPE_NAA 0x3
+#define _T10_VPD83_NAA_TYPE_2 0x2
+#define _T10_VPD83_NAA_TYPE_3 0x3
+#define _T10_VPD83_NAA_TYPE_5 0x5
+#define _T10_VPD83_NAA_TYPE_6 0x6
+
+#define _LSM_ERR_MSG_LEN 255
+
+#pragma pack(1)
+/*
+ * Table 589 — Device Identification VPD page
+ */
+struct t10_vpd83_header {
+    uint8_t dev_type : 5;
+    /* ^ PERIPHERAL DEVICE TYPE */
+    uint8_t qualifier : 3;
+    /* PERIPHERAL QUALIFIER */
+    uint8_t page_code;
+    uint8_t page_len_msb;
+    uint8_t page_len_lsb;
+};
+
+/*
+ * Table 590 — Designation descriptor
+ */
+struct t10_vpd83_id_header {
+    uint8_t code_set        : 4;
+    uint8_t protocol_id     : 4;
+    uint8_t designator_type : 4;
+    uint8_t association     : 2;
+    uint8_t reserved_1      : 1;
+    uint8_t piv             : 1;
+    uint8_t reserved_2;
+    uint8_t len;
+};
+
+struct t10_vpd83_naa_header {
+    uint8_t data_msb : 4;
+    uint8_t naa_type : 4;
+};
+
+#pragma pack()
+
+#define _lsm_err_msg_clear(err_msg) memset(err_msg, 0, _LSM_ERR_MSG_LEN)
+
+#define _lsm_err_msg_set(err_msg, format, ...) \
+    snprintf(err_msg, _LSM_ERR_MSG_LEN, format, ##__VA_ARGS__)
+
+#define _lsm_string_list_foreach(l, i, d) \
+    for(i = 0; \
+        (l != NULL) && (i < lsm_string_list_size(l)) && \
+        (d = lsm_string_list_elem_get(l, i)); \
+        ++i)
+
+/*
+ * All the 'err_msg' used in these static functions are expected to be
+ * pointer of char[_LSM_ERR_MSG_LEN].
+ */
+static void _be_raw_to_hex(uint8_t *raw, size_t len, char *out);
+static int _sysfs_read_file(char *err_msg, const char *sys_fs_path,
+                            uint8_t *buff, ssize_t *size, size_t max_size);
+static int _sysfs_vpd83_naa_of_sd_name(char *err_msg, const char *sd_name,
+                                       char *vpd83);
+static int _udev_vpd83_of_sd_name(char *err_msg, const char *sd_name,
+                                  char *vpd83);
+static int _sysfs_get_all_sd_names(char *err_msg,
+                                   lsm_string_list **sd_name_list);
+static int _check_null_ptr(char *err_msg, int arg_count, ...);
+static bool _file_is_exist(char *err_msg, const char *path);
+
+/*
+ * Assume input path is not NULL or empty string.
+ * Try to open provided path file or folder, return true if file could be open,
+ * or false.
+ */
+static bool _file_is_exist(char *err_msg, const char *path)
+{
+    int fd = 0;
+
+    fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        _lsm_err_msg_set(err_msg, "Failed to open %s, error: %d, %s",
+                         path, errno, strerror(errno));
+        return false;
+    }
+    close(fd);
+    return true;
+}
+
+/*
+ * Check whether input pointer is NULL.
+ * If found NULL pointer, set error message and return LSM_ERR_INVALID_ARGUMENT.
+ * Return LSM_ERR_OK if no NULL pointer.
+ */
+static int _check_null_ptr(char *err_msg, int arg_count, ...)
+{
+    int rc = LSM_ERR_OK;
+    va_list arg;
+    int i = 0;
+    void *ptr = NULL;
+
+    va_start(arg, arg_count);
+
+    for (; i < arg_count; ++i) {
+        ptr = va_arg(arg, void*);
+        if (ptr == NULL) {
+            _lsm_err_msg_set(err_msg, "Got NULL pointer in arguments");
+            rc = LSM_ERR_INVALID_ARGUMENT;
+            goto out;
+        }
+    }
+
+ out:
+    va_end(arg);
+    return rc;
+}
+
+/*
+ * Input big-endian uint8_t array, output has hex string.
+ * No check on output memory size or boundary, make sure before invoke.
+ */
+static void _be_raw_to_hex(uint8_t *raw, size_t len, char *out)
+{
+    size_t i = 0;
+
+    for (; i < len; ++i) {
+        snprintf(out + (i * 2), 3, "%02x", raw[i]);
+    }
+    out[len * 2] = 0;
+
+}
+
+static int _sysfs_read_file(char *err_msg, const char *sys_fs_path,
+                            uint8_t *buff, ssize_t *size, size_t max_size)
+{
+    int fd = -1;
+
+    *size = 0;
+    memset(buff, 0, max_size);
+
+    fd = open(sys_fs_path, O_RDONLY);
+    if (fd < 0) {
+        if (errno == ENOENT)
+            return LSM_ERR_NO_SUPPORT;
+
+        _lsm_err_msg_set(err_msg, "_sysfs_read_file(): Failed to open %s, "
+                         "error: %d, %s", sys_fs_path, errno, strerror(errno));
+        return LSM_ERR_LIB_BUG;
+    }
+    *size = read(fd, buff, max_size);
+    close(fd);
+
+    if (*size < 0) {
+        _lsm_err_msg_set(err_msg, "Failed to read %s, error: %d, %s",
+                         sys_fs_path, errno, strerror(errno));
+        return LSM_ERR_LIB_BUG;
+    }
+    return LSM_ERR_OK;
+}
+
+/*
+ * Parse _SYSFS_VPD83_PATH_FORMAT file for VPD83 NAA ID.
+ * When no such sysfs file found, return LSM_ERR_NO_SUPPORT.
+ * When VPD83 page does not have NAA ID, return LSM_ERR_OK and vpd83 as empty
+ * string.
+ *
+ * Input *vpd83 should be char[_MAX_VPD83_NAA_ID_LEN], assuming caller did
+ * the check.
+ * The maximum *sd_name strlen is (_MAX_SD_NAME_STR_LEN - 1), assuming caller
+ * did the check.
+ * Return LSM_ERR_NO_MEMORY or LSM_ERR_NO_SUPPORT or LSM_ERR_LIB_BUG or
+ *        LSM_ERR_NOT_FOUND_DISK
+ */
+static int _sysfs_vpd83_naa_of_sd_name(char *err_msg, const char *sd_name,
+                                       char *vpd83)
+{
+    ssize_t read_size = 0;
+    uint8_t *end_p = NULL;
+    uint8_t *p = NULL;
+    struct t10_vpd83_header *vpd83_header = NULL;
+    uint32_t vpd83_len = 0;
+    struct t10_vpd83_id_header *id_header = NULL;
+    struct t10_vpd83_naa_header *naa_header = NULL;
+    int rc = LSM_ERR_OK;
+    uint8_t buff[_MAX_VPD83_PAGE_LEN];
+    char sysfs_path[_MAX_SYSFS_VPD83_PATH_STR_LEN];
+    char sysfs_blk_path[_MAX_SYSFS_BLK_PATH_STR_LEN];
+
+    memset(vpd83, 0, _MAX_VPD83_NAA_ID_LEN);
+
+    if (sd_name == NULL) {
+        _lsm_err_msg_set(err_msg, "_sysfs_vpd83_naa_of_sd_name(): "
+                         "Input sd_name argument is NULL");
+        rc = LSM_ERR_LIB_BUG;
+        goto out;
+    }
+
+    /*
+     * Check the existence of disk vis /sys/block/sdX folder.
+     */
+    snprintf(sysfs_blk_path, _MAX_SYSFS_BLK_PATH_STR_LEN,
+             _SYSFS_BLK_PATH_FORMAT, sd_name);
+    if (_file_is_exist(err_msg, sysfs_blk_path) == false) {
+        rc = LSM_ERR_NOT_FOUND_DISK;
+        goto out;
+    }
+
+    snprintf(sysfs_path, _MAX_SYSFS_VPD83_PATH_STR_LEN,
+             _SYSFS_VPD83_PATH_FORMAT, sd_name);
+
+    rc = _sysfs_read_file(err_msg, sysfs_path, buff, &read_size,
+                          _MAX_VPD83_PAGE_LEN);
+
+    if (rc != LSM_ERR_OK)
+        goto out;
+
+    /* Return NULL and LSM_ERR_OK when got invalid sysfs file */
+    /* Read size is smaller than VPD83 header */
+    if (read_size < sizeof(struct t10_vpd83_header))
+        goto out;
+
+    vpd83_header = (struct t10_vpd83_header*) buff;
+
+    /* Incorrect page code */
+    if (vpd83_header->page_code != _T10_VPD83_PAGE_CODE)
+        goto out;
+
+    vpd83_len = (((uint32_t) vpd83_header->page_len_msb) << 8) +
+        vpd83_header->page_len_lsb + sizeof(struct t10_vpd83_header);
+
+    end_p = buff + vpd83_len - 1;
+    p = buff + sizeof(struct t10_vpd83_header);
+
+
+    while(p <= end_p) {
+        /* Corrupted data: facing data end */
+        if (p + sizeof(struct t10_vpd83_id_header) > end_p)
+            goto out;
+
+        id_header = (struct t10_vpd83_id_header *) p;
+        /* Skip non-NAA ID */
+        if (id_header->designator_type != _T10_VPD83_DESIGNATOR_TYPE_NAA)
+            goto next_one;
+
+        naa_header = (struct t10_vpd83_naa_header *)
+            ((uint8_t *)id_header + sizeof(struct t10_vpd83_id_header));
+
+        switch(naa_header->naa_type) {
+        case _T10_VPD83_NAA_TYPE_2:
+        case _T10_VPD83_NAA_TYPE_3:
+        case _T10_VPD83_NAA_TYPE_5:
+            _be_raw_to_hex((uint8_t *) naa_header, _T10_VPD83_NAA_235_ID_LEN,
+                           vpd83);
+            break;
+        case _T10_VPD83_NAA_TYPE_6:
+            _be_raw_to_hex((uint8_t *) naa_header, _T10_VPD83_NAA_6_ID_LEN,
+                           vpd83);
+            break;
+        default:
+            /* Skip for Unknown NAA ID type */
+            goto next_one;
+        }
+        /* Quit when found first NAA ID */
+        if (vpd83[0] != 0)
+            break;
+
+     next_one:
+        p = (uint8_t *) id_header + id_header->len +
+            sizeof(struct t10_vpd83_id_header);
+        continue;
+    }
+
+ out:
+    return rc;
+}
+
+/*
+ * Try to parse /sys/block/sda/device/vpd_pg83 for VPD83 NAA ID first.
+ * This sysfs file is missing in some older kernel(like RHEL6), we use udev
+ * ID_WWN_WITH_EXTENSION property instead, even through ID_WWN_WITH_EXTENSION
+ * does not mean VPD83 NAA ID, this is the only workaround I could found for
+ * old system without root privilege.
+ * Input *vpd83 should be char[_MAX_VPD83_NAA_ID_LEN], assuming caller did
+ * the check.
+ * The maximum *sd_name strlen is (_MAX_SD_NAME_STR_LEN - 1), assuming caller
+ * did the check.
+ */
+static int _udev_vpd83_of_sd_name(char *err_msg, const char *sd_name,
+                                  char *vpd83)
+{
+    struct udev *udev = NULL;
+    struct udev_device *sd_udev = NULL;
+    int rc = LSM_ERR_OK;
+    const char *wwn = NULL;
+    char sys_path[_MAX_SYSFS_BLK_PATH_STR_LEN];
+
+    memset(vpd83, 0, _MAX_VPD83_NAA_ID_LEN);
+    snprintf(sys_path, _MAX_SYSFS_BLK_PATH_STR_LEN, _SYSFS_BLK_PATH_FORMAT,
+             sd_name);
+
+    udev = udev_new();
+    if (udev == NULL) {
+        rc = LSM_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    sd_udev = udev_device_new_from_syspath(udev, sys_path);
+    if (sd_udev == NULL) {
+        _lsm_err_msg_set(err_msg, "Provided disk not found");
+        rc = LSM_ERR_NOT_FOUND_DISK;
+        goto out;
+    }
+    wwn = udev_device_get_property_value(sd_udev, "ID_WWN_WITH_EXTENSION");
+    if (wwn == NULL)
+        goto out;
+
+    if (strncmp(wwn, "0x", strlen("0x")) == 0)
+        wwn += strlen("0x");
+
+    snprintf(vpd83, _MAX_VPD83_NAA_ID_LEN, wwn);
+
+ out:
+    if (udev != NULL)
+        udev_unref(udev);
+
+    if (sd_udev != NULL)
+        udev_device_unref(sd_udev);
+
+    return rc;
+}
+
+static int _sysfs_get_all_sd_names(char *err_msg,
+                                   lsm_string_list **sd_name_list)
+{
+    DIR *dir = NULL;
+    struct dirent *dp = NULL;
+    int rc = LSM_ERR_OK;
+
+    *sd_name_list = lsm_string_list_alloc(0 /* no pre-allocation */);
+    if (*sd_name_list == NULL) {
+        return LSM_ERR_NO_MEMORY;
+    }
+
+    dir = opendir(_SYS_BLOCK_PATH);
+    if (dir == NULL) {
+        _lsm_err_msg_set(err_msg, "Cannot open %s: error (%d)%s",
+                         _SYS_BLOCK_PATH, errno, strerror(errno));
+        rc = LSM_ERR_LIB_BUG;
+        goto out;
+    }
+
+    do {
+        if ((dp = readdir(dir)) != NULL) {
+            if (strncmp(dp->d_name, "sd", strlen("sd")) != 0)
+                continue;
+            if (strlen(dp->d_name) >= _MAX_SD_NAME_STR_LEN) {
+                _lsm_err_msg_set(err_msg, "BUG: Got a SCSI disk name exceeded "
+                                 "the maximum string length %d, current %zd",
+                                 _MAX_SD_PATH_STR_LEN, strlen(dp->d_name));
+                rc = LSM_ERR_LIB_BUG;
+                goto out;
+            }
+            if (lsm_string_list_append(*sd_name_list, dp->d_name) != 0) {
+                rc = LSM_ERR_NO_MEMORY;
+                goto out;
+            }
+        }
+    } while(dp != NULL);
+
+ out:
+    if (dir != NULL) {
+        if (closedir(dir) != 0) {
+            _lsm_err_msg_set(err_msg, "Failed to close dir %s: error (%d)%s",
+                             _SYS_BLOCK_PATH, errno, strerror(errno));
+            rc = LSM_ERR_LIB_BUG;
+        }
+    }
+
+    if (rc != LSM_ERR_OK) {
+        lsm_string_list_free(*sd_name_list);
+        *sd_name_list = NULL;
+    }
+    return rc;
+}
+
+int lsm_scsi_disk_paths_of_vpd83(const char *vpd83,
+                                 lsm_string_list **sd_path_list,
+                                 lsm_error **lsm_err)
+{
+    int rc = LSM_ERR_OK;
+    lsm_string_list *sd_name_list = NULL;
+    uint32_t i = 0;
+    const char *sd_name = NULL;
+    char tmp_vpd83[_MAX_VPD83_NAA_ID_LEN];
+    char sd_path[_MAX_SD_PATH_STR_LEN];
+    bool sysfs_support = true;
+    char err_msg[_LSM_ERR_MSG_LEN];
+
+    _lsm_err_msg_clear(err_msg);
+
+    rc = _check_null_ptr(err_msg, 3 /* argument count */, vpd83, sd_path_list,
+                         lsm_err);
+
+    if (rc != LSM_ERR_OK) {
+        /* set output pointers to NULL if possible when facing error in case
+         * application use output memory.
+         */
+        if (sd_path_list != NULL)
+            *sd_path_list = NULL;
+
+        goto out;
+    }
+
+    if (strlen(vpd83) >= _MAX_VPD83_NAA_ID_LEN) {
+        _lsm_err_msg_set(err_msg, "Provided vpd83 string exceeded the maximum "
+                         "string length for SCSI VPD83 NAA ID %d, current %zd",
+                         _MAX_VPD83_NAA_ID_LEN - 1, strlen(vpd83));
+        rc = LSM_ERR_INVALID_ARGUMENT;
+        goto out;
+    }
+
+
+    *lsm_err = NULL;
+    *sd_path_list = lsm_string_list_alloc(0 /* no pre-allocation */);
+    if (*sd_path_list == NULL) {
+        rc = LSM_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    rc = _sysfs_get_all_sd_names(err_msg, &sd_name_list);
+    if (rc != LSM_ERR_OK)
+        goto out;
+
+    _lsm_string_list_foreach(sd_name_list, i, sd_name) {
+        if (sd_name == NULL)
+            continue;
+        if (sysfs_support == true) {
+            rc = _sysfs_vpd83_naa_of_sd_name(err_msg, sd_name, tmp_vpd83);
+            if (rc == LSM_ERR_NO_SUPPORT) {
+                sysfs_support = false;
+            } else if (rc == LSM_ERR_NOT_FOUND_DISK) {
+                /* In case disk got removed after _sysfs_get_all_sd_names() */
+                continue;
+            }
+            else if (rc != LSM_ERR_OK)
+                break;
+        }
+        /* Try udev way if got NO_SUPPORT from sysfs way. */
+        if (sysfs_support == false) {
+            rc = _udev_vpd83_of_sd_name(err_msg, sd_name, tmp_vpd83);
+            if (rc == LSM_ERR_NOT_FOUND_DISK)
+                /* In case disk got removed after _sysfs_get_all_sd_names() */
+                continue;
+            else if (rc != LSM_ERR_OK)
+                break;
+        }
+        if (strncmp(vpd83, tmp_vpd83, _MAX_VPD83_NAA_ID_LEN) == 0) {
+            snprintf(sd_path, _MAX_SD_PATH_STR_LEN, _SD_PATH_FORMAT, sd_name);
+
+            if (lsm_string_list_append(*sd_path_list, sd_path) != 0) {
+                rc = LSM_ERR_NO_MEMORY;
+                goto out;
+            }
+        }
+    }
+
+ out:
+    if (sd_name_list != NULL)
+        lsm_string_list_free(sd_name_list);
+
+    if (rc == LSM_ERR_OK) {
+        /* clean sd_path_list if nothing found */
+        if (lsm_string_list_size(*sd_path_list) == 0) {
+            lsm_string_list_free(*sd_path_list);
+            *sd_path_list = NULL;
+        }
+    } else {
+        /* Error found, clean up */
+
+        if (lsm_err != NULL)
+            *lsm_err = LSM_ERROR_CREATE_PLUGIN_MSG(rc, err_msg);
+
+        if ((sd_path_list != NULL) && (*sd_path_list != NULL)) {
+            lsm_string_list_free(*sd_path_list);
+            *sd_path_list = NULL;
+        }
+    }
+
+    return rc;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,18 @@ AC_PYTHON_MODULE([pywbem], [Required])
 AC_PYTHON_MODULE([M2Crypto], [Required])
 AC_PYTHON_MODULE([argparse], [Required])
 PKG_CHECK_MODULES([LIBUDEV], [libudev])
+PKG_CHECK_MODULES([PYTHON2], [python2], [], [not_found_py_pkg=yes])
+
+if test "x$not_found_py_pkg" == "xyes"; then
+    AC_CHECK_PROG([PY_CONFIG_CHECK], [python-config], [yes])
+    if test "x${PY_CONFIG_CHECK}" != "xyes"; then
+        AC_MSG_ERROR([Python2 development libraries required])
+    fi
+    PYTHON2_CFLAGS=`python-config --cflags`
+    PYTHON2_LIBS=`python-config --libs`
+    AC_SUBST(PYTHON2_CFLAGS)
+    AC_SUBST(PYTHON2_LIBS)
+fi
 
 dnl ==========================================================================
 dnl Check for libmicrohttpd and json-c as it is needed for REST API daemon

--- a/configure.ac
+++ b/configure.ac
@@ -162,6 +162,7 @@ AM_PATH_PYTHON([2.6], [], AC_MSG_ERROR([Python interpreter 2.6 or 2.7 required])
 AC_PYTHON_MODULE([pywbem], [Required])
 AC_PYTHON_MODULE([M2Crypto], [Required])
 AC_PYTHON_MODULE([argparse], [Required])
+PKG_CHECK_MODULES([LIBUDEV], [libudev])
 
 dnl ==========================================================================
 dnl Check for libmicrohttpd and json-c as it is needed for REST API daemon

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -70,6 +70,13 @@ BuildRequires:  libyajl-devel
 BuildRequires:  yajl-devel
 %endif
 
+%if 0%{?rhel} == 6
+BuildRequires:  libudev-devel
+%else
+BuildRequires:  systemd-devel
+%endif
+BuildRequires:  python-devel
+
 %if 0%{?do_fdupes}
 BuildRequires:  fdupes
 %endif
@@ -134,6 +141,14 @@ Requires:       python-ordereddict
 The %{libstoragemgmt}-python package contains python client libraries as
 well as python framework support and open source plug-ins written in python.
 
+%package        -n %{libstoragemgmt}-python-clibs
+Summary:        Python C extension module for %{libstoragemgmt}
+Group:          System Environment/Libraries
+Requires:       %{libstoragemgmt} = %{version}-%{release}
+
+%description    -n %{libstoragemgmt}-python-clibs
+The %{libstoragemgmt}-python-clibs package contains python client C extension
+libraries.
 
 %package        -n %{libstoragemgmt}-smis-plugin
 Summary:        Files for SMI-S generic array support for %{libstoragemgmt}
@@ -558,6 +573,9 @@ fi
 %{_bindir}/sim_lsmplugin
 %{_sysconfdir}/lsm/pluginconf.d/sim.conf
 %{_mandir}/man1/sim_lsmplugin.1*
+
+%files -n %{libstoragemgmt}-python-clibs
+%{python_sitelib}/lsm/_scsi.*
 
 %files -n %{libstoragemgmt}-smis-plugin
 %defattr(-,root,root,-)

--- a/python_binding/Makefile.am
+++ b/python_binding/Makefile.am
@@ -12,6 +12,15 @@ lsm_PYTHON = \
 	lsm/_iplugin.py \
 	lsm/_pluginrunner.py
 
+pyexec_LTLIBRARIES = lsm/_scsi.la
+pyexecdir = $(pythondir)/lsm
+
+lsm__scsi_la_CFLAGS = $(PYTHON2_CFLAGS) -I$(top_srcdir)/c_binding/include
+lsm__scsi_la_SOURCES = lsm/_scsi.c
+lsm__scsi_la_LDFLAGS = $(PYTHON2_LIBS) \
+		       -module -avoid-version -export-symbols-regex init_scsi
+lsm__scsi_la_LIBADD = $(top_builddir)/c_binding/libstoragemgmt.la
+
 external_PYTHON = \
 	lsm/external/__init__.py \
 	lsm/external/xmltodict.py

--- a/python_binding/lsm/__init__.py
+++ b/python_binding/lsm/__init__.py
@@ -5,6 +5,9 @@ from version import VERSION
 from _common import error, info, LsmError, ErrorNumber, \
     JobStatus, uri_parse, md5, Proxy, size_bytes_2_size_human, \
     common_urllib2_error_handler, size_human_2_size_bytes
+
+import lsm._scsi as SCSI
+
 from _data import (Disk, Volume, Pool, System, FileSystem, FsSnapshot,
                    NfsExport, BlockRange, AccessGroup, TargetPort,
                    Capabilities)

--- a/python_binding/lsm/_scsi.c
+++ b/python_binding/lsm/_scsi.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#include <Python.h>
+#include <stdint.h>
+
+#include <libstoragemgmt/libstoragemgmt.h>
+
+static const char disk_paths_of_vpd83_docstring[] =
+    "Version:\n"
+    "    1.3\n"
+    "Usage:\n"
+    "    Find out the /dev/sdX paths for given SCSI VPD page 0x83 NAA type\n"
+    "    ID. Considering multipath, certain VPD83 might have multiple disks\n"
+    "    associated.\n"
+    "Parameters:\n"
+    "    vpd83 (string)\n"
+    "        The VPD83 NAA type ID.\n"
+    "Returns:\n"
+    "    sd_name (list of string)\n"
+    "        Empty list is not found. The string format is '/dev/sd[a-z]+'.\n"
+    "\n"
+    "SpecialExceptions:\n"
+    "    N/A\n"
+    "Capability:\n"
+    "    N/A\n"
+    "        No capability required from plugin as this is a library level\n"
+    "        method.";
+
+static PyObject *disk_paths_of_vpd83(PyObject *self, PyObject *args,
+                                     PyObject *kwargs);
+
+/*
+ * TODO: Support METH_VARARGS | METH_KEYWORDS
+ */
+static PyMethodDef _scsi_methods[] = {
+    {"disk_paths_of_vpd83",  (PyCFunction) disk_paths_of_vpd83,
+     METH_VARARGS | METH_KEYWORDS, disk_paths_of_vpd83_docstring},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+
+static PyObject *disk_paths_of_vpd83(PyObject *self, PyObject *args,
+                                     PyObject *kwargs)
+{
+    static const char *kwlist[] = {"vpd83", NULL};
+    const char *vpd83 = NULL;
+    PyObject *rc_list = NULL;
+    lsm_string_list *sd_path_list = NULL;
+    lsm_error *lsm_err = NULL;
+    int rc = LSM_ERR_OK;
+    uint8_t i = 0;
+    const char *sd_path = NULL;
+    PyObject *sd_path_obj = NULL;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s", (char **) kwlist,
+                                     &vpd83))
+        return NULL;
+
+    rc = lsm_scsi_disk_paths_of_vpd83(vpd83, &sd_path_list, &lsm_err);
+    /* In python API definition, we don't raise error in function, only
+     * return empty list.
+     */
+    lsm_error_free(lsm_err);
+
+    rc_list = PyList_New(0 /* No pre-allocation */);
+    if (rc_list == NULL)
+        return NULL;
+
+    if ((rc != LSM_ERR_OK) || (sd_path_list == NULL))
+        return rc_list;
+
+    for (; i < lsm_string_list_size(sd_path_list); ++i) {
+        sd_path = lsm_string_list_elem_get(sd_path_list, i);
+        if (sd_path == NULL)
+            continue;
+        sd_path_obj = PyString_FromString(sd_path);
+        if (sd_path_obj == NULL) {
+            Py_DECREF(rc_list);
+            rc_list = NULL;
+            goto out;
+        }
+        PyList_Append(rc_list, sd_path_obj);
+        /* ^ PyList_Append will increase the reference count of sd_path_obj */
+        Py_DECREF(sd_path_obj);
+    }
+
+ out:
+    lsm_string_list_free(sd_path_list);
+
+    return rc_list;
+}
+
+PyMODINIT_FUNC init_scsi(void)
+{
+        (void) Py_InitModule("_scsi", _scsi_methods);
+}

--- a/test/cmdtest.py
+++ b/test/cmdtest.py
@@ -745,7 +745,8 @@ def volume_raid_create_test(cap, system_id):
 
         out = call([
             cmd, '-t' + sep, 'volume-raid-create', '--disk', free_disk_ids[0],
-            '--disk', free_disk_ids[1], '--name', 'test_volume_raid_create',
+            '--disk', free_disk_ids[1], '--name',
+            'test_volume_raid_create_%s' % rs(4),
             '--raid-type', 'raid1'])[1]
 
         volume = parse(out)

--- a/test/cmdtest.py
+++ b/test/cmdtest.py
@@ -750,7 +750,7 @@ def volume_raid_create_test(cap, system_id):
 
         volume = parse(out)
         vol_id = volume[0][0]
-        pool_id = volume[0][-2]
+        pool_id = volume[0][5]
 
         if cap['VOLUME_RAID_INFO']:
             out = call(

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -90,6 +90,7 @@ bin_plugin=$rootdir/plugin/simc/.libs/
 lsm_py_folder=$rootdir/python_binding
 lsm_plugin_py_folder=$rootdir/plugin
 lsmcli_py_folder=$rootdir/tools/lsmcli
+py_scsi_folder=$rootdir/python_binding/lsm/.libs/
 
 if [ -e $rootdir/_build ]
 then
@@ -97,6 +98,7 @@ then
     LSMD_DAEMON=$rootdir/_build/daemon/lsmd
     shared_libs=$rootdir/_build/c_binding/.libs/
     bin_plugin=$rootdir/_build/plugin/simc/.libs/
+    py_scsi_folder=$rootdir/_build/python_binding/lsm/.libs/
     # In distcheck, all folder is read only(except _build and _inst).
     # which prevent us from linking plugin and lsmcli into python/lsm folder.
     chmod +w $rootdir/python_binding/lsm
@@ -143,6 +145,9 @@ if [ -e "$PYTHONPATH/lsm/lsmcli" ] || [ -L "$PYTHONPATH/lsm/lsmcli" ];then
     good "rm $PYTHONPATH/lsm/lsmcli"
 fi
 good "cp -av $lsmcli_py_folder $PYTHONPATH/lsm/"
+
+#Copy Python shared library _scsi.so
+good "cp -av $py_scsi_folder/*.so* $PYTHONPATH/lsm/"
 
 #Copy plugins to one directory.
 good "find $rootdir/ \( ! -regex '.*/\..*' \) -type f -name \*_lsmplugin -exec cp {} $plugins \;"

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -45,14 +45,8 @@ cleanup() {
     cat $LSMD_TMP_LOG_FILE
     if [ -e $LSM_UDS_PATH ]
     then
+        chmod +w -R $base
         rm -rf     $base
-    fi
-
-    if [ -e $rootdir/_build ]
-    then
-        rm $lsm_py_folder/lsm/plugin
-        rm $lsm_py_folder/lsm/lsmcli
-        chmod -w $lsm_py_folder/lsm
     fi
 }
 

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -418,6 +418,7 @@ class DisplayData(object):
     VOL_HEADER['admin_state'] = 'Disabled'
     VOL_HEADER['pool_id'] = 'Pool ID'
     VOL_HEADER['system_id'] = 'System ID'
+    VOL_HEADER['sd_paths'] = 'Disk Paths'    # This is appended by cmdline.py
 
     VOL_COLUMN_SKIP_KEYS = ['block_size', 'num_of_blocks']
 

--- a/tools/lsmenv
+++ b/tools/lsmenv
@@ -139,6 +139,13 @@ sub lsm_env_setup() {
         print "INFO: Creating softlink for lsmcli folder\n";
         system("ln -sv ../../tools/lsmcli $py_lsm_dir");
     }
+    # Link python C extension module.
+    foreach (<$py_lsm_dir/.libs/*>) {
+        next unless /\.so$/;
+        my $c_lib_file = basename($_);
+        system("ln -sfv '.libs/$c_lib_file' '$py_lsm_dir/$c_lib_file'")
+          unless (-l "$py_lsm_dir/$c_lib_file");
+    }
 
     unless ( -d "$LSM_UDS_PATH" ) {
         print "INFO: Creating socket folder $LSM_UDS_PATH\n";

--- a/tools/utility/check_const.pl
+++ b/tools/utility/check_const.pl
@@ -267,7 +267,14 @@ sub _parse_py_init_file($) {
 
     foreach my $line (@lines) {
         if ( $line =~ /from ([^ ]+) import (.+)$/ ) {
-            push @rc1, sprintf "%s/%s.py", $folder_path, $1;
+            my $module_file_name = $1;
+            if ($module_file_name =~ /^lsm\.(.+)$/) {
+                $module_file_name = $1;
+                $module_file_name =~ s|\.|/|g;
+                push @rc1, sprintf "%s/%s.py", $folder_path, $module_file_name;
+            } else {
+                push @rc1, sprintf "%s/%s.py", $folder_path, $module_file_name;
+            }
             my $class_line = $2;
             while ( $class_line =~ /([A-Z][a-zA-Z]+)[, \\]*/g ) {
                 push @rc2, $1;


### PR DESCRIPTION
* API for querying scsi disk paths from VPD83 ID.
```
    C:
        int lsm_scsi_disk_paths_of_vpd83(const char *vpd83, 
                                         lsm_string_list **sd_path_list, 
                                         lsm_error **lsm_err)

    Python:
        lsm.SCSI.disk_paths_of_vpd83(vpd83)
```

* lsmcli changes: add "Disk Paths", example:
```
ID           | Name  | SCSI VPD 0x83    | Size       | Disabled | Pool ID       | System ID | Disk Paths
--------------------------------------------------------------------------------------------------------
VOL_ID_00001 | test  | 53333330000007d0 | 1073741824 | No       | POOL_ID_00001 | sim-01    | /dev/sda
             |       |                  |            |          |               |           | /dev/sdf
             |       |                  |            |          |               |           | /dev/sdh
             |       |                  |            |          |               |           | /dev/sdj
VOL_ID_00002 | test2 | 53333330000007d1 | 1073741824 | No       | POOL_ID_00001 | sim-01    | /dev/sde
             |       |                  |            |          |               |           | /dev/sdg
             |       |                  |            |          |               |           | /dev/sdi
             |       |                  |            |          |               |           | /dev/sdk
```