### PR TITLE
Update AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,11 +19,8 @@ Patches have also been contributed by:
    Eduardo Lima             <eblima@br.ibm.com>
    Dustin Schoenbrun        <Dustin.Schoenbrun@netapp.com>
    Ritesh Raj Sarraf        <rsarraf@netapp.com>
-   Andy Grover              <agrover@redhat.com>
    Anatoly Legkodymov       <legko777@fastmail.fm>
    Deepak C Shetty          <deepakcs@linux.vnet.ibm.com>
-   Gris Ge                  <fge@redhat.com>
-   Ma Shimiao               <mashimiao.fnst@cn.fujitsu.com>
    Ewan Milne               <emilne@redhat.com>
    Charles Rose             <charles.e.rose@gmail.com>
    Joe Handzik              <joseph.t.handzik@hpe.com>


### PR DESCRIPTION
Removed duplicates for Andy, Gris, and Ma...I figure they only need to be listed once under the "primary maintainers" heading.

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>