### PR TITLE
MegaRAID plugin: Add volume VPD83 support.

### DIFF
--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -508,7 +508,7 @@ class MegaRAID(IPlugin):
         if 'Name' in vd_basic_info.keys() and vd_basic_info['Name']:
             name += ": %s" % vd_basic_info['Name']
 
-        vpd83 = ''  # TODO(Gris Ge): Beg LSI to provide this information.
+        vpd83 = vd_prop_info.get('SCSI NAA Id', '')
         block_size = size_human_2_size_bytes(vd_pd_info_list[0]['SeSz'])
         num_of_blocks = vd_prop_info['Number of Blocks']
         admin_state = Volume.ADMIN_STATE_ENABLED


### PR DESCRIPTION
Use `SCSI NAA Id` property for volume VPD83.
This feature only valid with storcli 1.18.05 or later version.

Test results:
```
[fge@megadeth megaraid]$ sudo lsmenv mega lsmcli lv -s
Device alias: mega
URI: megaraid://
lsmcli lv -s
------------------------------------------------
ID            | SV51929674:VD0                  
Name          | VD 0                            
SCSI VPD 0x83 | 600605b00a5796201e272bad49e24206
Block Size    | 512                             
Block Count   | 3905945600                      
Size          | 1999844147200                   
Disabled      | No                              
Pool ID       | SV51929674:DG0                  
System ID     | SV51929674                      
Disk Paths    | /dev/sdan                       
------------------------------------------------

Time: 0:00.43
```