### PR TITLE
[PATCH V7 0/20] Querying disk rotation speed and link type

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
@@ -165,6 +165,10 @@ typedef enum {
     /**^ Plug-in allows user to retrieve storage mode*/
     LSM_CAP_DISK_LOCATION = 163,
     /**^ Plug-in allows user to retrieve disk location */
+    LSM_CAP_DISK_RPM = 164,
+    /**^ Plug-in allows user to retrieve disk rotation speed */
+    LSM_CAP_DISK_LINK_TYPE = 165,
+    /**^ Plug-in allows user to retrieve disk link type */
     LSM_CAP_VOLUME_LED = 171,
     /**^ Plugin allows user to set and clear volume LEDs */
     LSM_CAP_POOLS_QUICK_SEARCH = 210,

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_disk.h
@@ -115,6 +115,52 @@ int LSM_DLL_EXPORT lsm_disk_location_get(lsm_disk *d,
                                          const char **location);
 
 /**
+ * New in version 1.3. Retrieves a disk's rotation speed(revolutions per minute).
+ * @param d             Pointer to the disk of interest.
+ * @return Disk rotation speed - revolutions per minute(RPM). Special values:
+ *         LSM_DISK_RPM_NO_SUPPORT if not supported by plugin.
+ *         LSM_DISK_RPM_NON_ROTATING_MEDIUM for Non-rotating medium (e.g., SSD).
+ *         LSM_DISK_RPM_ROTATING_UNKNOWN_SPEED for Rotational disk with unknown
+ *         speed.
+ *         LSM_DISK_RPM_UNKNOWN if error or plugin failed to detect rpm.
+ */
+int32_t LSM_DLL_EXPORT lsm_disk_rpm_get(lsm_disk *d);
+
+/**
+ * New in version 1.3. Retrieves a disk link type.
+ * @param d             Pointer to the disk of interest.
+ * @return Disk link type - lsm_disk_link_type
+ *         LSM_DISK_LINK_TYPE_NO_SUPPORT
+ *              Plugin does not support this property.
+ *         LSM_DISK_LINK_TYPE_UNKNOWN
+ *              Given 'd' argument is NULL or plugin failed to detect link type.
+ *         LSM_DISK_LINK_TYPE_FC
+ *              Fibre Channel
+ *         LSM_DISK_LINK_TYPE_SSA
+ *              Serial Storage Architecture, Old IBM tech.
+ *         LSM_DISK_LINK_TYPE_SBP
+ *              Serial Bus Protocol, used by IEEE 1394.
+ *         LSM_DISK_LINK_TYPE_SRP
+ *              SCSI RDMA Protocol
+ *         LSM_DISK_LINK_TYPE_ISCSI
+ *              Internet Small Computer System Interface
+ *         LSM_DISK_LINK_TYPE_SAS
+ *              Serial Attached SCSI
+ *         LSM_DISK_LINK_TYPE_ADT
+ *              Automation/Drive Interface Transport
+ *              Protocol, often used by Tape.
+ *         LSM_DISK_LINK_TYPE_ATA
+ *              PATA/IDE or SATA.
+ *         LSM_DISK_LINK_TYPE_USB
+ *              USB disk
+ *         LSM_DISK_LINK_TYPE_SOP
+ *              SCSI over PCI-E
+ *         LSM_DISK_LINK_TYPE_PCIE
+ *              PCI-E, e.g. NVMe
+ */
+lsm_disk_link_type LSM_DLL_EXPORT lsm_disk_link_type_get(lsm_disk *d);
+
+/**
  * Returns the system id
  * Note: Return value is valid as long as disk pointer is valid.  It gets
  * freed when record is freed.

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_error.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_error.h
@@ -43,6 +43,9 @@ typedef enum {
     /** Daemon is not running */
     LSM_ERR_DAEMON_NOT_RUNNING = 12,
 
+    /** Permission denied. Only for library level function. */
+    LSM_ERR_PERMISSION_DENIED = 13,
+
     /** Name exists */
     LSM_ERR_NAME_CONFLICT = 50,
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
@@ -126,6 +126,56 @@ int LSM_DLL_EXPORT lsm_local_disk_rpm_get(const char *disk_path, int32_t *rpm,
 int LSM_DLL_EXPORT lsm_local_disk_list(lsm_string_list **disk_paths,
                                        lsm_error **lsm_err);
 
+/**
+ * Query the disk link type of given disk path.
+ * For SATA disks connected to SAS SES enclosure, will return
+ * LSM_SCSI_LINK_TYPE_ATA.
+ * Require permission to open /dev/sdX(root user or disk group).
+ * New in version 1.3.
+ * @param[in]  disk_path    String. The path of disk, example "/dev/sdb".
+ * @param[out] link_type    Output pointer of lsm_disk_link_type.
+ *                          LSM_DISK_LINK_TYPE_UNKNOWN when error.
+ *                          Possible values are:
+ *                              LSM_DISK_LINK_TYPE_UNKNOWN
+ *                                  Unknown
+ *                              LSM_DISK_LINK_TYPE_FC
+ *                                  Fibre Channel
+ *                              LSM_DISK_LINK_TYPE_SSA
+ *                                  Serial Storage Architecture, Old IBM tech.
+ *                              LSM_DISK_LINK_TYPE_SBP
+ *                                  Serial Bus Protocol, used by IEEE 1394.
+ *                              LSM_DISK_LINK_TYPE_SRP
+ *                                  SCSI RDMA Protocol
+ *                              LSM_DISK_LINK_TYPE_ISCSI
+ *                                  Internet Small Computer System Interface
+ *                              LSM_DISK_LINK_TYPE_SAS
+ *                                  Serial Attached SCSI
+ *                              LSM_DISK_LINK_TYPE_ADT
+ *                                  Automation/Drive Interface Transport
+ *                                  Protocol, often used by Tape.
+ *                              LSM_DISK_LINK_TYPE_ATA
+ *                                  PATA/IDE or SATA.
+ *                              LSM_DISK_LINK_TYPE_USB
+ *                                  USB disk
+ *                              LSM_DISK_LINK_TYPE_SOP
+ *                                  SCSI over PCI-E
+ *                              LSM_DISK_LINK_TYPE_PCIE
+ *                                  PCI-E, e.g. NVMe
+ *
+ * @param[out] lsm_err  Output pointer of lsm_error. Error message could be
+ *                      retrieved via lsm_error_message_get(). Memory should
+ *                      be freed by lsm_error_free().
+ * @return LSM_ERR_OK                   On success.
+ *         LSM_ERR_INVALID_ARGUMENT     When any argument is NULL.
+ *         LSM_ERR_LIB_BUG              When something unexpected happens.
+ *         LSM_ERR_NOT_FOUND_DISK       When provided disk path not found.
+ *         LSM_ERR_PERMISSION_DENIED    Insufficient permission to access
+ *                                      provided disk path.
+ */
+int LSM_DLL_EXPORT lsm_local_disk_link_type_get(const char *disk_path,
+                                                lsm_disk_link_type *link_type,
+                                                lsm_error **lsm_err);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
@@ -104,6 +104,27 @@ int LSM_DLL_EXPORT lsm_local_disk_vpd83_get(const char *sd_path,
 int LSM_DLL_EXPORT lsm_local_disk_rpm_get(const char *disk_path, int32_t *rpm,
                                           lsm_error **lsm_err);
 
+/**
+ * Query local disk paths. Currently, only SCSI, ATA and NVMe disks will be
+ * included.
+ * New in version 1.3.
+ * @param[out]  disk_paths
+ *                      lsm_string_list pointer.
+ *                      The disk_path string format is '/dev/sd[a-z]+' for SCSI
+ *                      and ATA disks, '/dev/nvme[0-9]+n[0-9]+' for NVMe disks.
+ *                      Empty lsm_string_list but not NULL will be returned
+ *                      if no disk found.
+ *                      Memory should be freed by lsm_string_list_free().
+ * @param[out] lsm_err
+ *                      Output pointer of lsm_error. Error message could be
+ *                      retrieved via lsm_error_message_get(). Memory should be
+ *                      freed by lsm_error_free().
+ * @return LSM_ERR_OK                   On success.
+ *         LSM_ERR_INVALID_ARGUMENT     When any argument is NULL.
+ *         LSM_ERR_LIB_BUG              When something unexpected happens.
+ */
+int LSM_DLL_EXPORT lsm_local_disk_list(lsm_string_list **disk_paths,
+                                       lsm_error **lsm_err);
 
 #ifdef __cplusplus
 }

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
@@ -73,6 +73,38 @@ int LSM_DLL_EXPORT lsm_local_disk_vpd83_get(const char *sd_path,
                                             char **vpd83,
                                             lsm_error **lsm_err);
 
+/**
+ * Query the disk rotation speed - revolutions per minute(RPM) of given disk
+ * path.
+ * Requires permission to open disk path(root user or disk group).
+ * New in version 1.3.
+ * @param[in]  disk_path
+ *                      String. The path of disk block, example: "/dev/sdb",
+ *                      "/dev/nvme0n1".
+ * @param[out] rpm      Output pointer of int32_t.
+ *                          -1 (LSM_DISK_RPM_UNKNOWN):
+ *                              Unknown RPM
+ *                           0 (LSM_DISK_RPM_NON_ROTATING_MEDIUM):
+ *                              Non-rotating medium (e.g., SSD)
+ *                           1 (LSM_DISK_RPM_ROTATING_UNKNOWN_SPEED):
+ *                              Rotational disk with unknown speed
+ *                          >1:
+ *                              Normal rotational disk (e.g., HDD)
+ * @param[out] lsm_err
+ *                      Output pointer of lsm_error. Error message could be
+ *                      retrieved via lsm_error_message_get(). Memory should be
+ *                      freed by lsm_error_free().
+ * @return LSM_ERR_OK                   On success.
+ *         LSM_ERR_INVALID_ARGUMENT     When any argument is NULL.
+ *         LSM_ERR_LIB_BUG              When something unexpected happens.
+ *         LSM_ERR_NOT_FOUND_DISK       When provided disk path not found.
+ *         LSM_ERR_PERMISSION_DENIED    No sufficient permission to access
+ *                                      provided disk path.
+ */
+int LSM_DLL_EXPORT lsm_local_disk_rpm_get(const char *disk_path, int32_t *rpm,
+                                          lsm_error **lsm_err);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
@@ -1659,6 +1659,23 @@ void LSM_DLL_EXPORT
  */
 int LSM_DLL_EXPORT lsm_disk_vpd83_set(lsm_disk *disk, const char *vpd83);
 
+/**
+ * New in version 1.3. Set disk rotation speed - revolutions per minute(RPM)
+ * @param[in] disk          Disk to update.
+ * @param[in] rpm           revolutions per minute(RPM).
+ * @return LSM_ERR_OK or LSM_ERR_INVALID_ARGUMENT.
+ */
+int LSM_DLL_EXPORT lsm_disk_rpm_set(lsm_disk *disk, int32_t rpm);
+
+/**
+ * New in version 1.3. Set disk link type.
+ * @param[in] disk          Disk to update.
+ * @param[in] link_type     lsm_disk_link_type
+ * @return LSM_ERR_OK or LSM_ERR_INVALID_ARGUMENT.
+ */
+int LSM_DLL_EXPORT lsm_disk_link_type_set(lsm_disk *disk,
+                                          lsm_disk_link_type link_type);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -268,6 +268,21 @@ typedef enum {
     LSM_DISK_TYPE_HYBRID = 54,
 } lsm_disk_type;
 
+typedef enum {
+    LSM_DISK_LINK_TYPE_UNKNOWN =  -1,
+    LSM_DISK_LINK_TYPE_FC = 0,
+    LSM_DISK_LINK_TYPE_SSA = 2,
+    LSM_DISK_LINK_TYPE_SBP = 3,
+    LSM_DISK_LINK_TYPE_SRP = 4,
+    LSM_DISK_LINK_TYPE_ISCSI = 5,
+    LSM_DISK_LINK_TYPE_SAS = 6,
+    LSM_DISK_LINK_TYPE_ADT = 7,
+    LSM_DISK_LINK_TYPE_ATA = 8,
+    LSM_DISK_LINK_TYPE_USB = 9,
+    LSM_DISK_LINK_TYPE_SOP = 10,
+    LSM_DISK_LINK_TYPE_PCIE = 11,
+} lsm_disk_link_type;
+/* ^ SPC-5 rev7, Table 444 - PROTOCOL IDENTIFIER field values */
 
 #define LSM_DISK_STATUS_UNKNOWN                     0x0000000000000001
 #define LSM_DISK_STATUS_OK                          0x0000000000000002

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -269,6 +269,7 @@ typedef enum {
 } lsm_disk_type;
 
 typedef enum {
+    LSM_DISK_LINK_TYPE_NO_SUPPORT = -2,
     LSM_DISK_LINK_TYPE_UNKNOWN =  -1,
     LSM_DISK_LINK_TYPE_FC = 0,
     LSM_DISK_LINK_TYPE_SSA = 2,
@@ -311,6 +312,8 @@ typedef enum {
 #define LSM_DISK_BLOCK_SIZE_NOT_FOUND               -1
 #define LSM_DISK_BLOCK_COUNT_NOT_FOUND              -1
 
+#define LSM_DISK_RPM_NO_SUPPORT                     -2
+/* ^ New in version 1.3. */
 #define LSM_DISK_RPM_UNKNOWN                        -1
 /* ^ New in version 1.3. */
 #define LSM_DISK_RPM_NON_ROTATING_MEDIUM            0

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -296,6 +296,15 @@ typedef enum {
 #define LSM_DISK_BLOCK_SIZE_NOT_FOUND               -1
 #define LSM_DISK_BLOCK_COUNT_NOT_FOUND              -1
 
+#define LSM_DISK_RPM_UNKNOWN                        -1
+/* ^ New in version 1.3. */
+#define LSM_DISK_RPM_NON_ROTATING_MEDIUM            0
+/* ^ New in version 1.3. */
+#define LSM_DISK_RPM_ROTATING_UNKNOWN_SPEED         1
+/* ^ New in version 1.3. Indicate given disk is a rotating disk, but speed is
+ *   unknown
+ */
+
 #define LSM_POOL_STATUS_UNKNOWN                     0x0000000000000001
 #define LSM_POOL_STATUS_OK                          0x0000000000000002
 #define LSM_POOL_STATUS_OTHER                       0x0000000000000004

--- a/c_binding/lsm_convert.cpp
+++ b/c_binding/lsm_convert.cpp
@@ -156,13 +156,32 @@ lsm_disk *value_to_disk(Value & disk)
 
         if ((rc != NULL) && std_map_has_key(d, "disk_location") &&
             (d["disk_location"].asC_str()[0] != '\0')) {
-            
+
             if (lsm_disk_location_set(rc, d["disk_location"].asC_str()) !=
                 LSM_ERR_OK) {
                 lsm_disk_record_free(rc);
                 rc = NULL;
                 throw ValueException("value_to_disk: failed to update "
                                      "disk_location");
+            }
+        }
+        if ((rc != NULL) && std_map_has_key(d, "rpm") &&
+            (d["rpm"].asInt32_t() != LSM_DISK_RPM_NO_SUPPORT)) {
+            if (lsm_disk_rpm_set(rc, d["rpm"].asInt32_t()) != LSM_ERR_OK) {
+                lsm_disk_record_free(rc);
+                rc = NULL;
+                throw ValueException("value_to_disk: failed to update rpm");
+            }
+        }
+        if ((rc != NULL) && std_map_has_key(d, "link_type") &&
+            (d["link_type"].asInt32_t() != LSM_DISK_LINK_TYPE_NO_SUPPORT)) {
+            if (lsm_disk_link_type_set(rc, (lsm_disk_link_type)
+                                       d["link_type"].asInt32_t()) !=
+                LSM_ERR_OK) {
+                lsm_disk_record_free(rc);
+                rc = NULL;
+                throw ValueException("value_to_disk: failed to update "
+                                     "link_type");
             }
         }
     } else {
@@ -186,6 +205,10 @@ Value disk_to_value(lsm_disk * disk)
         d["system_id"] = Value(disk->system_id);
         if (disk->disk_location != NULL)
             d["disk_location"] = Value(disk->disk_location);
+        if (disk->rpm != LSM_DISK_RPM_NO_SUPPORT)
+            d["rpm"] = Value(disk->rpm);
+        if (disk->link_type != LSM_DISK_LINK_TYPE_NO_SUPPORT)
+            d["link_type"] = Value(disk->link_type);
 
         return Value(d);
     }

--- a/c_binding/lsm_datatypes.cpp
+++ b/c_binding/lsm_datatypes.cpp
@@ -708,6 +708,8 @@ lsm_disk *lsm_disk_record_alloc(const char *id, const char *name,
         rc->system_id = strdup(system_id);
         rc->vpd83 = NULL;
         rc->disk_location = NULL;
+        rc->rpm = LSM_DISK_RPM_NO_SUPPORT;
+        rc->link_type = LSM_DISK_LINK_TYPE_NO_SUPPORT;
 
         if (!rc->id || !rc->name || !rc->system_id) {
             lsm_disk_record_free(rc);
@@ -977,6 +979,8 @@ lsm_disk *lsm_disk_record_copy(lsm_disk * disk)
             lsm_disk_record_free(new_lsm_disk);
             return NULL;
         }
+        new_lsm_disk->rpm = disk->rpm;
+        new_lsm_disk->link_type = disk->link_type;
         return new_lsm_disk;
     }
     return NULL;
@@ -1001,7 +1005,7 @@ int lsm_disk_record_free(lsm_disk * d)
 
         if (d->disk_location != NULL)
             free((char *) d->disk_location);
-        
+
         free(d);
         return LSM_ERR_OK;
     }
@@ -1157,6 +1161,36 @@ int lsm_disk_vpd83_set(lsm_disk *disk, const char *vpd83)
     if (disk->vpd83 == NULL)
         return LSM_ERR_NO_MEMORY;
 
+    return LSM_ERR_OK;
+}
+
+int32_t lsm_disk_rpm_get(lsm_disk *disk)
+{
+    MEMBER_GET(disk, LSM_IS_DISK, rpm, LSM_DISK_RPM_UNKNOWN);
+}
+
+int lsm_disk_rpm_set(lsm_disk *disk, int32_t rpm)
+{
+    if ((disk == NULL) || (! LSM_IS_DISK(disk)) ||
+        (rpm == LSM_DISK_RPM_NO_SUPPORT))
+        return LSM_ERR_INVALID_ARGUMENT;
+
+    disk->rpm = rpm;
+    return LSM_ERR_OK;
+}
+
+lsm_disk_link_type lsm_disk_link_type_get(lsm_disk *disk)
+{
+    MEMBER_GET(disk, LSM_IS_DISK, link_type, LSM_DISK_LINK_TYPE_UNKNOWN);
+}
+
+int lsm_disk_link_type_set(lsm_disk *disk, lsm_disk_link_type link_type)
+{
+    if ((disk == NULL) || (! LSM_IS_DISK(disk)) ||
+        (link_type == LSM_DISK_LINK_TYPE_NO_SUPPORT))
+        return LSM_ERR_INVALID_ARGUMENT;
+
+    disk->link_type = link_type;
     return LSM_ERR_OK;
 }
 

--- a/c_binding/lsm_datatypes.hpp
+++ b/c_binding/lsm_datatypes.hpp
@@ -279,6 +279,8 @@ struct LSM_DLL_LOCAL _lsm_disk {
     char *system_id;
     char *vpd83;
     const char *disk_location;
+    int32_t rpm;
+    lsm_disk_link_type link_type;
 };
 
 #define LSM_HASH_MAGIC     0xAA7A0011

--- a/c_binding/lsm_local_disk.c
+++ b/c_binding/lsm_local_disk.c
@@ -1005,7 +1005,7 @@ int lsm_local_disk_rpm_get(const char *sd_path, int32_t *rpm,
     *rpm = be16toh(bdc->medium_rotation_rate_be);
     if (((*rpm >= 2) && (*rpm <= 0x400)) || (*rpm == 0xffff) ||
         (*rpm == _T10_SBC_MEDIUM_ROTATION_NO_SUPPORT))
-        *rpm = LSM_DISK_RPM_UNKNOWN;
+        *rpm = LSM_DISK_RPM_NO_SUPPORT;
 
     if (*rpm == _T10_SBC_MEDIUM_ROTATION_SSD)
         *rpm = LSM_DISK_RPM_NON_ROTATING_MEDIUM;
@@ -1167,7 +1167,7 @@ int lsm_local_disk_link_type_get(const char *disk_path,
                          lsm_err),
           rc, out);
 
-    *link_type = LSM_DISK_LINK_TYPE_UNKNOWN;
+    *link_type = LSM_DISK_LINK_TYPE_NO_SUPPORT;
     *lsm_err = NULL;
 
     _good(_sg_io_ioctl_open(err_msg, disk_path, &fd), rc, out);

--- a/doc/man/lsmcli.1.in
+++ b/doc/man/lsmcli.1.in
@@ -615,6 +615,11 @@ The desired percentage of read cache for the targeted system. Write cache
 will be automatically changed to the remaining percentage available after
 updating the read cache (if supported by the system).
 
+.SS local-disk-list
+List all disks found on current local operating system.
+Require permission to open /dev/sdX as read-only, normally root user or disk
+group would have sufficient permission.
+
 .IP
 .SH ALIAS
 .SS ls
@@ -667,6 +672,8 @@ Alias of 'access-group-remove'
 Alias of 'access-group-delete'
 .SS srcps
 Alias of 'system-read-cache-pct-update'
+.SS ldl
+Alias of 'local-disk-list'
 
 .IP
 .SH SIZE OPTION

--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -219,6 +219,8 @@ def _disk_type_of(hp_disk):
         return Disk.TYPE_SSD
     elif disk_interface == 'SAS':
         return Disk.TYPE_SAS
+    elif disk_interface == 'Solid State SAS':
+        return Disk.TYPE_SSD
 
     return Disk.TYPE_UNKNOWN
 
@@ -234,6 +236,19 @@ def _disk_status_of(hp_disk, flag_free):
         disk_status |= Disk.STATUS_FREE
 
     return disk_status
+
+def _disk_link_type_of(hp_disk):
+    disk_interface = hp_disk['Interface Type']
+    if disk_interface == 'SATA':
+        return Disk.LINK_TYPE_ATA
+    elif disk_interface == 'Solid State SATA':
+        return Disk.LINK_TYPE_ATA
+    elif disk_interface == 'SAS':
+        return Disk.LINK_TYPE_SAS
+    elif disk_interface == 'Solid State SAS':
+        return Disk.LINK_TYPE_SAS
+
+    return Disk.LINK_TYPE_UNKNOWN
 
 
 _HP_RAID_LEVEL_CONV = {
@@ -602,11 +617,13 @@ class SmartArray(IPlugin):
             vpd83 = LocalDisk.vpd83_get(disk_path)
         else:
             vpd83 = ''
+        rpm = int(hp_disk.get('Rotational Speed', Disk.RPM_NON_ROTATING_MEDIUM))
+        link_type = _disk_link_type_of(hp_disk)
 
         return Disk(
             disk_id, disk_name, disk_type, blk_size, blk_count,
             status, sys_id, _plugin_data=plugin_data, _vpd83=vpd83,
-            _disk_location=disk_location)
+            _disk_location=disk_location, _rpm=rpm, _link_type=link_type)
 
     @_handle_errors
     def disks(self, search_key=None, search_value=None,

--- a/plugin/simc/simc_lsmplugin.c
+++ b/plugin/simc/simc_lsmplugin.c
@@ -2381,6 +2381,8 @@ int load(lsm_plugin_ptr c, const char *uri, const char *password,
                                       512, 0x8000000000000,
                                       LSM_DISK_STATUS_OK, sys_id);
             lsm_disk_location_set(d, disk_location);
+            lsm_disk_rpm_set(d, LSM_DISK_RPM_NON_ROTATING_MEDIUM);
+            lsm_disk_link_type_set(d, LSM_DISK_LINK_TYPE_SAS);
 
             key = strdup(lsm_disk_id_get(d));
 

--- a/python_binding/lsm/_clib.c
+++ b/python_binding/lsm/_clib.c
@@ -150,6 +150,24 @@ static const char local_disk_list_docstring[] =
     "        err_msg (string)\n"
     "            Error message, empty if no error.\n";
 
+static const char local_disk_link_type_get_docstring[] =
+    "INTERNAL USE ONLY!\n"
+    "\n"
+    "Usage:\n"
+    "    Query the link type of given disk path\n"
+    "Parameters:\n"
+    "    disk_path (string)\n"
+    "        The disk path, example '/dev/sdb'. Empty string is failure\n"
+    "Returns:\n"
+    "    [link_type, rc, err_msg]\n"
+    "        link_type (int)\n"
+    "              Link type.\n"
+    "        rc (integer)\n"
+    "            Error code, lsm.ErrorNumber.OK if no error\n"
+    "        err_msg (string)\n"
+    "            Error message, empty if no error.\n";
+
+
 static PyObject *local_disk_vpd83_search(PyObject *self, PyObject *args,
                                      PyObject *kwargs);
 static PyObject *local_disk_vpd83_get(PyObject *self, PyObject *args,
@@ -158,6 +176,8 @@ static PyObject *local_disk_rpm_get(PyObject *self, PyObject *args,
                                     PyObject *kwargs);
 static PyObject *local_disk_list(PyObject *self, PyObject *args,
                                  PyObject *kwargs);
+static PyObject *local_disk_link_type_get(PyObject *self, PyObject *args,
+                                          PyObject *kwargs);
 static PyObject *_lsm_string_list_to_pylist(lsm_string_list *str_list);
 static PyObject *_c_str_to_py_str(const char *str);
 
@@ -170,6 +190,8 @@ static PyMethodDef _methods[] = {
      METH_VARARGS | METH_KEYWORDS, local_disk_rpm_get_docstring},
     {"_local_disk_list",  (PyCFunction) local_disk_list,
      METH_NOARGS, local_disk_list_docstring},
+    {"_local_disk_link_type_get",  (PyCFunction) local_disk_link_type_get,
+     METH_VARARGS | METH_KEYWORDS, local_disk_link_type_get_docstring},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 
@@ -220,6 +242,9 @@ _wrapper(local_disk_vpd83_get, lsm_local_disk_vpd83_get,
 _wrapper(local_disk_rpm_get, lsm_local_disk_rpm_get,
          const char *, disk_path, int32_t, LSM_DISK_RPM_UNKNOWN,
          PyInt_FromLong);
+_wrapper(local_disk_link_type_get, lsm_local_disk_link_type_get,
+         const char *, disk_path, lsm_disk_link_type,
+         LSM_DISK_LINK_TYPE_UNKNOWN, PyInt_FromLong);
 
 static PyObject *local_disk_list(PyObject *self, PyObject *args,
                                  PyObject *kwargs)

--- a/python_binding/lsm/_clib.c
+++ b/python_binding/lsm/_clib.c
@@ -115,9 +115,28 @@ static const char local_disk_vpd83_get_docstring[] =
     "        err_msg (string)\n"
     "            Error message, empty if no error.\n";
 
+static const char local_disk_rpm_get_docstring[] =
+    "INTERNAL USE ONLY!\n"
+    "\n"
+    "Usage:\n"
+    "    Query the rotation speed of given disk path\n"
+    "Parameters:\n"
+    "    disk_path (string)\n"
+    "        The disk path, example '/dev/sdb'. Empty string is failure\n"
+    "Returns:\n"
+    "    [rpm, rc, err_msg]\n"
+    "        rpm (int)\n"
+    "              revolutions per minute (RPM).\n"
+    "        rc (integer)\n"
+    "            Error code, lsm.ErrorNumber.OK if no error\n"
+    "        err_msg (string)\n"
+    "            Error message, empty if no error.\n";
+
 static PyObject *local_disk_vpd83_search(PyObject *self, PyObject *args,
                                      PyObject *kwargs);
 static PyObject *local_disk_vpd83_get(PyObject *self, PyObject *args,
+                                    PyObject *kwargs);
+static PyObject *local_disk_rpm_get(PyObject *self, PyObject *args,
                                     PyObject *kwargs);
 static PyObject *_lsm_string_list_to_pylist(lsm_string_list *str_list);
 static PyObject *_c_str_to_py_str(const char *str);
@@ -127,6 +146,8 @@ static PyMethodDef _methods[] = {
      METH_VARARGS | METH_KEYWORDS, local_disk_vpd83_search_docstring},
     {"_local_disk_vpd83_get",  (PyCFunction) local_disk_vpd83_get,
      METH_VARARGS | METH_KEYWORDS, local_disk_vpd83_get_docstring},
+    {"_local_disk_rpm_get",  (PyCFunction) local_disk_rpm_get,
+     METH_VARARGS | METH_KEYWORDS, local_disk_rpm_get_docstring},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 
@@ -174,6 +195,9 @@ _wrapper(local_disk_vpd83_search, lsm_local_disk_vpd83_search,
 _wrapper(local_disk_vpd83_get, lsm_local_disk_vpd83_get,
          const char *, disk_path, char *, NULL,
          _c_str_to_py_str);
+_wrapper(local_disk_rpm_get, lsm_local_disk_rpm_get,
+         const char *, disk_path, int32_t, LSM_DISK_RPM_UNKNOWN,
+         PyInt_FromLong);
 
 PyMODINIT_FUNC init_clib(void)
 {

--- a/python_binding/lsm/_common.py
+++ b/python_binding/lsm/_common.py
@@ -420,6 +420,7 @@ class ErrorNumber(object):
     JOB_STARTED = 7
     TIMEOUT = 11
     DAEMON_NOT_RUNNING = 12
+    PERMISSION_DENIED = 13
 
     NAME_CONFLICT = 50
     EXISTS_INITIATOR = 52

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -211,6 +211,19 @@ class Disk(IData):
     RPM_NON_ROTATING_MEDIUM = 0
     RPM_ROTATING_UNKNOWN_SPEED = 1
 
+    LINK_TYPE_UNKNOWN = -1
+    LINK_TYPE_FC = 0
+    LINK_TYPE_SSA = 2
+    LINK_TYPE_SBP = 3
+    LINK_TYPE_SRP = 4
+    LINK_TYPE_ISCSI = 5
+    LINK_TYPE_SAS = 6
+    LINK_TYPE_ADT = 7
+    LINK_TYPE_ATA = 8
+    LINK_TYPE_USB = 9
+    LINK_TYPE_SOP = 10
+    LINK_TYPE_PCIE = 11
+
     def __init__(self, _id, _name, _disk_type, _block_size, _num_of_blocks,
                  _status, _system_id, _plugin_data=None, _vpd83='',
                  _disk_location=''):

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -207,6 +207,10 @@ class Disk(IData):
     # any explicit action when assigning to pool, it should be treated as
     # free disk and marked as STATUS_FREE|STATUS_SPARE_DISK.
 
+    RPM_UNKNOWN = -1
+    RPM_NON_ROTATING_MEDIUM = 0
+    RPM_ROTATING_UNKNOWN_SPEED = 1
+
     def __init__(self, _id, _name, _disk_type, _block_size, _num_of_blocks,
                  _status, _system_id, _plugin_data=None, _vpd83='',
                  _disk_location=''):

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -207,10 +207,12 @@ class Disk(IData):
     # any explicit action when assigning to pool, it should be treated as
     # free disk and marked as STATUS_FREE|STATUS_SPARE_DISK.
 
+    RPM_NO_SUPPORT = -2
     RPM_UNKNOWN = -1
     RPM_NON_ROTATING_MEDIUM = 0
     RPM_ROTATING_UNKNOWN_SPEED = 1
 
+    LINK_TYPE_NO_SUPPORT = -2
     LINK_TYPE_UNKNOWN = -1
     LINK_TYPE_FC = 0
     LINK_TYPE_SSA = 2
@@ -226,7 +228,8 @@ class Disk(IData):
 
     def __init__(self, _id, _name, _disk_type, _block_size, _num_of_blocks,
                  _status, _system_id, _plugin_data=None, _vpd83='',
-                 _disk_location=''):
+                 _disk_location='', _rpm=RPM_NO_SUPPORT,
+                 _link_type=LINK_TYPE_NO_SUPPORT):
         self._id = _id
         self._name = _name
         self._disk_type = _disk_type
@@ -242,6 +245,8 @@ class Disk(IData):
                            _vpd83)
         self._vpd83 = _vpd83
         self._disk_location = _disk_location
+        self._rpm = _rpm
+        self._link_type = _link_type
 
     @property
     def size_bytes(self):
@@ -275,6 +280,61 @@ class Disk(IData):
                            "Disk.disk_location() is not supported by this "
                            "plugin yet")
         return self._disk_location
+
+    @property
+    def rpm(self):
+        """
+        Integer. New in version 1.3.
+        Disk rotation speed - revolutions per minute(RPM):
+            -1 (LSM_DISK_RPM_UNKNOWN):
+                Unknown RPM
+             0 (LSM_DISK_RPM_NON_ROTATING_MEDIUM):
+                Non-rotating medium (e.g., SSD)
+             1 (LSM_DISK_RPM_ROTATING_UNKNOWN_SPEED):
+                Rotational disk with unknown speed
+            >1:
+                Normal rotational disk (e.g., HDD)
+        """
+        if self._rpm == Disk.RPM_NO_SUPPORT:
+            raise LsmError(ErrorNumber.NO_SUPPORT,
+                           "Disk.rpm is not supported by this plugin yet")
+        return self._rpm
+
+    @property
+    def link_type(self):
+        """
+        Integer. New in version 1.3.
+        Link type, possible values are:
+            lsm.Disk.LINK_TYPE_UNKNOWN
+                Failed to detect link type
+            lsm.Disk.LINK_TYPE_FC
+                Fibre Channel
+            lsm.Disk.LINK_TYPE_SSA
+                Serial Storage Architecture, Old IBM tech.
+            lsm.Disk.LINK_TYPE_SBP
+                Serial Bus Protocol, used by IEEE 1394.
+            lsm.Disk.LINK_TYPE_SRP
+                SCSI RDMA Protocol
+            lsm.Disk.LINK_TYPE_ISCSI
+                Internet Small Computer System Interface
+            lsm.Disk.LINK_TYPE_SAS
+                Serial Attached SCSI
+            lsm.Disk.LINK_TYPE_ADT
+                Automation/Drive Interface Transport
+                Protocol, often used by Tape.
+            lsm.Disk.LINK_TYPE_ATA
+                PATA/IDE or SATA.
+            lsm.Disk.LINK_TYPE_USB
+                USB disk.
+            lsm.Disk.LINK_TYPE_SOP
+                SCSI over PCI-E
+            lsm.Disk.LINK_TYPE_PCIE
+                PCI-E, e.g. NVMe
+        """
+        if self._link_type == Disk.LINK_TYPE_NO_SUPPORT:
+            raise LsmError(ErrorNumber.NO_SUPPORT,
+                           "Disk.link_type is not supported by this plugin yet")
+        return self._link_type
 
     def __str__(self):
         return self.name
@@ -871,6 +931,8 @@ class Capabilities(IData):
     SYS_FW_VERSION_GET = 160
     SYS_MODE_GET = 161
     DISK_LOCATION = 163
+    DISK_RPM = 164
+    DISK_LINK_TYPE = 165
     VOLUME_LED = 171
 
     POOLS_QUICK_SEARCH = 210

--- a/python_binding/lsm/_local_disk.py
+++ b/python_binding/lsm/_local_disk.py
@@ -14,7 +14,8 @@
 #
 # Author: Gris Ge <fge@redhat.com>
 
-from lsm._clib import (_local_disk_vpd83_search, _local_disk_vpd83_get)
+from lsm._clib import (_local_disk_vpd83_search, _local_disk_vpd83_get,
+                       _local_disk_rpm_get)
 from lsm import LsmError, ErrorNumber
 
 
@@ -26,6 +27,7 @@ def _use_c_lib_function(func_ref, arg):
 
 
 class LocalDisk(object):
+
     @staticmethod
     def vpd83_search(vpd83):
         """
@@ -85,3 +87,42 @@ class LocalDisk(object):
                 No capability required as this is a library level method.
         """
         return _use_c_lib_function(_local_disk_vpd83_get, disk_path)
+
+    @staticmethod
+    def rpm_get(disk_path):
+        """
+        Version:
+            1.3
+        Usage:
+            Query the disk rotation speed - revolutions per minute (RPM) of
+            given disk path.
+            Require permission to open disk path as read-only and non-block,
+            normally it's root or disk group privilege.
+        Parameters:
+            disk_path (string)
+                The disk path, example '/dev/sdb', '/dev/nvme0n1'.
+        Returns:
+            rpm (integer)
+                Disk rotation speed:
+                    -1 (lsm.Disk.RPM_UNKNOWN):
+                        Unknown RPM
+                     0 (lsm.Disk.RPM_NON_ROTATING_MEDIUM):
+                        Non-rotating medium (e.g., SSD)
+                     1 (lsm.Disk.RPM_ROTATING_UNKNOWN_SPEED):
+                        Rotational disk with unknown speed
+                    >1:
+                        Normal rotational disk (e.g., HDD)
+
+        SpecialExceptions:
+            LsmError
+                ErrorNumber.LIB_BUG
+                    Internal bug.
+                ErrorNumber.INVALID_ARGUMENT
+                    Invalid disk_path. Should be like '/dev/sdb'.
+                ErrorNumber.NOT_FOUND_DISK
+                    Provided disk is not found.
+        Capability:
+            N/A
+                No capability required as this is a library level method.
+        """
+        return _use_c_lib_function(_local_disk_rpm_get, disk_path)

--- a/python_binding/lsm/_local_disk.py
+++ b/python_binding/lsm/_local_disk.py
@@ -15,7 +15,8 @@
 # Author: Gris Ge <fge@redhat.com>
 
 from lsm._clib import (_local_disk_vpd83_search, _local_disk_vpd83_get,
-                       _local_disk_rpm_get, _local_disk_list)
+                       _local_disk_rpm_get, _local_disk_list,
+                       _local_disk_link_type_get)
 from lsm import LsmError, ErrorNumber
 
 
@@ -158,3 +159,62 @@ class LocalDisk(object):
         if err_no != ErrorNumber.OK:
             raise LsmError(err_no, err_msg)
         return disk_paths
+
+    @staticmethod
+    def link_type_get(disk_path):
+        """
+        Version:
+            1.3
+        Usage:
+            Query the disk link type of given disk path.
+            For SATA disks connected to SAS enclosure, will return
+            lsm.SCSI.LINK_TYPE_ATA.
+            Require permission to open disk_path(root user or disk group).
+        Parameters:
+            disk_path (string)
+                The disk path, example '/dev/sdb'.
+        Returns:
+            link_type (integer)
+                Link type, possible values are:
+                    lsm.Disk.LINK_TYPE_UNKNOWN
+                        Failed to detect link type
+                    lsm.Disk.LINK_TYPE_FC
+                        Fibre Channel
+                    lsm.Disk.LINK_TYPE_SSA
+                        Serial Storage Architecture, Old IBM tech.
+                    lsm.Disk.LINK_TYPE_SBP
+                        Serial Bus Protocol, used by IEEE 1394.
+                    lsm.Disk.LINK_TYPE_SRP
+                        SCSI RDMA Protocol
+                    lsm.Disk.LINK_TYPE_ISCSI
+                        Internet Small Computer System Interface
+                    lsm.Disk.LINK_TYPE_SAS
+                        Serial Attached SCSI
+                    lsm.Disk.LINK_TYPE_ADT
+                        Automation/Drive Interface Transport
+                        Protocol, often used by Tape.
+                    lsm.Disk.LINK_TYPE_ATA
+                        PATA/IDE or SATA.
+                    lsm.Disk.LINK_TYPE_USB
+                        USB disk.
+                    lsm.Disk.LINK_TYPE_SOP
+                        SCSI over PCI-E
+                    lsm.Disk.LINK_TYPE_PCIE
+                        PCI-E, e.g. NVMe
+        SpecialExceptions:
+            LsmError
+                ErrorNumber.LIB_BUG
+                    Internal bug.
+                ErrorNumber.INVALID_ARGUMENT
+                    Invalid disk_path. Should be like '/dev/sdb'.
+                ErrorNumber.NOT_FOUND_DISK
+                    Provided disk is not found.
+                ErrorNumber.NO_SUPPORT
+                    Provided disk does not support SCSI SPC.
+                ErrorNumber.PERMISSION_DENIED
+                    Insufficient permission to access provided disk path.
+        Capability:
+            N/A
+                No capability required as this is a library level method.
+        """
+        return _use_c_lib_function(_local_disk_link_type_get, disk_path)

--- a/python_binding/lsm/_local_disk.py
+++ b/python_binding/lsm/_local_disk.py
@@ -15,7 +15,7 @@
 # Author: Gris Ge <fge@redhat.com>
 
 from lsm._clib import (_local_disk_vpd83_search, _local_disk_vpd83_get,
-                       _local_disk_rpm_get)
+                       _local_disk_rpm_get, _local_disk_list)
 from lsm import LsmError, ErrorNumber
 
 
@@ -126,3 +126,35 @@ class LocalDisk(object):
                 No capability required as this is a library level method.
         """
         return _use_c_lib_function(_local_disk_rpm_get, disk_path)
+
+    @staticmethod
+    def list():
+        """
+        Version:
+            1.3
+        Usage:
+            Query local disk paths. Currently, only SCSI, ATA and NVMe disks
+            will be included.
+        Parameters:
+            N/A
+        Returns:
+            [disk_path]
+                List of string. Empty list if not disk found.
+                The disk_path string format is '/dev/sd[a-z]+' for SCSI and
+                ATA disks, '/dev/nvme[0-9]+n[0-9]+' for NVMe disks.
+        SpecialExceptions:
+            LsmError
+                ErrorNumber.LIB_BUG
+                    Internal bug.
+                ErrorNumber.INVALID_ARGUMENT
+                    Invalid disk_path. Should be like '/dev/sdb'.
+                ErrorNumber.NOT_FOUND_DISK
+                    Provided disk is not found.
+        Capability:
+            N/A
+                No capability required as this is a library level method.
+        """
+        (disk_paths, err_no, err_msg) = _local_disk_list()
+        if err_no != ErrorNumber.OK:
+            raise LsmError(err_no, err_msg)
+        return disk_paths

--- a/test/cmdtest.py
+++ b/test/cmdtest.py
@@ -811,6 +811,13 @@ def volume_ident_led_clear_test(cap):
 
     return
 
+def local_disk_list_test():
+    # Only run this by root user.
+    if os.geteuid() == 0:
+        call([cmd, 'local-disk-list'])
+    else:
+        print("Skipping test of 'local-disk-list' command when not "
+              "run by root user")
 
 def run_all_tests(cap, system_id):
 
@@ -830,6 +837,8 @@ def run_all_tests(cap, system_id):
     pool_member_info_test(cap, system_id)
 
     volume_raid_create_test(cap, system_id)
+
+    local_disk_list_test()
 
 if __name__ == "__main__":
     parser = OptionParser()

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -484,6 +484,8 @@ class TestPlugin(unittest.TestCase):
                 if supported(cap, [Cap.DISK_VPD83_GET]):
                     try:
                         list(disk.vpd83 for disk in disks)
+                        list(disk.rpm for disk in disks)
+                        list(disk.link_type for disk in disks)
                     except LsmError as lsm_err:
                         if lsm_err.code != ErrorNumber.NO_SUPPORT:
                             raise

--- a/test/tester.c
+++ b/test/tester.c
@@ -3451,6 +3451,45 @@ START_TEST(test_local_disk_rpm_get)
 }
 END_TEST
 
+START_TEST(test_local_disk_link_type)
+{
+    int rc = 0;
+    lsm_disk_link_type link_type = LSM_DISK_LINK_TYPE_UNKNOWN;
+    lsm_error *lsm_err = NULL;
+
+    rc = lsm_local_disk_link_type_get("/dev/sda", &link_type,  &lsm_err);
+    if (lsm_err != NULL)
+        fail_unless(rc != LSM_ERR_LIB_BUG,
+                    "lsm_local_disk_link_type_get() got LSM_ERR_LIB_BUG: %s",
+                    lsm_error_message_get(lsm_err));
+    else
+        fail_unless(rc != LSM_ERR_LIB_BUG,
+                    "lsm_local_disk_link_type_get() got LSM_ERR_LIB_BUG with "
+                    "NULL lsm_err");
+
+    if (rc != LSM_ERR_OK)
+        lsm_error_free(lsm_err);
+
+    /* Test non-exist disk */
+    rc = lsm_local_disk_link_type_get(NOT_EXIST_SD_PATH, &link_type, &lsm_err);
+    fail_unless(rc == LSM_ERR_NOT_FOUND_DISK,
+                "lsm_local_disk_link_type_get(): "
+                "Expecting LSM_ERR_NOT_FOUND_DISK error with "
+                "non-exist disk_path");
+    fail_unless(lsm_err != NULL, "lsm_local_disk_link_type_get(): "
+                "Expecting lsm_err not NULL with non-exist disk_path");
+    fail_unless(lsm_error_number_get(lsm_err) == LSM_ERR_NOT_FOUND_DISK,
+                "lsm_local_disk_link_type_get(): "
+                "Expecting error number of lsm_err been set as "
+                "LSM_ERR_NOT_FOUND_DISK with non-exist disk_path");
+    fail_unless(lsm_error_message_get(lsm_err) != NULL,
+                "lsm_local_disk_link_type_get(): "
+                "Expecting error message of lsm_err not NULL "
+                "with non-exist disk_path");
+    lsm_error_free(lsm_err);
+}
+END_TEST
+
 Suite * lsm_suite(void)
 {
     Suite *s = suite_create("libStorageMgmt");

--- a/test/tester.c
+++ b/test/tester.c
@@ -1106,6 +1106,52 @@ START_TEST(test_disks)
 }
 END_TEST
 
+START_TEST(test_disk_rpm_and_link_type)
+{
+    uint32_t count = 0;
+    lsm_disk **disks = NULL;
+    int i = 0;
+    int rc = LSM_ERR_OK;
+    int32_t rpm = LSM_DISK_RPM_UNKNOWN;
+    lsm_disk_link_type link_type = LSM_DISK_LINK_TYPE_UNKNOWN;
+
+    fail_unless(c != NULL);
+
+    rc = lsm_disk_list(c, NULL, NULL, &disks, &count, 0);
+    fail_unless(LSM_ERR_OK == rc, "rc: %d", rc);
+
+    if (LSM_ERR_OK == rc) {
+        fail_unless(count >= 1);
+
+        for (; i < count; ++i) {
+            rpm = lsm_disk_rpm_get(disks[i]);
+            fail_unless(rpm != LSM_DISK_RPM_UNKNOWN,
+                        "Should not be LSM_DISK_RPM_UNKNOWN when input disk "
+                        "is valid", rc);
+
+            link_type = lsm_disk_link_type_get(disks[i]);
+            fail_unless(link_type != LSM_DISK_LINK_TYPE_UNKNOWN,
+                        "Should not be LSM_DISK_LINK_TYPE_UNKNOWN when input "
+                        "disk is valid", rc);
+        }
+
+        rpm = lsm_disk_rpm_get(NULL);
+        fail_unless(rpm == LSM_DISK_RPM_UNKNOWN,
+                    "Should be LSM_DISK_RPM_UNKNOWN when input disk is NULL",
+                    rc);
+        link_type = lsm_disk_link_type_get(NULL);
+        fail_unless(rpm == LSM_DISK_LINK_TYPE_UNKNOWN,
+                    "Should be LSM_DISK_LINK_TYPE_UNKNOWN when input disk is "
+                    "NULL", rc);
+
+        lsm_disk_record_array_free(disks, count);
+    } else {
+        fail_unless(disks == NULL);
+        fail_unless(count == 0);
+    }
+}
+END_TEST
+
 START_TEST(test_disk_location)
 {
     uint32_t count = 0;
@@ -3513,6 +3559,7 @@ Suite * lsm_suite(void)
     tcase_add_test(basic, test_nfs_export_funcs);
     tcase_add_test(basic, test_disks);
     tcase_add_test(basic, test_disk_location);
+    tcase_add_test(basic, test_disk_rpm_and_link_type);
     tcase_add_test(basic, test_plugin_info);
     tcase_add_test(basic, test_system_fw_version);
     tcase_add_test(basic, test_system_mode);

--- a/test/tester.c
+++ b/test/tester.c
@@ -3282,6 +3282,28 @@ START_TEST(test_volume_ident_led_clear)
 }
 END_TEST
 
+/*
+ * lsm_local_disk_list() should never fail.
+ */
+START_TEST(test_local_disk_list)
+{
+    int rc = LSM_ERR_OK;
+    lsm_string_list *disk_paths = NULL;
+    /* Not initialized in order to test dangling pointer disk_path_list */
+    lsm_error *lsm_err = NULL;
+
+    if (is_simc_plugin == 1){
+        /* silently skip on simc, no need for duplicate test. */
+        return;
+    }
+
+    rc = lsm_local_disk_list(&disk_paths, &lsm_err);
+    fail_unless(rc == LSM_ERR_OK, "lsm_local_disk_list() failed as %d", rc);
+    fail_unless(disk_paths != NULL, "lsm_local_disk_list() return NULL for "
+                "disk_paths");
+    lsm_string_list_free(disk_paths);
+}
+END_TEST
 
 /*
  * Just check whether LSM_ERR_INVALID_ARGUMENT handle correctly.
@@ -3585,7 +3607,7 @@ Suite * lsm_suite(void)
     tcase_add_test(basic, test_local_disk_vpd83_search);
     tcase_add_test(basic, test_local_disk_vpd83_get);
     tcase_add_test(basic, test_read_cache_pct_update);
-
+    tcase_add_test(basic, test_local_disk_list);
     tcase_add_test(basic, test_local_disk_rpm_get);
 
     suite_add_tcase(s, basic);

--- a/test/tester.c
+++ b/test/tester.c
@@ -3415,6 +3415,42 @@ START_TEST(test_local_disk_vpd83_get)
 }
 END_TEST
 
+START_TEST(test_local_disk_rpm_get)
+{
+    int rc = 0;
+    int32_t rpm = LSM_DISK_RPM_UNKNOWN;
+    lsm_error *lsm_err = NULL;
+
+    rc = lsm_local_disk_rpm_get("/dev/sda", &rpm,  &lsm_err);
+    if (rc == LSM_ERR_OK) {
+        fail_unless(rpm != LSM_DISK_RPM_UNKNOWN,
+                    "lsm_local_disk_rpm_get(): "
+                    "Expecting rpm not been LSM_DISK_RPM_UNKNOWN "
+                    "when rc == LSM_ERR_OK");
+    } else {
+        lsm_error_free(lsm_err);
+    }
+
+    /* Test non-exist disk */
+    rc = lsm_local_disk_rpm_get(NOT_EXIST_SD_PATH, &rpm,  &lsm_err);
+    fail_unless(rc == LSM_ERR_NOT_FOUND_DISK, "lsm_local_disk_rpm_get(): "
+                "Expecting LSM_ERR_NOT_FOUND_DISK error with "
+                "non-exist sd_path");
+    fail_unless(lsm_err != NULL, "lsm_local_disk_rpm_get(): "
+                "Expecting lsm_err not NULL with non-exist sd_path");
+    fail_unless(lsm_error_number_get(lsm_err) == LSM_ERR_NOT_FOUND_DISK,
+                "lsm_local_disk_rpm_get(): "
+                "Expecting error number of lsm_err been set as "
+                "LSM_ERR_NOT_FOUND_DISK with non-exist sd_path");
+    fail_unless(lsm_error_message_get(lsm_err) != NULL,
+                "lsm_local_disk_rpm_get(): "
+                "Expecting error message of lsm_err not NULL "
+                "with non-exist sd_path");
+    lsm_error_free(lsm_err);
+
+}
+END_TEST
+
 Suite * lsm_suite(void)
 {
     Suite *s = suite_create("libStorageMgmt");
@@ -3464,6 +3500,7 @@ Suite * lsm_suite(void)
     tcase_add_test(basic, test_local_disk_vpd83_get);
     tcase_add_test(basic, test_read_cache_pct_update);
 
+    tcase_add_test(basic, test_local_disk_rpm_get);
 
     suite_add_tcase(s, basic);
     return s;

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -1674,7 +1674,8 @@ class CmdLine:
                 vpd83 = ""
 
             rpm = LocalDisk.rpm_get(disk_path)
+            link_type = LocalDisk.link_type_get(disk_path)
             local_disks.append(
-                LocalDiskInfo(disk_path, vpd83, rpm))
+                LocalDiskInfo(disk_path, vpd83, rpm, link_type))
 
         self.display_data(local_disks)

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -249,6 +249,8 @@ def tgt_port_type_to_str(port_type):
 def disk_rpm_to_str(rpm):
     if rpm == '':
         return "No Support"
+    if rpm == Disk.RPM_NO_SUPPORT:
+        return "No Support"
     if rpm == Disk.RPM_UNKNOWN:
         return "Unknown"
     if rpm == Disk.RPM_NON_ROTATING_MEDIUM:
@@ -258,7 +260,7 @@ def disk_rpm_to_str(rpm):
     return str(rpm)
 
 
-def link_type_to_str(link_type):
+def disk_link_type_to_str(link_type):
     if link_type == '':
         return "No Support"
     return _enum_type_to_str(link_type, LocalDiskInfo._LINK_TYPE_MAP)
@@ -340,6 +342,7 @@ class VcrCap(object):
 
 class LocalDiskInfo(object):
     _LINK_TYPE_MAP = {
+        Disk.LINK_TYPE_NO_SUPPORT: "No Support",
         Disk.LINK_TYPE_UNKNOWN: "Unknown",
         Disk.LINK_TYPE_FC: "FC",
         Disk.LINK_TYPE_SSA: "SSA",
@@ -488,12 +491,16 @@ class DisplayData(object):
     DISK_HEADER['system_id'] = 'System ID'
     DISK_HEADER['vpd83'] = 'SCSI VPD 0x83'
     DISK_HEADER['sd_paths'] = 'Disk Paths'    # This is appended by cmdline.py
+    DISK_HEADER['rpm'] = 'Revolutions Per Minute'
+    DISK_HEADER['link_type'] = 'Link Type'
 
     DISK_COLUMN_SKIP_KEYS = ['block_size', 'num_of_blocks']
 
     DISK_VALUE_CONV_ENUM = {
         'status': disk_status_to_str,
         'disk_type': disk_type_to_str,
+        'rpm': disk_rpm_to_str,
+        'link_type': disk_link_type_to_str,
     }
 
     DISK_VALUE_CONV_HUMAN = ['size_bytes', 'block_size']
@@ -696,7 +703,7 @@ class DisplayData(object):
 
     LOCAL_DISK_VALUE_CONV_ENUM = {
         'rpm': disk_rpm_to_str,
-        'link_type': link_type_to_str,
+        'link_type': disk_link_type_to_str,
     }
     LOCAL_DISK_VALUE_CONV_HUMAN = []
 

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -246,6 +246,18 @@ def tgt_port_type_to_str(port_type):
     return _enum_type_to_str(port_type, _TGT_PORT_TYPE_CONV)
 
 
+def disk_rpm_to_str(rpm):
+    if rpm == '':
+        return "No Support"
+    if rpm == Disk.RPM_UNKNOWN:
+        return "Unknown"
+    if rpm == Disk.RPM_NON_ROTATING_MEDIUM:
+        return "Non-Rotating Medium"
+    if rpm == Disk.RPM_ROTATING_UNKNOWN_SPEED:
+        return "Rotating Medium Unknown Speed"
+    return str(rpm)
+
+
 class PlugData(object):
     def __init__(self, description, plugin_version):
             self.desc = description
@@ -319,6 +331,12 @@ class VcrCap(object):
         self.system_id = system_id
         self.raid_types = raid_types
         self.strip_sizes = strip_sizes
+
+class LocalDiskInfo(object):
+    def __init__(self, sd_path, vpd83, rpm):
+        self.sd_path = sd_path
+        self.vpd83 = vpd83
+        self.rpm = rpm
 
 
 class DisplayData(object):
@@ -644,6 +662,25 @@ class DisplayData(object):
         'column_skip_keys': VCR_CAP_COLUMN_SKIP_KEYS,
         'value_conv_enum': VCR_CAP_VALUE_CONV_ENUM,
         'value_conv_human': VCR_CAP_VALUE_CONV_HUMAN,
+    }
+
+    LOCAL_DISK_HEADER = OrderedDict()
+    LOCAL_DISK_HEADER['sd_path'] = 'Path'
+    LOCAL_DISK_HEADER['vpd83'] = 'SCSI VPD 0x83'
+    LOCAL_DISK_HEADER['rpm'] = 'Revolutions Per Minute'
+
+    LOCAL_DISK_COLUMN_SKIP_KEYS = []
+
+    LOCAL_DISK_VALUE_CONV_ENUM = {
+        'rpm': disk_rpm_to_str,
+    }
+    LOCAL_DISK_VALUE_CONV_HUMAN = []
+
+    VALUE_CONVERT[LocalDiskInfo] = {
+        'headers': LOCAL_DISK_HEADER,
+        'column_skip_keys': LOCAL_DISK_COLUMN_SKIP_KEYS,
+        'value_conv_enum': LOCAL_DISK_VALUE_CONV_ENUM,
+        'value_conv_human': LOCAL_DISK_VALUE_CONV_HUMAN,
     }
 
     @staticmethod

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -25,7 +25,7 @@ from datetime import datetime
 
 from lsm import (size_bytes_2_size_human, LsmError, ErrorNumber,
                  System, Pool, Disk, Volume, AccessGroup,
-                 FileSystem, FsSnapshot, NfsExport, TargetPort)
+                 FileSystem, FsSnapshot, NfsExport, TargetPort, LocalDisk)
 
 BIT_MAP_STRING_SPLITTER = ','
 
@@ -258,6 +258,12 @@ def disk_rpm_to_str(rpm):
     return str(rpm)
 
 
+def link_type_to_str(link_type):
+    if link_type == '':
+        return "No Support"
+    return _enum_type_to_str(link_type, LocalDiskInfo._LINK_TYPE_MAP)
+
+
 class PlugData(object):
     def __init__(self, description, plugin_version):
             self.desc = description
@@ -333,10 +339,26 @@ class VcrCap(object):
         self.strip_sizes = strip_sizes
 
 class LocalDiskInfo(object):
-    def __init__(self, sd_path, vpd83, rpm):
+    _LINK_TYPE_MAP = {
+        Disk.LINK_TYPE_UNKNOWN: "Unknown",
+        Disk.LINK_TYPE_FC: "FC",
+        Disk.LINK_TYPE_SSA: "SSA",
+        Disk.LINK_TYPE_SBP: "SBP",
+        Disk.LINK_TYPE_SRP: "SRP",
+        Disk.LINK_TYPE_ISCSI: "iSCSI",
+        Disk.LINK_TYPE_SAS: "SAS",
+        Disk.LINK_TYPE_ADT: "ADT",
+        Disk.LINK_TYPE_ATA: "PATA/SATA",
+        Disk.LINK_TYPE_USB: "USB",
+        Disk.LINK_TYPE_SOP: "SCSI over PCIE",
+        Disk.LINK_TYPE_PCIE: "PCI-E",
+    }
+
+    def __init__(self, sd_path, vpd83, rpm, link_type):
         self.sd_path = sd_path
         self.vpd83 = vpd83
         self.rpm = rpm
+        self.link_type = link_type
 
 
 class DisplayData(object):
@@ -668,11 +690,13 @@ class DisplayData(object):
     LOCAL_DISK_HEADER['sd_path'] = 'Path'
     LOCAL_DISK_HEADER['vpd83'] = 'SCSI VPD 0x83'
     LOCAL_DISK_HEADER['rpm'] = 'Revolutions Per Minute'
+    LOCAL_DISK_HEADER['link_type'] = 'Link Type'
 
     LOCAL_DISK_COLUMN_SKIP_KEYS = []
 
     LOCAL_DISK_VALUE_CONV_ENUM = {
         'rpm': disk_rpm_to_str,
+        'link_type': link_type_to_str,
     }
     LOCAL_DISK_VALUE_CONV_HUMAN = []
 


### PR DESCRIPTION
Hightlights:

 * ~~Query local disk rotation speed -- `lsm_scsi_rpm_of_disk_path()`.~~
 * Query local disk rotation speed -- `lsm_local_disk_rpm_get()`.
 * ~~Query local disk link type -- `lsm_scsi_link_type_of_disk_path()`.~~
 * Query local disk link type -- `lsm_local_disk_link_type_get()`.
 * ~~Use macro _wrapper() to remove duplicate code in `_scsi_clib.c`.~~ Already in master.
 * ~~New lsmcli command -- `lsmcli lsd` to list all local scsi disks.~~
 * New lsmcli command -- `lsmcli ldl` to list all local scsi disks.

FAQ:
 * Why not use udev for RPM which does not need root privilege?

   Udev does not support SAS disk RPM query yet.
   Should we create a patch to udev or use this SCSI standard way?

 * Why need root privilege?

   Required by SGIO IOCTL. 
   If kernel could expose more VPD pages (like 0xb1and 0x00) via sysfs like they do for VPD 0x83, 
   we don't need to do SGIO any more.

 * Why create your own SGIO function instead of using libsgutils2?

    IMHO, libsgutils2 is too heavy for our simple use here and SGIO is not that complex.