### PR TITLE
API rename: lsm_scsi_xxx to lsm_local_disk_xxx

### DIFF
--- a/c_binding/Makefile.am
+++ b/c_binding/Makefile.am
@@ -14,4 +14,4 @@ libstoragemgmt_la_LDFLAGS= -version-info $(LIBSM_LIBTOOL_VERSION)
 libstoragemgmt_la_SOURCES= \
 	lsm_mgmt.cpp lsm_datatypes.hpp lsm_datatypes.cpp lsm_convert.hpp \
 	lsm_convert.cpp lsm_ipc.hpp lsm_ipc.cpp lsm_plugin_ipc.hpp \
-	lsm_plugin_ipc.cpp util/qparams.c util/qparams.h lsm_scsi.c
+	lsm_plugin_ipc.cpp util/qparams.c util/qparams.h lsm_local_disk.c

--- a/c_binding/include/libstoragemgmt/Makefile.am
+++ b/c_binding/include/libstoragemgmt/Makefile.am
@@ -23,7 +23,7 @@ lsminc_HEADERS =			\
    libstoragemgmt_targetport.h          \
    libstoragemgmt_types.h		\
    libstoragemgmt_version.h             \
-   libstoragemgmt_scsi.h		\
+   libstoragemgmt_local_disk.h		\
    libstoragemgmt_volumes.h
 
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt.h
@@ -34,7 +34,7 @@
 #include "libstoragemgmt_systems.h"
 #include "libstoragemgmt_targetport.h"
 #include "libstoragemgmt_volumes.h"
-#include "libstoragemgmt_scsi.h"
+#include "libstoragemgmt_local_disk.h"
 
 
 /*! \mainpage libStorageMgmt

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_disk.h
@@ -115,7 +115,7 @@ const char LSM_DLL_EXPORT *lsm_disk_system_id_get(lsm_disk *d);
 /**
  * News in version 1.3. Only available for direct attached storage system.
  * Returns the SCSI VPD83 NAA ID of disk. The VPD83 NAA ID could be used in
- * 'lsm_scsi_disk_paths_of_vpd83()' when physical disk is exposed to OS directly
+ * 'lsm_local_disk_vpd83_search()' when physical disk is exposed to OS directly
  * (also known as system HBA mode). Please be advised the capability
  * LSM_CAP_DISK_VPD83_GET only means plugin could query VPD83 for HBA mode disk,
  * for those physical disks acting as RAID member, plugin might return NULL as

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef LIBSTORAGEMGMT_SCSI_H
-#define LIBSTORAGEMGMT_SCSI_H
+#ifndef LIBSTORAGEMGMT_LOCAL_DISK_H
+#define LIBSTORAGEMGMT_LOCAL_DISK_H
 
 #include "libstoragemgmt_common.h"
 
@@ -27,32 +27,34 @@ extern "C" {
 #endif
 
 /**
- * Find out the scsi disk paths of given SCSI VPD page 0x83 NAA ID.
+ * Search all the disk paths of given SCSI VPD 0x83 page NAA type ID.
+ * For any ATA and other non-SCSI protocol disks supporting VPD 0x83 pages NAA
+ * ID, their disk path will also be included.
  * New in version 1.3.
- * @param[in] vpd83 String. The VPD83 ID retrieved from LSM volume or disk.
- *                  for supported strip sizes.
- * @param[out] sd_path_list
- *                  Output pointer of lsm_string_list. The format of scsi
- *                  disk path will be "/dev/sd[a-z]+".
+ * @param[in] vpd83
+ *                  String. The SCSI VPD 0x83 page NAA type ID.
+ * @param[out] disk_path_list
+ *                  Output pointer of lsm_string_list. The format of
+ *                  disk path will be like "/dev/sdb" for SCSI or ATA disk.
  *                  NULL if no found or got error.
  *                  Memory should be freed by lsm_string_list_free().
  * @param[out] lsm_err
  *                  Output pointer of lsm_error. Error message could be
  *                  retrieved via lsm_error_message_get(). Memory should be
  *                  freed by lsm_error_free().
- * @return LSM_ERR_OK                   on success.
+ * @return LSM_ERR_OK                   on success or not found.
  *         LSM_ERR_INVALID_ARGUMENT     when any argument is NULL.
  *         LSM_ERR_NO_MEMORY            when no memory.
  *         LSM_ERR_LIB_BUG              when something unexpected happens.
  */
-int LSM_DLL_EXPORT lsm_scsi_disk_paths_of_vpd83(const char *vpd83,
-                                                lsm_string_list **sd_path_list,
-                                                lsm_error **lsm_err);
+int LSM_DLL_EXPORT lsm_local_disk_vpd83_search(const char *vpd83,
+                                               lsm_string_list **disk_path_list,
+                                               lsm_error **lsm_err);
 
 /**
- * Query the SCSI VPD83 NAA ID of given SCSI disk path.
+ * Query the SCSI VPD 0x83 page NAA type ID of given disk path.
  * New in version 1.3.
- * @param[in]  sd_path  String. The path of SCSI disk, example "/dev/sdb".
+ * @param[in]  sd_path  String. The path of disk path, example "/dev/sdb".
  * @param[out] vpd83    Output pointer of SCSI VPD83 NAA ID. The format is:
  *                          (?:^6[0-9a-f]{31})|(?:^[235][0-9a-f]{15})$
  *                      NULL when error. Memory should be freed by free().
@@ -67,11 +69,11 @@ int LSM_DLL_EXPORT lsm_scsi_disk_paths_of_vpd83(const char *vpd83,
  *         LSM_ERR_LIB_BUG              when something unexpected happens.
  *         LSM_ERR_NOT_FOUND_DISK       When provided disk path not found.
  */
-int LSM_DLL_EXPORT lsm_scsi_vpd83_of_disk_path(const char *sd_path,
-                                               const char **vpd83,
-                                               lsm_error **lsm_err);
+int LSM_DLL_EXPORT lsm_local_disk_vpd83_get(const char *sd_path,
+                                            const char **vpd83,
+                                            lsm_error **lsm_err);
 
 #ifdef __cplusplus
 }
 #endif
-#endif                          /* LIBSTORAGEMGMT_SCSI_H */
+#endif                          /* LIBSTORAGEMGMT_LOCAL_DISK_H */

--- a/c_binding/lsm_scsi.c
+++ b/c_binding/lsm_scsi.c
@@ -116,6 +116,13 @@ struct t10_vpd83_naa_header {
         (d = lsm_string_list_elem_get(l, i)); \
         ++i)
 
+#define _good(rc, rc_val, out) \
+        do { \
+                rc_val = rc; \
+                if (rc_val != LSM_ERR_OK) \
+                        goto out; \
+        } while(0)
+
 /*
  * All the 'err_msg' used in these static functions are expected to be
  * pointer of char[_LSM_ERR_MSG_LEN].
@@ -297,13 +304,11 @@ static int _sysfs_vpd83_naa_of_sd_name(char *err_msg, const char *sd_name,
         goto out;
     }
 
-    rc = _sysfs_vpd_pg83_data_get(err_msg, sd_name, vpd_data, &read_size);
-    if (rc != LSM_ERR_OK)
-        goto out;
+    _good(_sysfs_vpd_pg83_data_get(err_msg, sd_name, vpd_data, &read_size),
+          rc, out);
 
-    rc = _parse_vpd_83(err_msg, vpd_data, read_size, &dps, &dp_count);
-    if (rc != LSM_ERR_OK)
-        goto out;
+    _good(_parse_vpd_83(err_msg, vpd_data, read_size, &dps, &dp_count),
+          rc, out);
 
     for (; i < dp_count; ++i) {
         if ((dps[i]->header.designator_type ==
@@ -620,9 +625,7 @@ int lsm_scsi_disk_paths_of_vpd83(const char *vpd83,
         goto out;
     }
 
-    rc = _sysfs_get_all_sd_names(err_msg, &sd_name_list);
-    if (rc != LSM_ERR_OK)
-        goto out;
+    _good(_sysfs_get_all_sd_names(err_msg, &sd_name_list), rc, out);
 
     _lsm_string_list_foreach(sd_name_list, i, sd_name) {
         if (sd_name == NULL)

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -556,7 +556,7 @@ fi
 %{python_sitelib}/lsm/external/*
 %{python_sitelib}/lsm/_client.*
 %{python_sitelib}/lsm/_common.*
-%{python_sitelib}/lsm/_scsi.*
+%{python_sitelib}/lsm/_local_disk.*
 %{python_sitelib}/lsm/_data.*
 %{python_sitelib}/lsm/_iplugin.*
 %{python_sitelib}/lsm/_pluginrunner.*
@@ -577,7 +577,7 @@ fi
 %{_mandir}/man1/sim_lsmplugin.1*
 
 %files -n %{libstoragemgmt}-python-clibs
-%{python_sitelib}/lsm/_scsi_clib.*
+%{python_sitelib}/lsm/_clib.*
 
 %files -n %{libstoragemgmt}-smis-plugin
 %defattr(-,root,root,-)

--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -23,7 +23,7 @@ import re
 from lsm import (
     IPlugin, Client, Capabilities, VERSION, LsmError, ErrorNumber, uri_parse,
     System, Pool, size_human_2_size_bytes, search_property, Volume, Disk,
-    SCSI)
+    LocalDisk)
 
 from lsm.plugin.hpsa.utils import cmd_exec, ExecError, file_read
 
@@ -530,7 +530,7 @@ class SmartArray(IPlugin):
         blk_count = int(_hp_size_to_lsm(hp_disk['Size']) / blk_size)
         status = _disk_status_of(hp_disk, flag_free)
         plugin_data = "%s:%s" % (ctrl_num, disk_num)
-        vpd83 = SCSI.vpd83_of_disk_path(hp_disk.get('Disk Name', ''))
+        vpd83 = LocalDisk.vpd83_get(hp_disk.get('Disk Name', ''))
 
         return Disk(
             disk_id, disk_name, disk_type, blk_size, blk_count,

--- a/python_binding/Makefile.am
+++ b/python_binding/Makefile.am
@@ -10,18 +10,18 @@ lsm_PYTHON = \
 	lsm/_transport.py \
 	lsm/version.py \
 	lsm/_iplugin.py \
-	lsm/_scsi.py \
+	lsm/_local_disk.py \
 	lsm/_pluginrunner.py
 
-pyexec_LTLIBRARIES = lsm/_scsi_clib.la
+pyexec_LTLIBRARIES = lsm/_clib.la
 pyexecdir = $(pythondir)/lsm
 
-lsm__scsi_clib_la_CFLAGS = $(PYTHON2_CFLAGS) -I$(top_srcdir)/c_binding/include
-lsm__scsi_clib_la_SOURCES = lsm/_scsi_clib.c
-lsm__scsi_clib_la_LDFLAGS = $(PYTHON2_LIBS) \
+lsm__clib_la_CFLAGS = $(PYTHON2_CFLAGS) -I$(top_srcdir)/c_binding/include
+lsm__clib_la_SOURCES = lsm/_clib.c
+lsm__clib_la_LDFLAGS = $(PYTHON2_LIBS) \
 		       -module -avoid-version -export-symbols-regex \
-		       init_scsi_clib
-lsm__scsi_clib_la_LIBADD = $(top_builddir)/c_binding/libstoragemgmt.la
+		       init_clib
+lsm__clib_la_LIBADD = $(top_builddir)/c_binding/libstoragemgmt.la
 
 external_PYTHON = \
 	lsm/external/__init__.py \

--- a/python_binding/lsm/__init__.py
+++ b/python_binding/lsm/__init__.py
@@ -6,7 +6,7 @@ from _common import error, info, LsmError, ErrorNumber, \
     JobStatus, uri_parse, md5, Proxy, size_bytes_2_size_human, \
     common_urllib2_error_handler, size_human_2_size_bytes
 
-from lsm._scsi import SCSI
+from lsm._local_disk import LocalDisk
 
 from _data import (Disk, Volume, Pool, System, FileSystem, FsSnapshot,
                    NfsExport, BlockRange, AccessGroup, TargetPort,

--- a/python_binding/lsm/_clib.c
+++ b/python_binding/lsm/_clib.c
@@ -77,7 +77,7 @@ static PyObject *func_name(PyObject *self, PyObject *args, PyObject *kwargs) \
     return rc_list; \
 }
 
-static const char disk_paths_of_vpd83_docstring[] =
+static const char local_disk_vpd83_search_docstring[] =
     "INTERNAL USE ONLY!\n"
     "\n"
     "Usage:\n"
@@ -96,11 +96,11 @@ static const char disk_paths_of_vpd83_docstring[] =
     "        err_msg (string)\n"
     "            Error message, empty if no error.\n";
 
-static const char vpd83_of_disk_path_docstring[] =
+static const char local_disk_vpd83_get_docstring[] =
     "INTERNAL USE ONLY!\n"
     "\n"
     "Usage:\n"
-    "    Query the SCSI VPD83 NAA ID of given scsi disk path\n"
+    "    Query the SCSI VPD83 NAA ID of given disk path\n"
     "Parameters:\n"
     "    sd_path (string)\n"
     "        The SCSI disk path, example '/dev/sdb'. Empty string is failure\n"
@@ -115,18 +115,18 @@ static const char vpd83_of_disk_path_docstring[] =
     "        err_msg (string)\n"
     "            Error message, empty if no error.\n";
 
-static PyObject *disk_paths_of_vpd83(PyObject *self, PyObject *args,
+static PyObject *local_disk_vpd83_search(PyObject *self, PyObject *args,
                                      PyObject *kwargs);
-static PyObject *vpd83_of_disk_path(PyObject *self, PyObject *args,
+static PyObject *local_disk_vpd83_get(PyObject *self, PyObject *args,
                                     PyObject *kwargs);
 static PyObject *_lsm_string_list_to_pylist(lsm_string_list *str_list);
 static PyObject *_c_str_to_py_str(const char *str);
 
-static PyMethodDef _scsi_methods[] = {
-    {"_disk_paths_of_vpd83",  (PyCFunction) disk_paths_of_vpd83,
-     METH_VARARGS | METH_KEYWORDS, disk_paths_of_vpd83_docstring},
-    {"_vpd83_of_disk_path",  (PyCFunction) vpd83_of_disk_path,
-     METH_VARARGS | METH_KEYWORDS, vpd83_of_disk_path_docstring},
+static PyMethodDef _methods[] = {
+    {"_local_disk_vpd83_search",  (PyCFunction) local_disk_vpd83_search,
+     METH_VARARGS | METH_KEYWORDS, local_disk_vpd83_search_docstring},
+    {"_local_disk_vpd83_get",  (PyCFunction) local_disk_vpd83_get,
+     METH_VARARGS | METH_KEYWORDS, local_disk_vpd83_get_docstring},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 
@@ -168,14 +168,14 @@ static PyObject *_c_str_to_py_str(const char *str)
     return PyString_FromString(str);
 }
 
-_wrapper(disk_paths_of_vpd83, lsm_scsi_disk_paths_of_vpd83,
+_wrapper(local_disk_vpd83_search, lsm_local_disk_vpd83_search,
          const char *, vpd83, lsm_string_list *, NULL,
          _lsm_string_list_to_pylist);
-_wrapper(vpd83_of_disk_path, lsm_scsi_vpd83_of_disk_path,
+_wrapper(local_disk_vpd83_get, lsm_local_disk_vpd83_get,
          const char *, disk_path, const char *, NULL,
          _c_str_to_py_str);
 
-PyMODINIT_FUNC init_scsi_clib(void)
+PyMODINIT_FUNC init_clib(void)
 {
-        (void) Py_InitModule("_scsi_clib", _scsi_methods);
+        (void) Py_InitModule("_clib", _methods);
 }

--- a/python_binding/lsm/_local_disk.py
+++ b/python_binding/lsm/_local_disk.py
@@ -14,7 +14,7 @@
 #
 # Author: Gris Ge <fge@redhat.com>
 
-from lsm._scsi_clib import (_vpd83_of_disk_path, _disk_paths_of_vpd83)
+from lsm._clib import (_local_disk_vpd83_search, _local_disk_vpd83_get)
 from lsm import LsmError, ErrorNumber
 
 
@@ -25,16 +25,16 @@ def _use_c_lib_function(func_ref, arg):
     return data
 
 
-class SCSI(object):
+class LocalDisk(object):
     @staticmethod
-    def disk_paths_of_vpd83(vpd83):
+    def vpd83_search(vpd83):
         """
-        lsm.SCSI.disk_paths_of_vpd83(vpd83)
+        lsm.LocalDisk.vpd83_search(vpd83)
 
         Version:
             1.3
         Usage:
-            Find out the /dev/sdX paths for given SCSI VPD page 0x83 NAA type
+            Find out the disk paths for given SCSI VPD page 0x83 NAA type
             ID. Considering multipath, certain VPD83 might have multiple disks
             associated.
         Parameters:
@@ -43,7 +43,8 @@ class SCSI(object):
         Returns:
             [disk_path]
                 List of string. Empty list if not disk found.
-                The disk_path string format is '/dev/sd[a-z]+'.
+                The disk_path string format is '/dev/sd[a-z]+' for SCSI and
+                ATA disks.
         SpecialExceptions:
             LsmError
                 ErrorNumber.LIB_BUG
@@ -52,20 +53,20 @@ class SCSI(object):
             N/A
                 No capability required as this is a library level method.
         """
-        return _use_c_lib_function(_disk_paths_of_vpd83, vpd83)
+        return _use_c_lib_function(_local_disk_vpd83_search, vpd83)
 
     @staticmethod
-    def vpd83_of_disk_path(disk_path):
+    def vpd83_get(disk_path):
         """
-        lsm.SCSI.vpd83_of_disk_path(disk_path)
+        lsm.LocalDisk.vpd83_get(disk_path)
 
         Version:
             1.3
         Usage:
-            Query the SCSI VPD83 NAA ID of given scsi disk path.
+            Query the SCSI VPD83 NAA ID of given disk path.
         Parameters:
-            sd_path (string)
-                The SCSI disk path, example '/dev/sdb'.
+            disk_path (string)
+                The disk path, example '/dev/sdb'.
         Returns:
             vpd83 (string)
                 String of VPD83 NAA ID. Empty string if not supported.
@@ -83,4 +84,4 @@ class SCSI(object):
             N/A
                 No capability required as this is a library level method.
         """
-        return _use_c_lib_function(_vpd83_of_disk_path, disk_path)
+        return _use_c_lib_function(_local_disk_vpd83_get, disk_path)

--- a/test/test_include.sh
+++ b/test/test_include.sh
@@ -224,9 +224,9 @@ function lsm_test_base_install
 
     # libtool 'install' mode does not works against python C extension,
     # use manual copy instead
-    _good cp "${build_dir}/python_binding/lsm/.libs/_scsi_clib.so" \
-        "${LSM_TEST_PY_MODULE_DIR}/lsm/_scsi_clib.so"
-    _good chrpath -d "${LSM_TEST_PY_MODULE_DIR}/lsm/_scsi_clib.so"
+    _good cp "${build_dir}/python_binding/lsm/.libs/_clib.so" \
+        "${LSM_TEST_PY_MODULE_DIR}/lsm/_clib.so"
+    _good chrpath -d "${LSM_TEST_PY_MODULE_DIR}/lsm/_clib.so"
 
     _good find "${src_dir}/python_binding/lsm/" -maxdepth 1 \
         -type f -name '*.py' \

--- a/test/tester.c
+++ b/test/tester.c
@@ -39,7 +39,7 @@ static int is_simc_plugin = 0;
 #define VPD83_TO_SEARCH "600508b1001c79ade5178f0626caaa9c"
 #define INVALID_VPD83 "600508b1001c79ade5178f0626caaa9c1"
 #define VALID_BUT_NOT_EXIST_VPD83 "5000000000000000"
-#define NOT_EXIST_SD_PATH "/dev/qda"
+#define NOT_EXIST_SD_PATH "/dev/sdazzzzzzzzzzz"
 
 lsm_connect *c = NULL;
 
@@ -3151,11 +3151,11 @@ END_TEST
 /*
  * Just check whether LSM_ERR_INVALID_ARGUMENT handle correctly.
  */
-START_TEST(test_scsi_disk_paths_of_vpd83)
+START_TEST(test_local_disk_vpd83_search)
 {
     int rc = LSM_ERR_OK;
-    lsm_string_list *sd_path_list;
-    /* Not initialized in order to test dangling pointer sd_path_list */
+    lsm_string_list *disk_path_list;
+    /* Not initialized in order to test dangling pointer disk_path_list */
     lsm_error *lsm_err = NULL;
 
     if (is_simc_plugin == 1){
@@ -3163,66 +3163,66 @@ START_TEST(test_scsi_disk_paths_of_vpd83)
         return;
     }
 
-    rc = lsm_scsi_disk_paths_of_vpd83(NULL, &sd_path_list, &lsm_err);
+    rc = lsm_local_disk_vpd83_search(NULL, &disk_path_list, &lsm_err);
     fail_unless(rc == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting "
+                "lsm_local_disk_vpd83_search(): Expecting "
                 "LSM_ERR_INVALID_ARGUMENT when vpd83 argument pointer is NULL");
 
-    fail_unless(sd_path_list == NULL,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting "
-                "sd_path_list been set as NULL.");
+    fail_unless(disk_path_list == NULL,
+                "lsm_local_disk_vpd83_search(): Expecting "
+                "disk_path_list been set as NULL.");
 
     fail_unless(lsm_err != NULL,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting "
+                "lsm_local_disk_vpd83_search(): Expecting "
                 "lsm_err been set as non-NULL.");
     fail_unless(lsm_error_number_get(lsm_err) == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting "
+                "lsm_local_disk_vpd83_search(): Expecting "
                 "lsm_err been set with LSM_ERR_INVALID_ARGUMENT");
     fail_unless(lsm_error_message_get(lsm_err) != NULL,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting "
+                "lsm_local_disk_vpd83_search(): Expecting "
                 "lsm_err been set with non-NULL error message");
     lsm_error_free(lsm_err);
 
 
-    rc = lsm_scsi_disk_paths_of_vpd83(VPD83_TO_SEARCH, NULL, &lsm_err);
+    rc = lsm_local_disk_vpd83_search(VPD83_TO_SEARCH, NULL, &lsm_err);
     fail_unless(rc == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting "
-                "LSM_ERR_INVALID_ARGUMENT when sd_path_list argument pointer "
+                "lsm_local_disk_vpd83_search(): Expecting "
+                "LSM_ERR_INVALID_ARGUMENT when disk_path_list argument pointer "
                 "is NULL");
     lsm_error_free(lsm_err);
 
-    rc = lsm_scsi_disk_paths_of_vpd83(VPD83_TO_SEARCH, &sd_path_list, NULL);
+    rc = lsm_local_disk_vpd83_search(VPD83_TO_SEARCH, &disk_path_list, NULL);
     fail_unless(rc == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting "
+                "lsm_local_disk_vpd83_search(): Expecting "
                 "LSM_ERR_INVALID_ARGUMENT when lsm_err argument pointer "
                 "is NULL");
 
-    rc = lsm_scsi_disk_paths_of_vpd83(INVALID_VPD83, &sd_path_list, &lsm_err);
+    rc = lsm_local_disk_vpd83_search(INVALID_VPD83, &disk_path_list, &lsm_err);
     fail_unless(lsm_err != NULL,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting lsm_err "
+                "lsm_local_disk_vpd83_search(): Expecting lsm_err "
                 "been set at not NULL when incorrect VPD83 provided");
     fail_unless(lsm_error_number_get(lsm_err) == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting "
+                "lsm_local_disk_vpd83_search(): Expecting "
                 "lsm_err been set with LSM_ERR_INVALID_ARGUMENT");
     fail_unless(lsm_error_message_get(lsm_err) != NULL,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting "
+                "lsm_local_disk_vpd83_search(): Expecting "
                 "lsm_err been set with non-NULL error message");
     fail_unless(rc == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting LSM_ERR_OK "
+                "lsm_local_disk_vpd83_search(): Expecting LSM_ERR_OK "
                 "when no argument is NULL");
     lsm_error_free(lsm_err);
 
-    rc = lsm_scsi_disk_paths_of_vpd83(VPD83_TO_SEARCH, &sd_path_list, &lsm_err);
+    rc = lsm_local_disk_vpd83_search(VPD83_TO_SEARCH, &disk_path_list, &lsm_err);
     fail_unless(rc == LSM_ERR_OK,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting LSM_ERR_OK"
+                "lsm_local_disk_vpd83_search(): Expecting LSM_ERR_OK"
                 "when no argument is NULL");
 
     fail_unless(lsm_err == NULL,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting lsm_err as NULL"
+                "lsm_local_disk_vpd83_search(): Expecting lsm_err as NULL"
                 "when valid argument provided");
 
-    if (sd_path_list != NULL)
-        lsm_string_list_free(sd_path_list);
+    if (disk_path_list != NULL)
+        lsm_string_list_free(disk_path_list);
 
     if (lsm_err != NULL)
         lsm_error_free(lsm_err);
@@ -3230,97 +3230,97 @@ START_TEST(test_scsi_disk_paths_of_vpd83)
      * keeping this line is just for code demonstration.
      */
 
-    rc = lsm_scsi_disk_paths_of_vpd83(VALID_BUT_NOT_EXIST_VPD83, &sd_path_list,
+    rc = lsm_local_disk_vpd83_search(VALID_BUT_NOT_EXIST_VPD83, &disk_path_list,
                                       &lsm_err);
     fail_unless(rc == LSM_ERR_OK,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting LSM_ERR_OK"
+                "lsm_local_disk_vpd83_search(): Expecting LSM_ERR_OK"
                 "when no argument is NULL");
     fail_unless(lsm_err == NULL,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting lsm_err as NULL"
+                "lsm_local_disk_vpd83_search(): Expecting lsm_err as NULL"
                 "when valid argument provided");
-    fail_unless(sd_path_list == NULL,
-                "lsm_scsi_disk_paths_of_vpd83(): Expecting sd_path_list as "
+    fail_unless(disk_path_list == NULL,
+                "lsm_local_disk_vpd83_search(): Expecting disk_path_list as "
                 "NULL when searching for VALID_BUT_NOT_EXIST_VPD83");
 
 }
 END_TEST
 
-START_TEST(test_scsi_vpd83_of_disk_path)
+START_TEST(test_local_disk_vpd83_get)
 {
     int rc = LSM_ERR_OK;
     const char *vpd83;
     /* Not initialized in order to test dangling pointer vpd83 */
     lsm_error *lsm_err = NULL;
 
-    rc = lsm_scsi_vpd83_of_disk_path(NULL, &vpd83, &lsm_err);
+    rc = lsm_local_disk_vpd83_get(NULL, &vpd83, &lsm_err);
 
     fail_unless(rc == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "LSM_ERR_INVALID_ARGUMENT when input is NULL");
     fail_unless(vpd83 == NULL,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "vpd83 been set as NULL.");
     fail_unless(lsm_err != NULL,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "lsm_err been set as non-NULL.");
     fail_unless(lsm_error_number_get(lsm_err) == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "lsm_err been set with LSM_ERR_INVALID_ARGUMENT");
     fail_unless(lsm_error_message_get(lsm_err) != NULL,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "lsm_err been set with non-NULL error message");
     lsm_error_free(lsm_err);
 
-    rc = lsm_scsi_vpd83_of_disk_path("/dev/sda", NULL, &lsm_err);
+    rc = lsm_local_disk_vpd83_get("/dev/sda", NULL, &lsm_err);
 
     fail_unless(rc == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "LSM_ERR_INVALID_ARGUMENT when input is NULL");
     lsm_error_free(lsm_err);
 
-    rc = lsm_scsi_vpd83_of_disk_path("/dev/sda", &vpd83, NULL);
+    rc = lsm_local_disk_vpd83_get("/dev/sda", &vpd83, NULL);
 
     fail_unless(rc == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "LSM_ERR_INVALID_ARGUMENT when lsm_err is NULL");
 
-    rc = lsm_scsi_vpd83_of_disk_path("/dev/", &vpd83, &lsm_err);
+    rc = lsm_local_disk_vpd83_get("/dev/", &vpd83, &lsm_err);
     fail_unless(rc == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "LSM_ERR_INVALID_ARGUMENT when input is illegal");
     fail_unless(lsm_err != NULL,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "lsm_err been set as non-NULL.");
     fail_unless(lsm_error_number_get(lsm_err) == LSM_ERR_INVALID_ARGUMENT,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "lsm_err been set with LSM_ERR_INVALID_ARGUMENT");
     fail_unless(lsm_error_message_get(lsm_err) != NULL,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "lsm_err been set with non-NULL error message");
     lsm_error_free(lsm_err);
 
     /* We cannot make sure /dev/sda exists, but worth trying */
-    lsm_scsi_vpd83_of_disk_path("/dev/sda", &vpd83, &lsm_err);
+    lsm_local_disk_vpd83_get("/dev/sda", &vpd83, &lsm_err);
     if (lsm_err != NULL)
         lsm_error_free(lsm_err);
     free((char *) vpd83);
 
     /* Test non-exist disk */
-    rc = lsm_scsi_vpd83_of_disk_path(NOT_EXIST_SD_PATH, &vpd83, &lsm_err);
+    rc = lsm_local_disk_vpd83_get(NOT_EXIST_SD_PATH, &vpd83, &lsm_err);
     fail_unless(rc == LSM_ERR_NOT_FOUND_DISK,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "LSM_ERR_NOT_FOUND_DISK when disk not exist");
     fail_unless(vpd83 == NULL,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "vpd83 as NULL when disk not exist");
     fail_unless(lsm_err != NULL,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "lsm_err not NULL when disk not exist");
     fail_unless(lsm_error_number_get(lsm_err) == LSM_ERR_NOT_FOUND_DISK,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting "
+                "lsm_local_disk_vpd83_get(): Expecting "
                 "lsm_err been set with LSM_ERR_NOT_FOUND_DISK");
     fail_unless(lsm_error_message_get(lsm_err) != NULL,
-                "lsm_scsi_vpd83_of_disk_path(): Expecting lsm_err "
+                "lsm_local_disk_vpd83_get(): Expecting lsm_err "
                 "been set with non-NULL error message when disk not exist");
     lsm_error_free(lsm_err);
 }
@@ -3369,8 +3369,8 @@ Suite * lsm_suite(void)
     tcase_add_test(basic, test_volume_raid_create);
     tcase_add_test(basic, test_volume_ident_led_set);
     tcase_add_test(basic, test_volume_ident_led_clear);
-    tcase_add_test(basic, test_scsi_disk_paths_of_vpd83);
-    tcase_add_test(basic, test_scsi_vpd83_of_disk_path);
+    tcase_add_test(basic, test_local_disk_vpd83_search);
+    tcase_add_test(basic, test_local_disk_vpd83_get);
 
 
     suite_add_tcase(s, basic);

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -34,7 +34,7 @@ from argparse import RawTextHelpFormatter
 from lsm import (Client, Pool, VERSION, LsmError, Disk,
                  Volume, JobStatus, ErrorNumber, BlockRange,
                  uri_parse, Proxy, size_human_2_size_bytes,
-                 AccessGroup, FileSystem, NfsExport, TargetPort, SCSI)
+                 AccessGroup, FileSystem, NfsExport, TargetPort, LocalDisk)
 
 from lsm.lsmcli.data_display import (
     DisplayData, PlugData, out,
@@ -185,7 +185,7 @@ def _add_sd_paths(lsm_obj):
     lsm_obj.sd_paths = []
     try:
         if len(lsm_obj.vpd83) > 0:
-            lsm_obj.sd_paths = SCSI.disk_paths_of_vpd83(lsm_obj.vpd83)
+            lsm_obj.sd_paths = LocalDisk.vpd83_search(lsm_obj.vpd83)
     except LsmError as lsm_err:
         if lsm_err.code != ErrorNumber.NO_SUPPORT:
             raise


### PR DESCRIPTION
Rename `lsm_scsi_xxx` to `lsm_local_disk_xxx` as we support ATA protocol disks also.
In the future, we might also support NVMe disks as well.

Include other fixes:
 * Fix constant check.
 * Eliminate duplicate code by using some C macros.
 * Split large functions to smaller one in `lsm_scsi_vpd83_of_disk_path()`.