### PR TITLE
hpsa.py: Add SYS_MODE_GET to capabilities list

### DIFF
--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -345,6 +345,7 @@ class SmartArray(IPlugin):
         cap.set(Capabilities.POOL_MEMBER_INFO)
         cap.set(Capabilities.VOLUME_RAID_CREATE)
         cap.set(Capabilities.SYS_FW_VERSION_GET)
+        cap.set(Capabilities.SYS_MODE_GET)
         cap.set(Capabilities.VOLUME_LED)
         return cap
 


### PR DESCRIPTION
The Smart Array plugin was missing the SYS_MODE_GET Capability, even though it clearly supports the feature and is collecting the data.

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>