### PR TITLE
[PATCH V3 0/7]  Library API: Controlling IDENT/FAULT LED of local disk.

### DIFF
--- a/c_binding/Makefile.am
+++ b/c_binding/Makefile.am
@@ -15,4 +15,4 @@ libstoragemgmt_la_SOURCES= \
 	lsm_mgmt.cpp lsm_datatypes.hpp lsm_datatypes.cpp lsm_convert.hpp \
 	lsm_convert.cpp lsm_ipc.hpp lsm_ipc.cpp lsm_plugin_ipc.hpp \
 	lsm_plugin_ipc.cpp util/qparams.c util/qparams.h \
-	utils.c utils.h libsg.c libsg.h lsm_local_disk.c
+	utils.c utils.h libsg.c libsg.h lsm_local_disk.c libses.c libses.h

--- a/c_binding/Makefile.am
+++ b/c_binding/Makefile.am
@@ -14,4 +14,5 @@ libstoragemgmt_la_LDFLAGS= -version-info $(LIBSM_LIBTOOL_VERSION)
 libstoragemgmt_la_SOURCES= \
 	lsm_mgmt.cpp lsm_datatypes.hpp lsm_datatypes.cpp lsm_convert.hpp \
 	lsm_convert.cpp lsm_ipc.hpp lsm_ipc.cpp lsm_plugin_ipc.hpp \
-	lsm_plugin_ipc.cpp util/qparams.c util/qparams.h lsm_local_disk.c
+	lsm_plugin_ipc.cpp util/qparams.c util/qparams.h \
+	utils.c utils.h libsg.c libsg.h lsm_local_disk.c

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
@@ -65,7 +65,7 @@ int LSM_DLL_EXPORT lsm_local_disk_vpd83_search(const char *vpd83,
  *                  freed by lsm_error_free().
  * @return Error code as enumerated by \ref lsm_error_number.
  * @retval LSM_ERR_OK               on success or not found.
- * @retval LSM_ERR_INVALID_ARGUMENT when any argument is NULL or 
+ * @retval LSM_ERR_INVALID_ARGUMENT when any argument is NULL or
  *                                  illegal sd_path.
  * @retval LSM_ERR_NO_MEMORY        when no memory.
  * @retval LSM_ERR_LIB_BUG          when something unexpected happens.
@@ -179,6 +179,87 @@ int LSM_DLL_EXPORT lsm_local_disk_list(lsm_string_list **disk_paths,
  */
 int LSM_DLL_EXPORT lsm_local_disk_link_type_get(const char *disk_path,
                                                 lsm_disk_link_type *link_type,
+                                                lsm_error **lsm_err);
+
+/**
+ * New in version 1.3.
+ * Turn on the identification LED for specified disk.
+ * Require read and write access to specified disk path.
+ * @param[in]  disk_path    String. The path of disk path, example "/dev/sdb".
+ * @param[out] lsm_err      Output pointer of lsm_error. Error message could be
+ *                          retrieved via lsm_error_message_get(). Memory should
+ *                          be freed by lsm_error_free().
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK                   On success.
+ * @retval LSM_ERR_INVALID_ARGUMENT     When any argument is NULL.
+ * @retval LSM_ERR_NO_MEMORY            When no memory.
+ * @retval LSM_ERR_LIB_BUG              When something unexpected happens.
+ * @retval LSM_ERR_NOT_FOUND_DISK       When provided disk path not found.
+ * @retval LSM_ERR_NO_SUPPORT           Action is not supported.
+ * @retval LSM_ERR_PERMISSION_DENIED    Insufficient permission to access
+ *                                      provided disk path.
+ */
+int LSM_DLL_EXPORT lsm_local_disk_ident_led_on(const char *disk_path,
+                                               lsm_error **lsm_err);
+/**
+ * New in version 1.3.
+ * Turn off the identification LED for specified disk.
+ * Require read and write access to specified disk path.
+ * @param[in]  disk_path    String. The path of disk path, example "/dev/sdb".
+ * @param[out] lsm_err      Output pointer of lsm_error. Error message could be
+ *                          retrieved via lsm_error_message_get().
+ *                          Memory should be freed by lsm_error_free().
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK                   On success.
+ * @retval LSM_ERR_INVALID_ARGUMENT     When any argument is NULL.
+ * @retval LSM_ERR_NO_MEMORY            When no memory.
+ * @retval LSM_ERR_LIB_BUG              When something unexpected happens.
+ * @retval LSM_ERR_NOT_FOUND_DISK       When provided disk path not found.
+ * @retval LSM_ERR_NO_SUPPORT           Action is not supported.
+ * @retval LSM_ERR_PERMISSION_DENIED    Insufficient permission to access
+ *                                      provided disk path.
+ */
+int LSM_DLL_EXPORT lsm_local_disk_ident_led_off(const char *disk_path,
+                                                  lsm_error **lsm_err);
+
+/**
+ * New in version 1.3.
+ * Turn on the fault LED for specified disk.
+ * Require read and write access to specified disk path.
+ * @param[in]  disk_path    String. The path of disk path, example "/dev/sdb".
+ * @param[out] lsm_err      Output pointer of lsm_error. Error message could be
+ *                          retrieved via lsm_error_message_get(). Memory should
+ *                          be freed by lsm_error_free().
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK                   On success.
+ * @retval LSM_ERR_INVALID_ARGUMENT     When any argument is NULL.
+ * @retval LSM_ERR_NO_MEMORY            When no memory.
+ * @retval LSM_ERR_LIB_BUG              When something unexpected happens.
+ * @retval LSM_ERR_NOT_FOUND_DISK       When provided disk path not found.
+ * @retval LSM_ERR_NO_SUPPORT           Action is not supported.
+ * @retval LSM_ERR_PERMISSION_DENIED    Insufficient permission to access
+ *                                      provided disk path.
+ */
+int LSM_DLL_EXPORT lsm_local_disk_fault_led_on(const char *disk_path,
+                                               lsm_error **lsm_err);
+/**
+ * New in version 1.3.
+ * Turn off the fault LED for specified disk.
+ * Require read and write access to specified disk path.
+ * @param[in]  disk_path    String. The path of disk path, example "/dev/sdb".
+ * @param[out] lsm_err      Output pointer of lsm_error. Error message could be
+ *                          retrieved via lsm_error_message_get(). Memory should
+ *                          be freed by lsm_error_free().
+ * @retval LSM_ERR_OK                   On success.
+ * @retval LSM_ERR_INVALID_ARGUMENT     When any argument is NULL.
+ * @retval LSM_ERR_NO_MEMORY            When no memory.
+ * @retval LSM_ERR_LIB_BUG              When something unexpected happens.
+ * @retval LSM_ERR_NOT_FOUND_DISK       When provided disk path not found.
+ * @retval LSM_ERR_NO_SUPPORT           Action is not supported.
+ * @retval LSM_ERR_PERMISSION_DENIED    Insufficient permission to access
+ *                                      provided disk path.
+ */
+int LSM_DLL_EXPORT lsm_local_disk_fault_led_off(const char *disk_path,
                                                 lsm_error **lsm_err);
 
 #ifdef __cplusplus

--- a/c_binding/libses.c
+++ b/c_binding/libses.c
@@ -1,0 +1,728 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+/* For strerror_r() */
+#define _GNU_SOURCE
+
+#include "libsg.h"
+#include "libses.h"
+#include "utils.h"
+#include "libstoragemgmt/libstoragemgmt_plug_interface.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <errno.h>
+#include <unistd.h>
+#include <inttypes.h>
+#include <assert.h>
+
+/* SPC-5 Table 139 - PERIPHERAL DEVICE TYPE field */
+#define _LINUX_SG_DEV_TYPE_SES                  "13"  /* 0x0d  */
+#define _LINUX_SG_DEV_TYPE_SES_LEN              2
+/* just two digits like above */
+
+#define _SYSFS_SG_ROOT_PATH                     "/sys/class/scsi_generic"
+
+#define _T10_SES_CFG_PG_CODE                    0x01
+#define _T10_SES_STATUS_PG_CODE                 0x02
+
+/* SES-3 rev 11a Table 30 - Additional Element Status diagnostic page */
+#define _T10_SES_ADD_STATUS_PG_CODE             0x0a
+
+/* SES-3 rev 11a Table 81 - Array Device Slot status element */
+#define _T10_SES_DEV_SLOT_STATUS_LEN            4
+
+/* SES-3 rev 11a Table 38 - DESCRIPTOR TYPE field */
+#define _T10_SES_DESCRIPTOR_TYPE_DEV_SLOT       0
+
+#define _T10_SES_CTRL_PRDFAIL_BYTES             0
+#define _T10_SES_CTRL_PRDFAIL_BIT               6
+#define _T10_SES_CTRL_SELECT_BYTES              0
+/* SES-3 rev 11a Table 69 - Control element format */
+#define _T10_SES_CTRL_SELECT_BIT                7
+#define _T10_SES_CTRL_RQST_IDENT_BYTES          2
+#define _T10_SES_CTRL_RQST_IDENT_BIT            1
+#define _T10_SES_CTRL_RQST_FAULT_BYTES          3
+/* SES-3 rev 11a Table 80 - Array Device Slot control element */
+#define _T10_SES_CTRL_RQST_FAULT_BIT            5
+
+/* SES-3 rev 11a Table 31 - Additional Element Status descriptor with the EIP
+ *                          bit set to one
+ */
+#define _T10_SES_ADD_DP_INCLUDE_OVERALL         1
+
+/* SES-3 Table 12 - Type descriptor header format */
+#define _T10_SES_CFG_DP_HDR_LEN                 4
+
+#pragma pack(push, 1)
+/*
+ * SES-3 rev 11a "Table 30 - Additional Element Status diagnostic page"
+ */
+struct _ses_add_st {
+    uint8_t page_code;
+    uint8_t reserved;
+    uint16_t len_be;
+    uint32_t gen_code_be;
+    uint8_t dp_list_begin;
+};
+
+/*
+ * SES-3 rev 11a Table 31 - Additional Element Status descriptor
+ */
+struct _ses_add_st_dp {
+    uint8_t protocol_id         : 4;
+    uint8_t eip                 : 1;
+    uint8_t reserved            : 2;
+    uint8_t invalid             : 1;
+    uint8_t len;
+    uint8_t eiioe               : 1;
+    uint8_t reserved_2          : 7;
+    uint8_t element_index;
+    uint8_t data_begin;
+};
+
+/*
+ * SES-3 rev 11a Table 39 - Additional Element Status descriptor
+ * protocol-specific information for Device Slot elements and Array Device Slot
+ * elements for SAS with the EIP bit set to one
+ */
+struct _ses_add_st_dp_sas {
+    uint8_t phy_count;
+    uint8_t not_all_phy         : 1;
+    uint8_t reserved            : 5;
+    uint8_t dp_type             : 2;
+    uint8_t reserved_2;
+    uint8_t dev_slot_num;
+    uint8_t phy_list;
+};
+
+/*
+ * SES-3 rev 11a Table 41 - Phy descriptor
+ */
+struct _ses_add_st_sas_phy {
+    uint8_t reserved            : 4;
+    uint8_t dev_type            : 3;
+    uint8_t reserved_2          : 1;
+    uint8_t reserved_3;
+    uint8_t we_dont_care_2;
+    uint8_t we_dont_care_3;
+    uint8_t attached_sas_addr[8];
+    uint8_t sas_addr[8];
+    uint8_t phy_id;
+    uint8_t reserved_4[7];
+};
+
+/*
+ * SES-3 rev 11a Table 80 - Array Device Slot control element
+ */
+struct _ses_ar_dev_ctrl {
+    uint8_t we_dont_care_0      : 7;
+    uint8_t select              : 1;
+    uint8_t we_dont_care_1      : 8;
+    uint8_t we_dont_care_2      : 1;
+    uint8_t rqst_ident          : 1;
+    uint8_t we_dont_care_3      : 6;
+    uint8_t we_dont_care_4      : 5;
+    uint8_t rqst_fault          : 1;
+    uint8_t we_dont_care_5      : 2;
+};
+
+struct _ses_ctrl_diag_hdr {
+    uint8_t page_code;
+    uint8_t we_dont_care_0;
+    uint16_t len_be;
+    uint32_t gen_code_be;
+    uint8_t ctrl_dp_list_begin;
+};
+
+struct _ses_st_hdr {
+    uint8_t page_code;
+    uint8_t we_dont_care_0;
+    uint16_t len_be;
+    uint32_t gen_code_be;
+    uint8_t st_dp_list;
+};
+
+struct _ses_cfg_hdr {
+    uint8_t page_code;
+    uint8_t num_of_sec_enc;
+    uint16_t len_be;
+    uint32_t gen_code_be;
+    uint8_t enc_dp_list;
+};
+
+struct _ses_cfg_enc_dp {
+    uint8_t we_dont_care_0[2];
+    uint8_t num_of_dp_hdr;
+    uint8_t len;
+    uint8_t we_dont_care_1[35];
+    uint8_t vendor_info_begin;
+};
+
+struct _ses_cfg_dp_hdr {
+    uint8_t element_type;
+    uint8_t num_of_possible_element;
+    uint8_t sub_enc_id;
+    uint8_t dp_text_len;
+};
+
+#pragma pack(pop)
+
+#define _set_array_bit(array, bytes, bit) \
+    do { \
+        array[bytes] |= 1 << bit; \
+    } while(0)
+
+#define _clear_array_bit(array, bytes, bit) \
+    do { \
+        array[bytes] &= ~(1 << bit); \
+    } while(0)
+
+/*
+ * Get all /dev/sgX which support SES via libudev.
+ * Assuming given pointer is not NULL.
+ */
+static int _ses_sg_paths_get(char *err_msg, char ***sg_paths,
+                             uint32_t *sg_count);
+
+/*
+ * Return element index of given SAS address. The index is including overall
+ * status item in status page(0x02).
+ * 'add_st_data' should be 'uint8_t [_SG_T10_SPC_RECV_DIAG_MAX_LEN]'
+ * 'cfg_data' should be 'uint8_t [_SG_T10_SPC_RECV_DIAG_MAX_LEN]'
+ * -1 for not found.
+ */
+static int16_t _ses_find_sas_addr(const char *sas_addr, uint8_t *add_st_data,
+                                  uint8_t *cfg_data);
+
+/*
+ * 'status' should be 'uint8_t [_T10_SES_DEV_SLOT_STATUS_LEN]'.
+ */
+static int _ses_get_status(char *err_msg, uint8_t *status_data,
+                           const int16_t element_index, uint8_t *status,
+                           uint32_t *gen_code_be);
+
+static int _ses_ctrl_data_gen(char *err_msg, uint8_t *status_data,
+                              uint8_t *status, const int16_t element_index,
+                              uint16_t *len);
+
+/*
+ * When EIIOE is set to zero, we need to add the overall element count into
+ * given element_index. Quote of SES-3 rev 11a:
+ *  An EIIOE (element index includes overall elements) bit set to one indicates
+ *  that the ELEMENT INDEX field in table 31 is based on the position in the
+ *  status descriptor list of the Enclosure Status diagnostic page (see 6.1.4)
+ *  including overall status elements (i.e., is the same as the CONNECTOR
+ *  ELEMENT INDEX fields (see table 43 and table 45) and the OTHER ELEMENT INDEX
+ *  fields (see table 43 and table 45)).  An EIIOE bit set to zero indicates
+ *  that the ELEMENT INDEX field is based on the position in the status
+ *  descriptor list of the Enclosure Status diagnostic page excluding overall
+ *  status elements. The device server should set the EIIOE bit to one.
+ *
+ *  The EIIOE is introduced by SES-3.
+ */
+static int16_t _ses_eiioe(uint8_t *cfg_data, int16_t element_index);
+
+
+/*
+ * Get the total count of 'Type descriptor header' and
+ * the beginning pointer of 'Type descriptor header list' from config page.
+ * If error, dp_hdr_begin will be NULL and total_dp_hdr_count will be 0.
+ */
+static void _ses_cfg_parse(uint8_t *cfg_data, uint8_t **dp_hdr_begin,
+                           uint16_t *total_dp_hdr_count);
+
+static void _ses_cfg_parse(uint8_t *cfg_data, uint8_t **dp_hdr_begin,
+                           uint16_t *total_dp_hdr_count)
+{
+    struct _ses_cfg_hdr *cfg_hdr = NULL;
+    struct _ses_cfg_enc_dp *enc_dp = NULL;
+    uint8_t *end_p = NULL;
+    uint8_t *tmp_p = NULL;
+    uint8_t i = 0;
+
+    assert(cfg_data != NULL);
+    assert(dp_hdr_begin != NULL);
+    assert(total_dp_hdr_count != NULL);
+
+    *total_dp_hdr_count = 0;
+    *dp_hdr_begin = NULL;
+
+    cfg_hdr = (struct _ses_cfg_hdr *)cfg_data;
+    end_p = cfg_data + be16toh(cfg_hdr->len_be) + 3;
+    if (end_p >= cfg_data + _SG_T10_SPC_RECV_DIAG_MAX_LEN)
+        /* Facing data boundary */
+        return;
+
+    tmp_p = &cfg_hdr->enc_dp_list;
+    /* Check the "Enclosure descriptor list" section */
+    for (; i <= cfg_hdr->num_of_sec_enc; ++i) {
+        enc_dp = (struct _ses_cfg_enc_dp *) tmp_p;
+        *total_dp_hdr_count += enc_dp->num_of_dp_hdr;
+        tmp_p += enc_dp->len + 4;
+        /* ENCLOSURE DESCRIPTOR LENGTH (m - 3) */
+    }
+    *dp_hdr_begin = tmp_p;
+    return;
+}
+
+static int _ses_sg_paths_get(char *err_msg, char ***sg_paths,
+                             uint32_t *sg_count)
+{
+    int rc = LSM_ERR_OK;
+    uint32_t i = 0;
+    DIR *dir = NULL;
+    struct dirent *dp = NULL;
+    lsm_string_list *sg_name_list = NULL;
+    const char *sg_name = NULL;
+    char *sysfs_sg_type_path = NULL;
+    char sg_dev_type[_LINUX_SG_DEV_TYPE_SES_LEN];
+    ssize_t sg_dev_type_size = 0;
+    char strerr_buff[_LSM_ERR_MSG_LEN];
+
+    assert(err_msg != NULL);
+    assert(sg_paths != NULL);
+    assert(sg_count != NULL);
+
+    *sg_paths = NULL;
+    *sg_count = 0;
+
+    sg_name_list = lsm_string_list_alloc(0 /* no pre-allocation */);
+    _alloc_null_check(err_msg, sg_name_list, rc, out);
+
+    /* We don't use libudev here because libudev seems have no way to check
+     * whether 'sg' kernel module is loaded or not.
+     */
+    if (! _file_exists(_SYSFS_SG_ROOT_PATH)) {
+        rc = LSM_ERR_INVALID_ARGUMENT;
+        _lsm_err_msg_set(err_msg, "Required kernel module 'sg' not loaded");
+        goto out;
+    }
+
+    dir = opendir(_SYSFS_SG_ROOT_PATH);
+    if (dir == NULL) {
+        _lsm_err_msg_set(err_msg, "Cannot open %s: error (%d)%s",
+                         _SYSFS_SG_ROOT_PATH, errno,
+                         strerror_r(errno, strerr_buff, _LSM_ERR_MSG_LEN));
+
+        rc = LSM_ERR_LIB_BUG;
+        goto out;
+    }
+
+    do {
+        if ((dp = readdir(dir)) != NULL) {
+            sg_name = dp->d_name;
+            if ((sg_name == NULL) || (strlen(sg_name) == 0) ||
+                (strncmp(sg_name, "sg", strlen("sg")) != 0))
+                continue;
+            sysfs_sg_type_path = (char *)
+                malloc(sizeof(char) * (sizeof(_SYSFS_SG_ROOT_PATH) +
+                                       strlen("/") +
+                                       sizeof(sg_name) +
+                                       strlen("/device/type") +
+                                       1 /* trailing \0 */));
+            _alloc_null_check(err_msg, sysfs_sg_type_path, rc, out);
+            sprintf(sysfs_sg_type_path, "%s/%s/device/type",
+                    _SYSFS_SG_ROOT_PATH, sg_name);
+            if (_read_file(sysfs_sg_type_path, (uint8_t *) sg_dev_type,
+                           &sg_dev_type_size,
+                           _LINUX_SG_DEV_TYPE_SES_LEN) != 0) {
+                free(sysfs_sg_type_path);
+                continue;
+            }
+            if (strncmp(sg_dev_type, _LINUX_SG_DEV_TYPE_SES,
+                        _LINUX_SG_DEV_TYPE_SES_LEN) == 0) {
+                if (lsm_string_list_append(sg_name_list, sg_name) != 0) {
+                    free(sysfs_sg_type_path);
+                    _lsm_err_msg_set(err_msg, "No memory");
+                    rc = LSM_ERR_NO_MEMORY;
+                    goto out;
+                }
+                free(sysfs_sg_type_path);
+            }
+        }
+    } while(dp != NULL);
+
+    *sg_count = lsm_string_list_size(sg_name_list);
+    *sg_paths = (char **) malloc(sizeof(char *) * (*sg_count));
+    _alloc_null_check(err_msg, sg_name_list, rc, out);
+
+    _lsm_string_list_foreach(sg_name_list, i, sg_name) {
+        (*sg_paths)[i] = (char *)
+            malloc(sizeof(char) * (strlen(sg_name) + strlen("/dev/") +
+                                   1 /* trailing \0 */));
+        if ((*sg_paths)[i] == NULL) {
+            rc = LSM_ERR_NO_MEMORY;
+            goto out;
+        }
+        sprintf((*sg_paths)[i], "/dev/%s", sg_name);
+    }
+
+ out:
+    if (dir != NULL)
+        closedir(dir);
+
+    if (sg_name_list != NULL)
+        lsm_string_list_free(sg_name_list);
+    if (rc != LSM_ERR_OK) {
+        if (*sg_paths != NULL) {
+            for (i = 0; i < *sg_count; ++i)
+                free((char *) (*sg_paths)[i]);
+            free(*sg_paths);
+        }
+        *sg_paths = NULL;
+        *sg_count = 0;
+    }
+    return rc;
+}
+
+static int16_t _ses_find_sas_addr(const char *sas_addr, uint8_t *add_st_data,
+                                  uint8_t *cfg_data)
+{
+    struct _ses_add_st *add_st = NULL;
+    struct _ses_add_st_dp *dp = NULL;
+    struct _ses_add_st_dp_sas *dp_sas = NULL;
+    struct _ses_add_st_sas_phy *phy = NULL;
+    uint8_t *end_p = NULL;
+    uint8_t *tmp_p = NULL;
+    int16_t element_index = -1;
+    uint8_t i = 0;
+    char tmp_sas_addr[_SG_T10_SPL_SAS_ADDR_LEN];
+
+    assert(sas_addr != NULL);
+    assert(add_st_data != NULL);
+    assert(cfg_data != NULL);
+
+    add_st = (struct _ses_add_st *) add_st_data;
+    end_p = add_st_data + be16toh(add_st->len_be) + 3;
+
+    tmp_p = &add_st->dp_list_begin;
+    while(tmp_p < end_p) {
+        if (tmp_p + sizeof(struct _ses_add_st_dp) > end_p)
+            goto out;
+        dp = (struct _ses_add_st_dp *) tmp_p;
+        tmp_p += dp->len + 2;
+
+        /* Both SES-2 and SES-3 said 'The EIP bit should be set to one.'
+         * The 'should' means 'is strongly recommended'.
+         * When EIP == 0, the SES standard is in blur state for count element
+         * index.
+         * Hence we silently ignore the descriptor with EIP=0.
+         */
+        if ((dp->protocol_id != _SG_T10_SPC_PROTOCOL_ID_SAS) ||
+            (dp->invalid == 1) ||
+            (dp->eip == 0))
+            continue;
+
+        if (&dp->data_begin + sizeof(struct _ses_add_st_dp_sas) > end_p)
+            goto out;
+        dp_sas = (struct _ses_add_st_dp_sas *) &dp->data_begin;
+        if (dp_sas->dp_type != _T10_SES_DESCRIPTOR_TYPE_DEV_SLOT)
+            continue;
+        if (dp_sas->phy_count == 0)
+            continue;
+        if (&dp_sas->phy_list + sizeof(struct _ses_add_st_sas_phy) > end_p)
+            goto out;
+        for (i = 0; i < dp_sas->phy_count; ++i) {
+            phy = (struct _ses_add_st_sas_phy *)
+                (&dp_sas->phy_list) + sizeof(struct _ses_add_st_sas_phy) * i;
+            _be_raw_to_hex((uint8_t *) &phy->sas_addr,
+                           _SG_T10_SPL_SAS_ADDR_LEN_BITS, tmp_sas_addr);
+            if (strncmp(tmp_sas_addr, sas_addr,
+                        _SG_T10_SPL_SAS_ADDR_LEN) == 0) {
+                if (dp->eiioe == _T10_SES_ADD_DP_INCLUDE_OVERALL)
+                    return dp->element_index;
+                else
+                    return _ses_eiioe(cfg_data, dp->element_index);
+            }
+        }
+    }
+
+ out:
+    return element_index;
+}
+
+static int _ses_get_status(char *err_msg, uint8_t *status_data,
+                           const int16_t element_index, uint8_t *status,
+                           uint32_t *gen_code_be)
+{
+    int rc = LSM_ERR_OK;
+    struct _ses_st_hdr *st_hdr = NULL;
+    uint8_t *end_p = NULL;
+    uint8_t *status_p = NULL;
+
+    assert(err_msg != NULL);
+    assert(status_data != NULL);
+    assert(status != NULL);
+    assert(gen_code_be != NULL);
+
+    st_hdr = (struct _ses_st_hdr *) status_data;
+    end_p = status_data + be16toh(st_hdr->len_be) + 3;
+    status_p = &st_hdr->st_dp_list +
+        element_index * _T10_SES_DEV_SLOT_STATUS_LEN;
+
+    if ((end_p >= status_data + _SG_T10_SPC_RECV_DIAG_MAX_LEN) ||
+        (status_p >= end_p) ||
+        (status_p + _T10_SES_DEV_SLOT_STATUS_LEN > end_p)) {
+        rc = LSM_ERR_LIB_BUG;
+        _lsm_err_msg_set(err_msg, "BUG: Got corrupted SES status page: "
+                         "facing data boundary");
+        goto out;
+    }
+
+    memcpy(status, status_p, _T10_SES_DEV_SLOT_STATUS_LEN);
+
+    *gen_code_be = st_hdr->gen_code_be;
+
+ out:
+    if (rc != LSM_ERR_OK) {
+        memset(status, 0, _T10_SES_DEV_SLOT_STATUS_LEN);
+        *gen_code_be = 0;
+    }
+
+    return rc;
+}
+
+static int _ses_ctrl_data_gen(char *err_msg, uint8_t *status_data,
+                              uint8_t *status, const int16_t element_index,
+                              uint16_t *len)
+{
+    struct _ses_ctrl_diag_hdr *ctrl_hdr = NULL;
+    uint8_t *tmp_p = NULL;
+    uint8_t *end_p = NULL;
+
+    assert(err_msg != NULL);
+    assert(status_data != NULL);
+    assert(status != NULL);
+    assert(len != NULL);
+
+    ctrl_hdr = (struct _ses_ctrl_diag_hdr *) (status_data);
+
+    *len = be16toh(ctrl_hdr->len_be) + 4;
+
+    /* set all element as not selected */
+    tmp_p = &ctrl_hdr->ctrl_dp_list_begin;
+    end_p = tmp_p + be16toh(ctrl_hdr->len_be);
+
+    while(tmp_p < end_p) {
+        _clear_array_bit(tmp_p, _T10_SES_CTRL_SELECT_BYTES,
+                         _T10_SES_CTRL_SELECT_BIT);
+        tmp_p += _T10_SES_DEV_SLOT_STATUS_LEN;
+    }
+
+    /* update the selected element */
+
+    tmp_p = &ctrl_hdr->ctrl_dp_list_begin + \
+            _T10_SES_DEV_SLOT_STATUS_LEN * element_index;
+
+    memcpy(tmp_p, status, _T10_SES_DEV_SLOT_STATUS_LEN);
+
+    return LSM_ERR_OK;
+}
+
+/*
+ * Workflow:
+ *  Parse config page(0x01)
+ *      Loop enclosure descriptor list
+ *          Loop descriptor header list
+ *              Store 'NUMBER OF POSSIBLE ELEMENTS' of descriptor header in
+ *              an array. The 0 indicates this element type only have overall
+ *              element.
+ */
+static int16_t _ses_eiioe(uint8_t *cfg_data, int16_t element_index)
+{
+    struct _ses_cfg_hdr *cfg_hdr = NULL;
+    struct _ses_cfg_dp_hdr *dp_hdr = NULL;
+    uint8_t *end_p = NULL;
+    uint8_t i = 0;
+    uint16_t total_dp_hdr_count = 0;
+    uint8_t add = 0;
+    uint8_t *dp_hdr_begin = NULL;
+
+    assert(cfg_data != NULL);
+
+    cfg_hdr = (struct _ses_cfg_hdr *)cfg_data;
+    end_p = cfg_data + be16toh(cfg_hdr->len_be) + 3;
+    if (end_p >= cfg_data + _SG_T10_SPC_RECV_DIAG_MAX_LEN)
+        /* Facing data boundary */
+        return -1;
+
+    _ses_cfg_parse(cfg_data, &dp_hdr_begin, &total_dp_hdr_count);
+    if ((dp_hdr_begin == NULL) || (total_dp_hdr_count == 0))
+        return -1;
+
+    for (i = 0; i < total_dp_hdr_count; ++i) {
+        dp_hdr = (struct _ses_cfg_dp_hdr *) dp_hdr_begin +
+            (_T10_SES_CFG_DP_HDR_LEN * i);
+        if ((uint8_t *) &dp_hdr >= end_p)
+            /* Facing data boundary */
+            return -1;
+        add++;
+        if (element_index <= dp_hdr->num_of_possible_element)
+            break;
+        element_index -= dp_hdr->num_of_possible_element;
+    }
+
+    return element_index + add;
+}
+
+/*
+ * Workflow:
+ *  1. Find all scsi generic paths that correspond to enclosures.
+ *  2. Find which scsi generic path connects to the given SAS address via the
+ *     following SES page:
+ *      6.1.13 Additional Element Status diagnostic page
+ *  3. Record the element index of the port that the given SAS address is
+ *     connecting to.
+ *  4. Retrieve status of above element index.
+ *  5. Update status data of these SES pages with ctrl_value:
+ *      6.1.3 Enclosure Control diagnostic page
+ *      7.2.2 Control element format
+ *      7.3.2 Device Slot element
+ *  4. Invoke SEND DIAGNOSTICS command.
+ */
+int _ses_dev_slot_ctrl(char *err_msg, const char *tp_sas_addr,
+                       int ctrl_value, int ctrl_type)
+{
+    int rc = LSM_ERR_OK;
+    uint32_t i = 0;
+    char  **sg_paths = NULL;
+    uint32_t sg_count = 0;
+    int fd = -1;
+    uint8_t cfg_data[_SG_T10_SPC_RECV_DIAG_MAX_LEN];
+    uint8_t status_data[_SG_T10_SPC_RECV_DIAG_MAX_LEN];
+    uint8_t add_st_data[_SG_T10_SPC_RECV_DIAG_MAX_LEN];
+    uint8_t status[_T10_SES_DEV_SLOT_STATUS_LEN];
+    bool found = false;
+    int16_t element_index = -1;
+    /* The SES-3 ELEMENT INDEX field which is uint8_t, we expand it to
+     * int16_t in order to include -1 as 'not found' error.
+     */
+    uint8_t ctrl_bytes = 0;
+    uint8_t ctrl_bit = 0;
+    uint32_t gen_code_be;
+    uint16_t ctrl_data_len = 0;
+
+    _good(_ses_sg_paths_get(err_msg, &sg_paths, &sg_count), rc, out);
+
+    for (i = 0; i < sg_count; ++i) {
+        _good(_sg_io_open_rw(err_msg, sg_paths[i], &fd), rc, out);
+        _good(_sg_io_recv_diag(err_msg, fd, _T10_SES_CFG_PG_CODE, cfg_data),
+              rc, out);
+        _good(_sg_io_recv_diag(err_msg, fd, _T10_SES_STATUS_PG_CODE,
+                               status_data), rc, out);
+        _good(_sg_io_recv_diag(err_msg, fd, _T10_SES_ADD_STATUS_PG_CODE,
+                               add_st_data),
+              rc, out);
+        /* TODO(Gris Ge): We need to check "GENERATION CODE" of above four
+         *                pages are identical, or we need retry.
+         */
+
+        element_index = _ses_find_sas_addr(tp_sas_addr, add_st_data, cfg_data);
+        if (element_index != -1) {
+            found = true;
+            break;
+        }
+
+        close(fd);
+        fd = -1;
+    }
+    if (found != true) {
+        rc = LSM_ERR_NO_SUPPORT;
+        _lsm_err_msg_set(err_msg, "Failed to find any SCSI enclosure with "
+                         "given SAS address %s", tp_sas_addr);
+        goto out;
+    }
+
+    _good(_ses_get_status(err_msg, status_data, element_index, status,
+                          &gen_code_be),
+          rc, out);
+
+    /* Only keep the PRDFAIL bit */
+    status[_T10_SES_CTRL_PRDFAIL_BYTES] &= 1 << _T10_SES_CTRL_PRDFAIL_BIT;
+
+    /* Set the SELECT bit */
+    _set_array_bit(status, _T10_SES_CTRL_SELECT_BYTES,
+                   _T10_SES_CTRL_SELECT_BIT);
+
+    if (ctrl_value == _SES_DEV_CTRL_RQST_IDENT) {
+        ctrl_bytes = _T10_SES_CTRL_RQST_IDENT_BYTES;
+        ctrl_bit = _T10_SES_CTRL_RQST_IDENT_BIT;
+    } else if (ctrl_value == _SES_DEV_CTRL_RQST_FAULT) {
+        ctrl_bytes = _T10_SES_CTRL_RQST_FAULT_BYTES;
+        ctrl_bit = _T10_SES_CTRL_RQST_FAULT_BIT;
+    } else {
+        rc = LSM_ERR_LIB_BUG;
+        _lsm_err_msg_set(err_msg, "Got invalid ctrl_value %d", ctrl_value);
+        goto out;
+    }
+
+    if (ctrl_type == _SES_CTRL_SET)
+        _set_array_bit(status, ctrl_bytes, ctrl_bit);
+    else if (ctrl_type == _SES_CTRL_CLEAR)
+        _clear_array_bit(status, ctrl_bytes, ctrl_bit);
+    else {
+        rc = LSM_ERR_LIB_BUG;
+        _lsm_err_msg_set(err_msg, "Got invalid ctrl_type %d", ctrl_type);
+        goto out;
+    }
+
+
+    _good(_ses_ctrl_data_gen(err_msg, status_data, status, element_index,
+                             &ctrl_data_len),
+          rc, out);
+
+    /* TODO(Gris Ge): If gen_code_be not match, the SEND DIAGNOSTIC will fail,
+     *                in that case, we should refresh status and retry.
+     */
+    _good(_sg_io_send_diag(err_msg, fd, status_data, ctrl_data_len), rc, out);
+
+    /*
+     * Verify whether certain action is supported
+     */
+    _good(_sg_io_recv_diag(err_msg, fd, _T10_SES_STATUS_PG_CODE,
+                           status_data), rc, out);
+
+    _good(_ses_get_status(err_msg, status_data, element_index, status,
+                          &gen_code_be),
+          rc, out);
+
+    if (((ctrl_type == _SES_CTRL_CLEAR) &&
+         (status[ctrl_bytes] & (1 << ctrl_bit))) ||
+        ((ctrl_type == _SES_CTRL_SET) &&
+         !((status[ctrl_bytes] & (1 << ctrl_bit))))) {
+            /* Control bit is still set */
+            rc = LSM_ERR_NO_SUPPORT;
+            _lsm_err_msg_set(err_msg, "Requested SES action is not supported "
+                             "by vendor enclosure vendor or/and kernel driver");
+    }
+
+ out:
+    if (fd != -1)
+        close(fd);
+    if (sg_paths != NULL) {
+        for (i = 0; i < sg_count; ++i) {
+            free(sg_paths[i]);
+        }
+        free(sg_paths);
+    }
+    return rc;
+}

--- a/c_binding/libses.h
+++ b/c_binding/libses.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#ifndef _LIBSES_H_
+#define _LIBSES_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "libstoragemgmt/libstoragemgmt_common.h"
+#include "libstoragemgmt/libstoragemgmt_error.h"
+
+#define _SES_CTRL_SET                       1
+#define _SES_CTRL_CLEAR                     2
+
+#define _SES_DEV_CTRL_RQST_IDENT            1
+#define _SES_DEV_CTRL_RQST_FAULT            2
+
+/*
+ * err_msg:     Should be 'char err_msg[_LSM_ERR_MSG_LEN]'.
+ * tp_sas_addr: Target port SAS address.
+ * ctrl_value:  Should be _SES_DEV_CTRL_RQST_IDENT or _SES_DEV_CTRL_RQST_FAULT.
+ * ctrl_type:   _SES_CTRL_SET or _SES_CTRL_CLEAR.
+ *
+ */
+LSM_DLL_LOCAL int _ses_dev_slot_ctrl(char *err_msg, const char *tp_sas_addr,
+                                     int ctrl_value, int ctrl_type);
+
+#endif  /* End of _LIBSES_H_ */

--- a/c_binding/libsg.c
+++ b/c_binding/libsg.c
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+/* For strerror_r() */
+#define _GNU_SOURCE
+
+#include "libsg.h"
+#include "utils.h"
+
+#include "libstoragemgmt/libstoragemgmt_error.h"
+
+#include <scsi/sg.h>
+#include <scsi/scsi.h>
+#include <sys/ioctl.h>
+#include <string.h>
+#include <stdbool.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+/* SGIO timeout: 1 second
+ * TODO(Gris Ge): Raise LSM_ERR_TIMEOUT error for this
+ */
+#define _SG_IO_TMO                                      1000
+
+/* SPC-5 rev7 Table 142 - INQUIRY command */
+#define _T10_SPC_INQUIRY_CMD_LEN                        6
+/* SPC-5 rev7 Table 219 - RECEIVE DIAGNOSTIC RESULTS command */
+#define _T10_SPC_RECV_DIAG_CMD_LEN                      6
+/* SPC-5 rev7 Table 269 - SEND DIAGNOSTIC command */
+#define _T10_SPC_SEND_DIAG_CMD_LEN                      6
+/* SPC-5 rev7 Table 534 - Supported VPD Pages VPD page */
+#define _T10_SPC_VPD_SUP_VPD_PGS_LIST_OFFSET            4
+
+#define _SG_IO_SEND_DATA                                1
+#define _SG_IO_RECV_DATA                                2
+
+#pragma pack(push, 1)
+/*
+ * SPC-5 rev 7 Table 589 - Device Identification VPD page
+ */
+struct _sg_t10_vpd83_header {
+    uint8_t dev_type : 5;
+    uint8_t qualifier : 3;
+    uint8_t page_code;
+    uint16_t page_len;
+};
+
+#pragma pack(pop)
+
+/*
+ * Return 0 if pass, return errno if failure.
+ *
+ */
+static int _sg_io(int fd, uint8_t *cdb, uint8_t cdb_len, uint8_t *data,
+                  ssize_t data_len, int direction);
+
+static struct _sg_t10_vpd83_dp *_sg_t10_vpd83_dp_new(void);
+
+static int _sg_io_open(char *err_msg, const char *disk_path, int *fd,
+                       int oflag);
+
+static int _sg_io(int fd, uint8_t *cdb, uint8_t cdb_len, uint8_t *data,
+                  ssize_t data_len, int direction)
+{
+    int rc = 0;
+    struct sg_io_hdr io_hdr;
+
+    assert(cdb != NULL);
+    assert(cdb_len != 0);
+    assert(data != NULL);
+    assert(data_len != 0);
+
+    memset(&io_hdr, 0, sizeof(struct sg_io_hdr));
+    if (direction == _SG_IO_RECV_DATA)
+        memset(data, 0, (size_t) data_len);
+    io_hdr.interface_id = 'S';  /* 'S' for SCSI generic */
+    io_hdr.cmdp = cdb;
+    io_hdr.cmd_len = cdb_len;
+    io_hdr.sbp = NULL;  /* TODO(Gris Ge): Handle sense data for error message */
+    io_hdr.mx_sb_len = 0;
+    if (direction == _SG_IO_RECV_DATA)
+        io_hdr.dxfer_direction = SG_DXFER_FROM_DEV;
+    else
+        io_hdr.dxfer_direction = SG_DXFER_TO_DEV;
+
+    io_hdr.dxferp = (unsigned char *) data;
+    io_hdr.dxfer_len = data_len;
+    io_hdr.timeout = _SG_IO_TMO;
+
+    if (ioctl(fd, SG_IO, &io_hdr) != 0)
+        rc = errno;
+
+    if (rc != 0)
+        memset(data, 0, (size_t) data_len);
+
+    return rc;
+}
+
+int _sg_io_vpd(char *err_msg, int fd, uint8_t page_code, uint8_t *data)
+{
+    int rc = LSM_ERR_OK;
+    uint8_t vpd_00_data[_SG_T10_SPC_VPD_MAX_LEN];
+    uint8_t cdb[_T10_SPC_INQUIRY_CMD_LEN];
+    int ioctl_errno = 0;
+    int rc_vpd_00 = 0;
+    char strerr_buff[_LSM_ERR_MSG_LEN];
+
+    assert(err_msg != NULL);
+    assert(fd >= 0);
+    assert(data != NULL);
+
+    /* SPC-5 Table 142 - INQUIRY command */
+    cdb[0] = INQUIRY;                           /* OPERATION CODE */
+    cdb[1] = 1;                                 /* EVPD */
+    /* VPD INQUIRY requires EVPD == 1 */;
+    cdb[2] = page_code & UINT8_MAX;             /* PAGE CODE */
+    cdb[3] = (_SG_T10_SPC_VPD_MAX_LEN >> 8 )& UINT8_MAX;
+                                                /* ALLOCATION LENGTH, MSB */
+    cdb[4] = _SG_T10_SPC_VPD_MAX_LEN & UINT8_MAX;
+                                                /* ALLOCATION LENGTH, LSB */
+    cdb[5] = 0;                                 /* CONTROL */
+    /* We have no use case need for handling auto contingent allegiance(ACA)
+     * yet.
+     */
+
+    ioctl_errno = _sg_io(fd, cdb, _T10_SPC_INQUIRY_CMD_LEN, data,
+                         _SG_T10_SPC_VPD_MAX_LEN, _SG_IO_RECV_DATA);
+    if (ioctl_errno != 0) {
+        if (page_code == _SG_T10_SPC_VPD_SUP_VPD_PGS) {
+            _lsm_err_msg_set(err_msg, "Not a SCSI compatible device");
+            return LSM_ERR_NO_SUPPORT;
+        }
+        /* Check whether provided page is supported */
+        rc_vpd_00 = _sg_io_vpd(err_msg, fd, _SG_T10_SPC_VPD_SUP_VPD_PGS,
+                               vpd_00_data);
+        if (rc_vpd_00 != 0) {
+            rc = LSM_ERR_NO_SUPPORT;
+            goto out;
+        }
+
+        if (_sg_is_vpd_page_supported(vpd_00_data, page_code) == true) {
+            /* Current VPD page is supported, then it's a library bug */
+            rc = LSM_ERR_LIB_BUG;
+            _lsm_err_msg_set(err_msg,
+                             "BUG: VPD page 0x%02x is supported, "
+                             "but failed with error %d(%s)",
+                             page_code, ioctl_errno,
+                             strerror_r(ioctl_errno, strerr_buff,
+                                        _LSM_ERR_MSG_LEN));
+            goto out;
+
+        }
+
+        rc = LSM_ERR_NO_SUPPORT;
+
+        _lsm_err_msg_set(err_msg, "SCSI VPD 0x%02x page is not supported",
+                         page_code);
+        goto out;
+    }
+
+ out:
+
+    return rc;
+}
+
+bool _sg_is_vpd_page_supported(uint8_t *vpd_0_data, uint8_t page_code)
+{
+    uint16_t supported_list_len = 0;
+    uint16_t i = 0;
+
+    assert(vpd_0_data != NULL);
+
+    supported_list_len = (vpd_0_data[2] << 8) + vpd_0_data[3];
+
+    for (; i < supported_list_len; ++i) {
+        if (i + _T10_SPC_VPD_SUP_VPD_PGS_LIST_OFFSET >= _SG_T10_SPC_VPD_MAX_LEN)
+            break;
+        if (page_code == vpd_0_data[i + _T10_SPC_VPD_SUP_VPD_PGS_LIST_OFFSET])
+            return true;
+    }
+    return false;
+}
+
+int _sg_parse_vpd_83(char *err_msg, uint8_t *vpd_data,
+                     struct _sg_t10_vpd83_dp ***dps, uint16_t *dp_count)
+{
+    int rc = LSM_ERR_OK;
+    struct _sg_t10_vpd83_header *vpd83_header = NULL;
+    uint8_t *p = NULL;
+    uint8_t *end_p = NULL;
+    struct _sg_t10_vpd83_dp_header * dp_header = NULL;
+    struct _sg_t10_vpd83_dp *dp = NULL;
+    uint16_t i = 0;
+    uint16_t vpd83_len = 0;
+
+    assert(err_msg != NULL);
+    assert(vpd_data != NULL);
+    assert(dps != NULL);
+    assert(dp_count != NULL);
+
+    *dps = NULL;
+    *dp_count = 0;
+
+    vpd83_header = (struct _sg_t10_vpd83_header*) vpd_data;
+
+    if (vpd83_header->page_code != _SG_T10_SPC_VPD_DI) {
+        rc = LSM_ERR_LIB_BUG;
+        _lsm_err_msg_set(err_msg, "BUG: Got incorrect VPD page code '%02x', "
+                         "should be 0x83", vpd83_header->page_code);
+        goto out;
+    }
+
+    vpd83_len = ntohs(vpd83_header->page_len) +
+        sizeof(struct _sg_t10_vpd83_header);
+
+    end_p = vpd_data + vpd83_len - 1;
+    if (end_p >= vpd_data + _SG_T10_SPC_VPD_MAX_LEN) {
+        rc = LSM_ERR_LIB_BUG;
+        _lsm_err_msg_set(err_msg, "BUG: Got invalid VPD DI page response, "
+                         "data length exceeded the maximum size of a legal VPD "
+                         "data");
+        goto out;
+    }
+    p = vpd_data + sizeof(struct _sg_t10_vpd83_header);
+
+    /* First loop finds out how many IDs we have */
+    while(p <= end_p) {
+        if (p + sizeof(struct _sg_t10_vpd83_dp_header) > end_p) {
+            rc = LSM_ERR_LIB_BUG;
+            _lsm_err_msg_set(err_msg, "BUG: Illegal VPD 0x83 page data, "
+                             "got partial designation descriptor.");
+            goto out;
+        }
+        ++i;
+
+        dp_header = (struct _sg_t10_vpd83_dp_header *) p;
+
+        p += dp_header->designator_len + sizeof(struct _sg_t10_vpd83_dp_header);
+        continue;
+    }
+
+    if (i == 0)
+        goto out;
+
+    *dps = (struct _sg_t10_vpd83_dp **)
+        malloc(sizeof(struct _sg_t10_vpd83_dp*) * i);
+
+    if (*dps == NULL) {
+        rc = LSM_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    p = vpd_data + sizeof(struct _sg_t10_vpd83_header);
+
+    while(*dp_count < i) {
+        dp = _sg_t10_vpd83_dp_new();
+        if (dp == NULL) {
+            rc = LSM_ERR_NO_MEMORY;
+            goto out;
+        }
+        (*dps)[*dp_count] = dp;
+        ++*dp_count;
+
+        dp_header = (struct _sg_t10_vpd83_dp_header *) p;
+        memcpy(&dp->header, dp_header, sizeof(struct _sg_t10_vpd83_dp_header));
+        memcpy(dp->designator, p + sizeof(struct _sg_t10_vpd83_dp_header),
+               dp_header->designator_len);
+
+        p += dp_header->designator_len + sizeof(struct _sg_t10_vpd83_dp_header);
+        continue;
+    }
+
+ out:
+    if (rc != LSM_ERR_OK) {
+        if (*dps != NULL) {
+            _sg_t10_vpd83_dp_array_free(*dps, *dp_count);
+            *dps = NULL;
+            *dp_count = 0;
+        }
+    }
+    return rc;
+}
+
+static struct _sg_t10_vpd83_dp *_sg_t10_vpd83_dp_new(void)
+{
+    struct _sg_t10_vpd83_dp *dp = NULL;
+
+    dp = (struct _sg_t10_vpd83_dp *) malloc(sizeof(struct _sg_t10_vpd83_dp));
+
+    if (dp != NULL) {
+        memset(dp, 0, sizeof(struct _sg_t10_vpd83_dp));
+    }
+    return dp;
+}
+
+static int _sg_io_open(char *err_msg, const char *disk_path, int *fd, int oflag)
+{
+    int rc = LSM_ERR_OK;
+    char strerr_buff[_LSM_ERR_MSG_LEN];
+
+    assert(err_msg != NULL);
+    assert(disk_path != NULL);
+    assert(fd != NULL);
+
+    *fd = open(disk_path, oflag);
+    if (*fd < 0) {
+        switch(errno) {
+        case ENOENT:
+            rc = LSM_ERR_NOT_FOUND_DISK;
+            _lsm_err_msg_set(err_msg, "Disk %s not found", disk_path);
+            goto out;
+        case EACCES:
+            rc = LSM_ERR_PERMISSION_DENIED;
+            _lsm_err_msg_set(err_msg, "Permission denied: Cannot open %s "
+                             "with %d flag", disk_path, oflag);
+            goto out;
+        default:
+            rc = LSM_ERR_LIB_BUG;
+            _lsm_err_msg_set(err_msg, "BUG: Failed to open %s, error: %d, %s",
+                             disk_path, errno,
+                             strerror_r(errno, strerr_buff, _LSM_ERR_MSG_LEN));
+        }
+    }
+ out:
+    return rc;
+}
+
+int _sg_io_open_ro(char *err_msg, const char *disk_path, int *fd)
+{
+    return _sg_io_open(err_msg, disk_path, fd, O_RDONLY|O_NONBLOCK);
+}
+
+void _sg_t10_vpd83_dp_array_free(struct _sg_t10_vpd83_dp **dps,
+                                 uint16_t dp_count)
+{
+    uint16_t i = 0;
+
+    assert(dps != NULL);
+
+    for (; i < dp_count; ++i) {
+        free(dps[i]);
+    }
+    free(dps);
+}

--- a/c_binding/libsg.h
+++ b/c_binding/libsg.h
@@ -67,6 +67,13 @@
 /* SPC-5 Table 444 - PROTOCOL IDENTIFIER field values */
 #define _SG_T10_SPC_PROTOCOL_ID_RESERVED           0xc
 
+#define _SG_T10_SPC_RECV_DIAG_MAX_LEN               0xffff
+/* ^ SPC-5 rev 7, Table 219 - RECEIVE DIAGNOSTIC RESULTS command */
+#define _SG_T10_SPC_SEND_DIAG_MAX_LEN               0xffff
+/* ^ SPC-5 rev 7, Table 269 - SEND DIAGNOSTIC command */
+#define _SG_T10_SPC_PROTOCOL_ID_SAS                 6
+/* ^ SPC-5 rev 7, Table 444 - PROTOCOL IDENTIFIER field values */
+
 #pragma pack(push, 1)
 
 /*
@@ -139,5 +146,44 @@ LSM_DLL_LOCAL int _sg_parse_vpd_83(char *err_msg, uint8_t *vpd_data,
  */
 LSM_DLL_LOCAL bool _sg_is_vpd_page_supported(uint8_t *vpd_0_data,
                                              uint8_t page_code);
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  disk_path != NULL
+ *  fd != NULL
+ */
+LSM_DLL_LOCAL int _sg_io_open_rw(char *err_msg, const char *disk_path, int *fd);
+
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  fd >= 0
+ *  tp_sas_addr != NULL
+ *  tp_sas_addr is char[_SG_T10_SPL_SAS_ADDR_LEN]
+ */
+LSM_DLL_LOCAL int _sg_tp_sas_addr_of_disk(char *err_msg, int fd,
+                                          char *tp_sas_addr);
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  fd >= 0
+ *  data != NULL
+ *  data is uint8_t[_SG_T10_SPC_RECV_DIAG_MAX_LEN]
+ */
+LSM_DLL_LOCAL int _sg_io_recv_diag(char *err_msg, int fd, uint8_t page_code,
+                                   uint8_t *data);
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  fd >= 0
+ *  data != NULL
+ *  data is uint8_t[_SG_T10_SPC_SEND_DIAG_MAX_LEN]
+ */
+LSM_DLL_LOCAL int _sg_io_send_diag(char *err_msg, int fd, uint8_t *data,
+                                   uint16_t data_len);
 
 #endif  /* End of _LIBSG_H_ */

--- a/c_binding/libsg.h
+++ b/c_binding/libsg.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#ifndef _LIBSG_H_
+#define _LIBSG_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "libstoragemgmt/libstoragemgmt_common.h"
+
+/* SPC-5 rev 7, Table 487 - ASSOCIATION field */
+#define _SG_T10_SPC_ASSOCIATION_TGT_PORT            1
+
+#define _SG_T10_SPC_VPD_DI_DESIGNATOR_TYPE_NAA      0x3
+
+/* SPL-4 rev5 4.2.4 SAS address. With trailing \0. */
+#define _SG_T10_SPL_SAS_ADDR_LEN                    17
+/* SPL-4 rev5 4.2.4 SAS address. */
+#define _SG_T10_SPL_SAS_ADDR_LEN_BITS               8
+
+#define _SG_T10_SPC_VPD_DI                          0x83
+#define _SG_T10_SPC_VPD_DI_NAA_235_ID_LEN           8
+#define _SG_T10_SPC_VPD_DI_NAA_6_ID_LEN             16
+#define _SG_T10_SPC_VPD_DI_NAA_TYPE_2               0x2
+#define _SG_T10_SPC_VPD_DI_NAA_TYPE_3               0x3
+#define _SG_T10_SPC_VPD_DI_NAA_TYPE_5               0x5
+#define _SG_T10_SPC_VPD_DI_NAA_TYPE_6               0x6
+#define _SG_T10_SPC_VPD_DI_ASSOCIATION_LUN          0
+
+/* SBC-4 rev9 Table 236 - Block Device Characteristics VPD page */
+#define _SG_T10_SBC_VPD_BLK_DEV_CHA                 0xb1
+/* SBC-4 rev9 Table 237 - MEDIUM ROTATION RATE field */
+#define _SG_T10_SBC_MEDIUM_ROTATION_NO_SUPPORT      0
+/* SBC-4 rev9 Table 237 - MEDIUM ROTATION RATE field */
+#define _SG_T10_SBC_MEDIUM_ROTATION_SSD             1
+
+/* SAT-4 rev4 12.4.2 ATA Information VPD page */
+#define _SG_T10_SPC_VPD_ATA_INFO                    0x89
+
+/* SPC-5 rev 7, 7.7.16 Supported VPD Pages VPD page */
+#define _SG_T10_SPC_VPD_SUP_VPD_PGS                 0x00
+
+/* SPC-5 rev 7, Table 142 - INQUIRY command */
+#define _SG_T10_SPC_INQUIRY_MAX_LEN                 0xffff
+/* VPD is a INQUIRY */
+#define _SG_T10_SPC_VPD_MAX_LEN                     _SG_T10_SPC_INQUIRY_MAX_LEN
+
+/* SPC-5 Table 444 - PROTOCOL IDENTIFIER field values */
+#define _SG_T10_SPC_PROTOCOL_ID_OBSOLETE           1
+/* SPC-5 Table 444 - PROTOCOL IDENTIFIER field values */
+#define _SG_T10_SPC_PROTOCOL_ID_RESERVED           0xc
+
+#pragma pack(push, 1)
+
+/*
+ * SPC-5 rev 7 Table 590 - Designation descriptor
+ */
+struct _sg_t10_vpd83_dp_header {
+    uint8_t code_set        : 4;
+    uint8_t protocol_id     : 4;
+    uint8_t designator_type : 4;
+    uint8_t association     : 2;
+    uint8_t reserved_1      : 1;
+    uint8_t piv             : 1;
+    uint8_t reserved_2;
+    uint8_t designator_len;
+};
+
+/* SPC-5 rev 7, Table 486 - Designation descriptor. */
+LSM_DLL_LOCAL struct _sg_t10_vpd83_dp {
+    struct _sg_t10_vpd83_dp_header header;
+    uint8_t designator[0xff];
+};
+
+LSM_DLL_LOCAL struct _sg_t10_vpd83_naa_header {
+    uint8_t data_msb : 4;
+    uint8_t naa_type : 4;
+};
+
+#pragma pack(pop)
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  disk_path != NULL
+ *  fd != NULL
+ */
+LSM_DLL_LOCAL int _sg_io_open_ro(char *err_msg, const char *disk_path, int *fd);
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  fd >= 0
+ *  data != NULL
+ *  data is uint8_t[_SG_T10_SPC_VPD_MAX_LEN]
+ */
+LSM_DLL_LOCAL int _sg_io_vpd(char *err_msg, int fd, uint8_t page_code,
+                             uint8_t *data);
+
+/*
+ * Preconditions:
+ *  dps != NULL
+ */
+LSM_DLL_LOCAL void _sg_t10_vpd83_dp_array_free(struct _sg_t10_vpd83_dp **dps,
+                                               uint16_t dp_count);
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  vpd_data != NULL
+ *  vpd_data is uint8_t[_SG_T10_SPC_VPD_MAX_LEN]
+ *  dps != NULL
+ *  dp_count != NULL
+ */
+LSM_DLL_LOCAL int _sg_parse_vpd_83(char *err_msg, uint8_t *vpd_data,
+                                   struct _sg_t10_vpd83_dp ***dps,
+                                   uint16_t *dp_count);
+/*
+ * Preconditions:
+ *  vpd_0_data != NULL
+ *  vpd_0_data is uint8_t[_SG_T10_SPC_VPD_MAX_LEN]
+ */
+LSM_DLL_LOCAL bool _sg_is_vpd_page_supported(uint8_t *vpd_0_data,
+                                             uint8_t page_code);
+
+#endif  /* End of _LIBSG_H_ */

--- a/c_binding/lsm_local_disk.c
+++ b/c_binding/lsm_local_disk.c
@@ -31,61 +31,14 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdarg.h>
-#include <arpa/inet.h>
-#include <scsi/sg.h>
-#include <scsi/scsi.h>
-#include <sys/ioctl.h>
 #include <assert.h>
 #include <endian.h>
 
 #include "libstoragemgmt/libstoragemgmt.h"
 #include "libstoragemgmt/libstoragemgmt_error.h"
 #include "libstoragemgmt/libstoragemgmt_plug_interface.h"
-
-#define _T10_SBC_VPD_BLK_DEV_CHA                        0xb1
-/* ^ SBC-4 rev9 Table 236 - Block Device Characteristics VPD page */
-#define _T10_SBC_VPD_BLK_DEV_CHA_MAX_PAGE_LEN            0x3c + 4
-/* ^ SBC-4 rev9 Table 236 Block Device Characteristics VPD page */
-#define _T10_SPC_VPD_SUP_VPD_PGS                         0x00
-/* ^ SPC-5 rev7 7.7.16 Supported VPD Pages VPD page */
-#define _T10_SPC_VPD_SUP_VPD_PGS_MAX_PAGE_LEN            0xff + 1 + 4
-/* ^ There are 256(0xff + 1) page codes, each only take 1 byte, we only
- *   need 256 bytes to store them. Addition 4 bytes for VPD 0x00 page header.
- *   Please refer to "SPC-5 rev7 Table 534 - Supported VPD Pages VPD page"
- *   for detail.
- */
-#define _T10_SPC_VPD_SUP_VPD_PGS_LIST_OFFSET            4
-/* ^ SPC-5 rev7 Table 534 - Supported VPD Pages VPD page */
-#define _T10_SPC_INQUERY_CMD_LEN                        6
-/* ^ SPC-5 rev7 Table 142 - INQUIRY command */
-#define _T10_SBC_MEDIUM_ROTATION_NO_SUPPORT             0
-/* ^ SPC-5 rev7 Table 237 - MEDIUM ROTATION RATE field */
-#define _T10_SBC_MEDIUM_ROTATION_SSD                    1
-/* ^ SPC-5 rev7 Table 237 - MEDIUM ROTATION RATE field */
-
-#define _VPD_QUERY_TMO                                  1000
-/* ^ VPD timeout: 1 second */
-/*TODO(Gris Ge): Raise LSM_ERR_TIMEOUT error for this */
-
-#define _T10_SPC_VPD_DI                         0x83
-#define _T10_SPC_VPD_DI_MAX_LEN                 0xff + 4
-#define _T10_SPC_VPD_DI_NAA_235_ID_LEN          8
-#define _T10_SPC_VPD_DI_NAA_6_ID_LEN            16
-#define _T10_SPC_VPD_DI_DESIGNATOR_TYPE_NAA     0x3
-#define _T10_SPC_VPD_DI_NAA_TYPE_2              0x2
-#define _T10_SPC_VPD_DI_NAA_TYPE_3              0x3
-#define _T10_SPC_VPD_DI_NAA_TYPE_5              0x5
-#define _T10_SPC_VPD_DI_NAA_TYPE_6              0x6
-#define _T10_SPC_VPD_DI_ASSOCIATION_LUN         0
-/* ^ SPC-5 rev7 7.7.6 Device Identification VPD page */
-#define _T10_SPC_VPD_ATA_INFO                   0x89
-/* ^ SAT-4 rev4 12.4.2 ATA Information VPD page */
-#define _T10_SPC_ASSOCIATION_TGT_PORT           1
-/* ^ SPC-5 rev7 Table 487 — ASSOCIATION field */
-#define _T10_SPC_PROTOCOL_ID_OBSOLETE           1
-/* ^ SPC-5 Table 444 — PROTOCOL IDENTIFIER field values */
-#define _T10_SPC_PROTOCOL_ID_RESERVED           0xc
-/* ^ SPC-5 Table 444 — PROTOCOL IDENTIFIER field values */
+#include "utils.h"
+#include "libsg.h"
 
 #define _LSM_MAX_VPD83_ID_LEN                   33
 /* ^ Max one is 6h IEEE Registered Extended ID which it 32 bits hex string. */
@@ -107,43 +60,6 @@
 #define _LSM_ERR_MSG_LEN 255
 
 #pragma pack(push, 1)
-/*
- * Table 589 - Device Identification VPD page
- */
-struct t10_vpd83_header {
-    uint8_t dev_type : 5;
-    /* ^ PERIPHERAL DEVICE TYPE */
-    uint8_t qualifier : 3;
-    /* PERIPHERAL QUALIFIER */
-    uint8_t page_code;
-    uint16_t page_len;
-};
-
-/*
- * Table 590 - Designation descriptor
- */
-struct t10_vpd83_dp_header {
-    uint8_t code_set        : 4;
-    uint8_t protocol_id     : 4;
-    uint8_t designator_type : 4;
-    uint8_t association     : 2;
-    uint8_t reserved_1      : 1;
-    uint8_t piv             : 1;
-    uint8_t reserved_2;
-    uint8_t designator_len;
-};
-
-struct t10_vpd83_dp {
-    struct t10_vpd83_dp_header header;
-    uint8_t designator[0xff];
-};
-/* ^ SPC-5 rev7 Table 486 - Designation descriptor. */
-
-struct t10_vpd83_naa_header {
-    uint8_t data_msb : 4;
-    uint8_t naa_type : 4;
-};
-
 struct t10_sbc_vpd_bdc {
     uint8_t we_dont_care_0;
     uint8_t pg_code;
@@ -155,163 +71,35 @@ struct t10_sbc_vpd_bdc {
 
 #pragma pack(pop)
 
-#define _lsm_err_msg_clear(err_msg) memset(err_msg, 0, _LSM_ERR_MSG_LEN)
-
-#define _lsm_err_msg_set(err_msg, format, ...) \
-    snprintf(err_msg, _LSM_ERR_MSG_LEN, format, ##__VA_ARGS__)
-
-#define _lsm_string_list_foreach(l, i, d) \
-    for(i = 0; \
-        (l != NULL) && (i < lsm_string_list_size(l)) && \
-        (d = lsm_string_list_elem_get(l, i)); \
-        ++i)
-
-#define _good(rc, rc_val, out) \
-        do { \
-                rc_val = rc; \
-                if (rc_val != LSM_ERR_OK) \
-                        goto out; \
-        } while(0)
-
-/*
- * All the 'err_msg' used in these static functions are expected to be
- * pointer of char[_LSM_ERR_MSG_LEN].
- */
-static void _be_raw_to_hex(uint8_t *raw, size_t len, char *out);
-static int _sysfs_read_file(char *err_msg, const char *sys_fs_path,
-                            uint8_t *buff, ssize_t *size, size_t max_size);
 static int _sysfs_vpd83_naa_of_sd_name(char *err_msg, const char *sd_name,
                                        char *vpd83);
 static int _udev_vpd83_of_sd_name(char *err_msg, const char *sd_name,
                                   char *vpd83);
 static int _sysfs_get_all_sd_names(char *err_msg,
                                    lsm_string_list **sd_name_list);
-static int _check_null_ptr(char *err_msg, int arg_count, ...);
-static bool _file_is_exist(char *err_msg, const char *path);
-static int _parse_vpd_83(char *err_msg, uint8_t *vpd_data,
-                         uint16_t vpd_data_len, struct t10_vpd83_dp ***dps,
-                         uint16_t *dp_count);
-static struct t10_vpd83_dp *_t10_vpd83_dp_new(void);
-static void _t10_vpd83_dp_array_free(struct t10_vpd83_dp **dps,
-                                    uint16_t dp_count);
 static int _sysfs_vpd_pg83_data_get(char *err_msg, const char *sd_name,
                                     uint8_t *vpd_data, ssize_t *read_size);
-static int _sg_io_ioctl_vpd(char *err_msg, int fd, uint8_t page_cde,
-                            uint8_t *vpd_data, uint16_t vpd_data_len);
-static int _sg_io_ioctl_open(char *err_msg, const char *sd_path, int *fd);
-static bool _is_vpd_page_supported(uint8_t *vpd_0_data, uint16_t vpd_0_len,
-                                   uint8_t page_code);
-
-/*
- * Assume input path is not NULL or empty string.
- * Try to open provided path file or folder, return true if file could be open,
- * or false.
- */
-static bool _file_is_exist(char *err_msg, const char *path)
-{
-    int fd = 0;
-
-    fd = open(path, O_RDONLY);
-    if (fd == -1) {
-        return false;
-    }
-    close(fd);
-    return true;
-}
-
-/*
- * Check whether input pointer is NULL.
- * If found NULL pointer, set error message and return LSM_ERR_INVALID_ARGUMENT.
- * Return LSM_ERR_OK if no NULL pointer.
- */
-static int _check_null_ptr(char *err_msg, int arg_count, ...)
-{
-    int rc = LSM_ERR_OK;
-    va_list arg;
-    int i = 0;
-    void *ptr = NULL;
-
-    va_start(arg, arg_count);
-
-    for (; i < arg_count; ++i) {
-        ptr = va_arg(arg, void*);
-        if (ptr == NULL) {
-            _lsm_err_msg_set(err_msg, "Got NULL pointer in arguments");
-            rc = LSM_ERR_INVALID_ARGUMENT;
-            goto out;
-        }
-    }
-
- out:
-    va_end(arg);
-    return rc;
-}
-
-/*
- * Input big-endian uint8_t array, output has hex string.
- * No check on output memory size or boundary, make sure before invoke.
- */
-static void _be_raw_to_hex(uint8_t *raw, size_t len, char *out)
-{
-    size_t i = 0;
-
-    for (; i < len; ++i) {
-        snprintf(out + (i * 2), 3, "%02x", raw[i]);
-    }
-    out[len * 2] = 0;
-
-}
-
-static int _sysfs_read_file(char *err_msg, const char *sys_fs_path,
-                            uint8_t *buff, ssize_t *size, size_t max_size)
-{
-    int fd = -1;
-    char strerr_buff[_LSM_ERR_MSG_LEN];
-
-    *size = 0;
-    memset(buff, 0, max_size);
-
-    fd = open(sys_fs_path, O_RDONLY);
-    if (fd < 0) {
-        if (errno == ENOENT)
-            return LSM_ERR_NO_SUPPORT;
-
-        _lsm_err_msg_set(err_msg, "_sysfs_read_file(): Failed to open %s, "
-                         "error: %d, %s", sys_fs_path, errno,
-                         strerror_r(errno, strerr_buff, _LSM_ERR_MSG_LEN));
-        return LSM_ERR_LIB_BUG;
-    }
-    *size = read(fd, buff, max_size);
-    close(fd);
-
-    if (*size < 0) {
-        _lsm_err_msg_set(err_msg, "Failed to read %s, error: %d, %s",
-                         sys_fs_path, errno,
-                         strerror_r(errno, strerr_buff, _LSM_ERR_MSG_LEN));
-        return LSM_ERR_LIB_BUG;
-    }
-    return LSM_ERR_OK;
-}
-
 /*
  * Retrieve the content of /sys/block/sda/device/vpd_pg83 file.
  * No argument checker here, assume all non-NULL and vpd_data is
-                * char[_T10_SPC_VPD_DI_MAX_LEN]
+                * char[_SG_T10_SPC_VPD_MAX_LEN]
  */
 static int _sysfs_vpd_pg83_data_get(char *err_msg, const char *sd_name,
                                     uint8_t *vpd_data, ssize_t *read_size)
 {
+    int file_rc = 0;
     char sysfs_path[_MAX_SYSFS_VPD83_PATH_STR_LEN];
     char sysfs_blk_path[_MAX_SYSFS_BLK_PATH_STR_LEN];
+    char strerr_buff[_LSM_ERR_MSG_LEN];
 
-    memset(vpd_data, 0, _T10_SPC_VPD_DI_MAX_LEN);
+    memset(vpd_data, 0, _SG_T10_SPC_VPD_MAX_LEN);
 
     /*
      * Check the existence of disk vis /sys/block/sdX folder.
      */
     snprintf(sysfs_blk_path, _MAX_SYSFS_BLK_PATH_STR_LEN,
              _SYSFS_BLK_PATH_FORMAT, sd_name);
-    if (_file_is_exist(err_msg, sysfs_blk_path) == false) {
+    if (! _file_exists(sysfs_blk_path)) {
         _lsm_err_msg_set(err_msg, "Disk %s not found", sd_name);
         return LSM_ERR_NOT_FOUND_DISK;
     }
@@ -319,8 +107,21 @@ static int _sysfs_vpd_pg83_data_get(char *err_msg, const char *sd_name,
     snprintf(sysfs_path, _MAX_SYSFS_VPD83_PATH_STR_LEN,
              _SYSFS_VPD83_PATH_FORMAT, sd_name);
 
-    return _sysfs_read_file(err_msg, sysfs_path, vpd_data, read_size,
-                            _T10_SPC_VPD_DI_MAX_LEN);
+    file_rc = _read_file(sysfs_path, vpd_data, read_size,
+                         _SG_T10_SPC_VPD_MAX_LEN);
+    if (file_rc != 0) {
+        if (errno == ENOENT) {
+            _lsm_err_msg_set(err_msg, "File '%s' not exist", sysfs_path);
+            return LSM_ERR_NO_SUPPORT;
+        } else {
+            _lsm_err_msg_set(err_msg, "BUG: Unknown error %d(%s) from "
+                             "_read_file().", file_rc,
+                             strerror_r(file_rc, strerr_buff,
+                                        _LSM_ERR_MSG_LEN));
+            return LSM_ERR_LIB_BUG;
+        }
+    }
+    return LSM_ERR_OK;
 }
 
 /*
@@ -340,10 +141,10 @@ static int _sysfs_vpd83_naa_of_sd_name(char *err_msg, const char *sd_name,
                                        char *vpd83)
 {
     ssize_t read_size = 0;
-    struct t10_vpd83_naa_header *naa_header = NULL;
+    struct _sg_t10_vpd83_naa_header *naa_header = NULL;
     int rc = LSM_ERR_OK;
-    uint8_t vpd_data[_T10_SPC_VPD_DI_MAX_LEN];
-    struct t10_vpd83_dp **dps = NULL;
+    uint8_t vpd_data[_SG_T10_SPC_VPD_MAX_LEN];
+    struct _sg_t10_vpd83_dp **dps = NULL;
     uint16_t dp_count = 0;
     uint16_t i = 0;
 
@@ -359,24 +160,24 @@ static int _sysfs_vpd83_naa_of_sd_name(char *err_msg, const char *sd_name,
     _good(_sysfs_vpd_pg83_data_get(err_msg, sd_name, vpd_data, &read_size),
           rc, out);
 
-    _good(_parse_vpd_83(err_msg, vpd_data, read_size, &dps, &dp_count),
-          rc, out);
+    _good(_sg_parse_vpd_83(err_msg, vpd_data, &dps, &dp_count), rc, out);
 
     for (; i < dp_count; ++i) {
         if ((dps[i]->header.designator_type ==
-             _T10_SPC_VPD_DI_DESIGNATOR_TYPE_NAA)  &&
-            (dps[i]->header.association == _T10_SPC_VPD_DI_ASSOCIATION_LUN)) {
-            naa_header = (struct t10_vpd83_naa_header *) dps[i]->designator;
+             _SG_T10_SPC_VPD_DI_DESIGNATOR_TYPE_NAA)  &&
+            (dps[i]->header.association ==
+             _SG_T10_SPC_VPD_DI_ASSOCIATION_LUN)) {
+            naa_header = (struct _sg_t10_vpd83_naa_header *) dps[i]->designator;
             switch(naa_header->naa_type) {
-            case _T10_SPC_VPD_DI_NAA_TYPE_2:
-            case _T10_SPC_VPD_DI_NAA_TYPE_3:
-            case _T10_SPC_VPD_DI_NAA_TYPE_5:
+            case _SG_T10_SPC_VPD_DI_NAA_TYPE_2:
+            case _SG_T10_SPC_VPD_DI_NAA_TYPE_3:
+            case _SG_T10_SPC_VPD_DI_NAA_TYPE_5:
                 _be_raw_to_hex((uint8_t *) naa_header,
-                               _T10_SPC_VPD_DI_NAA_235_ID_LEN, vpd83);
+                               _SG_T10_SPC_VPD_DI_NAA_235_ID_LEN, vpd83);
                 break;
-            case _T10_SPC_VPD_DI_NAA_TYPE_6:
+            case _SG_T10_SPC_VPD_DI_NAA_TYPE_6:
                 _be_raw_to_hex((uint8_t *) naa_header,
-                               _T10_SPC_VPD_DI_NAA_6_ID_LEN, vpd83);
+                               _SG_T10_SPC_VPD_DI_NAA_6_ID_LEN, vpd83);
                 break;
             default:
                 rc = LSM_ERR_LIB_BUG;
@@ -394,7 +195,7 @@ static int _sysfs_vpd83_naa_of_sd_name(char *err_msg, const char *sd_name,
 
  out:
     if (dps != NULL)
-        _t10_vpd83_dp_array_free(dps, dp_count);
+        _sg_t10_vpd83_dp_array_free(dps, dp_count);
     return rc;
 }
 
@@ -506,131 +307,6 @@ static int _sysfs_get_all_sd_names(char *err_msg,
     if (rc != LSM_ERR_OK) {
         lsm_string_list_free(*sd_name_list);
         *sd_name_list = NULL;
-    }
-    return rc;
-}
-
-static struct t10_vpd83_dp *_t10_vpd83_dp_new(void)
-{
-    struct t10_vpd83_dp *dp = NULL;
-
-    dp = (struct t10_vpd83_dp *) malloc(sizeof(struct t10_vpd83_dp));
-
-    if (dp != NULL) {
-        memset(dp, 0, sizeof(struct t10_vpd83_dp));
-    }
-    return dp;
-}
-
-/*
- * Assuming input pointer is not NULL, caller should do that.
- */
-static void _t10_vpd83_dp_array_free(struct t10_vpd83_dp **dps,
-                                    uint16_t dp_count)
-{
-    uint16_t i = 0;
-    for (; i < dp_count; ++i) {
-        free(dps[i]);
-    }
-    free(dps);
-}
-
-/*
- * Assuming input pointer is not NULL, caller should do that.
- * The memory of output pointer 'dps' should be manually freed.
- *
- */
-static int _parse_vpd_83(char *err_msg, uint8_t *vpd_data,
-                         uint16_t vpd_data_len, struct t10_vpd83_dp ***dps,
-                         uint16_t *dp_count)
-{
-    int rc = LSM_ERR_OK;
-    struct t10_vpd83_header *vpd83_header = NULL;
-    uint8_t *p = NULL;
-    uint8_t *end_p = NULL;
-    struct t10_vpd83_dp_header * dp_header = NULL;
-    struct t10_vpd83_dp *dp = NULL;
-    uint16_t i = 0;
-    uint32_t vpd83_len = 0;
-
-    if (vpd_data_len < sizeof(struct t10_vpd83_header)) {
-        rc = LSM_ERR_LIB_BUG;
-        _lsm_err_msg_set(err_msg, "BUG: VPD 83 data len '%" PRIu16
-                         "' is less than struct t10_vpd83_header size '%zu'",
-                         vpd_data_len, sizeof(struct t10_vpd83_header));
-        goto out;
-    }
-
-    *dps = NULL;
-    *dp_count = 0;
-
-    vpd83_header = (struct t10_vpd83_header*) vpd_data;
-
-    if (vpd83_header->page_code != _T10_SPC_VPD_DI) {
-        rc = LSM_ERR_LIB_BUG;
-        _lsm_err_msg_set(err_msg, "BUG: Got incorrect VPD page code '%02x', "
-                         "should be 0x83", vpd83_header->page_code);
-        goto out;
-    }
-
-    vpd83_len = ntohs(vpd83_header->page_len) + sizeof(struct t10_vpd83_header);
-
-    end_p = vpd_data + vpd83_len - 1;
-    p = vpd_data + sizeof(struct t10_vpd83_header);
-
-    /* First loop find out how many id we got */
-    while(p <= end_p) {
-        if (p + sizeof(struct t10_vpd83_dp_header) > end_p) {
-            rc = LSM_ERR_LIB_BUG;
-            _lsm_err_msg_set(err_msg, "BUG: Illegal VPD 0x83 page data, "
-                             "got partial designation descriptor.");
-            goto out;
-        }
-        ++i;
-
-        dp_header = (struct t10_vpd83_dp_header *) p;
-
-        p += dp_header->designator_len + sizeof(struct t10_vpd83_dp_header);
-        continue;
-    }
-
-    if (i == 0)
-        goto out;
-
-    *dps = (struct t10_vpd83_dp **) malloc(sizeof(struct t10_vpd83_dp*) * i);
-
-    if (*dps == NULL) {
-        rc = LSM_ERR_NO_MEMORY;
-        goto out;
-    }
-
-    p = vpd_data + sizeof(struct t10_vpd83_header);
-
-    while(*dp_count < i) {
-        dp = _t10_vpd83_dp_new();
-        if (dp == NULL) {
-            rc = LSM_ERR_NO_MEMORY;
-            goto out;
-        }
-        (*dps)[*dp_count] = dp;
-        ++*dp_count;
-
-        dp_header = (struct t10_vpd83_dp_header *) p;
-        memcpy(&dp->header, dp_header, sizeof(struct t10_vpd83_dp_header));
-        memcpy(dp->designator, p + sizeof(struct t10_vpd83_dp_header),
-               dp_header->designator_len);
-
-        p += dp_header->designator_len + sizeof(struct t10_vpd83_dp_header);
-        continue;
-    }
-
- out:
-    if (rc != LSM_ERR_OK) {
-        if (*dps != NULL) {
-            _t10_vpd83_dp_array_free(*dps, *dp_count);
-            *dps = NULL;
-            *dp_count = 0;
-        }
     }
     return rc;
 }
@@ -813,165 +489,10 @@ int lsm_local_disk_vpd83_get(const char *disk_path, char **vpd83,
     return rc;
 }
 
-/*
- * Preconditions:
- *  vpd_0_len > 3
- *  vpd_0_data not NULL
- */
-static bool _is_vpd_page_supported(uint8_t *vpd_0_data, uint16_t vpd_0_len,
-                                   uint8_t page_code)
-{
-    uint16_t supported_list_len = 0;
-    uint16_t i = 0;
-
-    assert(vpd_0_len > 3);
-    assert(vpd_0_data != NULL);
-
-    supported_list_len = (vpd_0_data[2] << 8) + vpd_0_data[3];
-
-    for (; (i < supported_list_len) &&
-           ((i + _T10_SPC_VPD_SUP_VPD_PGS_LIST_OFFSET) < vpd_0_len); ++i) {
-        if (page_code == vpd_0_data[i + _T10_SPC_VPD_SUP_VPD_PGS_LIST_OFFSET])
-            return true;
-    }
-    return false;
-}
-
-/*
- * Preconditions:
- *  err_msg != NULL
- *  fd >= 0
- *  vpd_data != NULL
- *  vpd_data_len > 0
- */
-static int _sg_io_ioctl_vpd(char *err_msg, int fd, uint8_t page_code,
-                            uint8_t *vpd_data, uint16_t vpd_data_len)
-{
-    int rc = LSM_ERR_OK;
-    uint8_t vpd_00_data[_T10_SPC_VPD_SUP_VPD_PGS_MAX_PAGE_LEN];
-    uint8_t cdb[_T10_SPC_INQUERY_CMD_LEN];
-    struct sg_io_hdr io_hdr;
-    int ioctl_rc = 0;
-    int ioctl_errno = 0;
-    int rc_vpd_00 = 0;
-    char strerr_buff[_LSM_ERR_MSG_LEN];
-
-    assert(err_msg != NULL);
-    assert(fd >= 0);
-    assert(vpd_data != NULL);
-    assert(vpd_data_len > 0);
-
-    /* SPC-5 Table 142 - INQUIRY command */
-    cdb[0] = INQUIRY;
-    /* ^ OPERATION CODE */
-    cdb[1] = 1;
-    /* ^  EVPD, VPD INQUIRY require EVPD == 1 */;
-    cdb[2] = page_code & UINT8_MAX;
-    /* ^ PAGE CODE */
-    cdb[3] = (vpd_data_len >> 8 )& UINT8_MAX;
-    /* ^ ALLOCATION LENGTH, MSB */
-    cdb[4] = vpd_data_len & UINT8_MAX;
-    /* ^ ALLOCATION LENGTH, LSB */
-    cdb[5] = 0;
-    /* ^ CONTROL, no need to handle auto contingent allegiance(ACA) */
-
-    memset(&io_hdr, 0, sizeof(struct sg_io_hdr));
-    memset(vpd_data, 0, (size_t) vpd_data_len);
-    io_hdr.interface_id = 'S'; /* 'S' for SCSI generic */
-    io_hdr.cmd_len = _T10_SPC_INQUERY_CMD_LEN;
-    io_hdr.sbp = NULL; /* No need to parse sense data */
-    io_hdr.mx_sb_len = 0;
-    io_hdr.dxfer_direction = SG_DXFER_FROM_DEV;
-    io_hdr.dxfer_len = vpd_data_len;
-    io_hdr.dxferp = vpd_data;
-    io_hdr.cmdp = cdb;
-    io_hdr.timeout = _VPD_QUERY_TMO;
-
-    ioctl_rc = ioctl(fd, SG_IO, &io_hdr);
-    if (ioctl_rc != 0) {
-        ioctl_errno = errno;
-        if (page_code == _T10_SPC_VPD_SUP_VPD_PGS) {
-            _lsm_err_msg_set(err_msg, "Not a SCSI compatible device");
-            return LSM_ERR_NO_SUPPORT;
-        }
-        /* Check whether provided page is supported */
-        rc_vpd_00 = _sg_io_ioctl_vpd(err_msg, fd, _T10_SPC_VPD_SUP_VPD_PGS,
-                                     vpd_00_data,
-                                     _T10_SPC_VPD_SUP_VPD_PGS_MAX_PAGE_LEN);
-        if (rc_vpd_00 != 0) {
-            rc = LSM_ERR_NO_SUPPORT;
-            goto out;
-        }
-
-        if (_is_vpd_page_supported(vpd_00_data,
-                                   _T10_SPC_VPD_SUP_VPD_PGS_MAX_PAGE_LEN,
-                                   page_code) == true) {
-            /* Current VPD page is supported, then it's a library bug */
-            rc = LSM_ERR_LIB_BUG;
-            _lsm_err_msg_set(err_msg,
-                             "BUG: VPD page 0x%02x is supported, "
-                             "but failed with error %d(%s)", ioctl_rc,
-                             strerror_r(ioctl_errno, strerr_buff, _LSM_ERR_MSG_LEN));
-            goto out;
-
-        }
-
-        rc = LSM_ERR_NO_SUPPORT;
-
-        _lsm_err_msg_set(err_msg, "SCSI VPD 0x%02x page is not supported",
-                         page_code);
-        goto out;
-    }
-
- out:
-    if (rc != LSM_ERR_OK)
-        memset(vpd_data, 0, (size_t) vpd_data_len);
-
-    return rc;
-}
-
-/*
- * Preconditions:
- *  err_msg != NULL
- *  sd_path != NULL
- *  fd != NULL
- */
-static int _sg_io_ioctl_open(char *err_msg, const char *sd_path, int *fd)
-{
-    int rc = LSM_ERR_OK;
-    char strerr_buff[_LSM_ERR_MSG_LEN];
-
-    assert(err_msg != NULL);
-    assert(sd_path != NULL);
-    assert(fd != NULL);
-
-    *fd = open(sd_path, O_RDONLY|O_NONBLOCK);
-    if (*fd < 0) {
-        switch(errno) {
-        case ENOENT:
-            rc = LSM_ERR_NOT_FOUND_DISK;
-            _lsm_err_msg_set(err_msg, "Disk %s not found", sd_path);
-            goto out;
-        case EACCES:
-            rc = LSM_ERR_PERMISSION_DENIED;
-            _lsm_err_msg_set(err_msg, "Permission denied: Cannot open %s "
-                             "with O_RDONLY and O_NONBLOCK flag", sd_path);
-            goto out;
-        default:
-            rc = LSM_ERR_LIB_BUG;
-            _lsm_err_msg_set(err_msg, "BUG: Failed to open %s, error: %d, %s",
-                             sd_path, errno,
-                             strerror_r(errno, strerr_buff, _LSM_ERR_MSG_LEN));
-        }
-    }
- out:
-    return rc;
-}
-
 int lsm_local_disk_rpm_get(const char *sd_path, int32_t *rpm,
                            lsm_error **lsm_err)
 {
-    uint8_t vpd_data[_T10_SBC_VPD_BLK_DEV_CHA_MAX_PAGE_LEN];
+    uint8_t vpd_data[_SG_T10_SPC_VPD_MAX_LEN];
     int fd = -1;
     char err_msg[_LSM_ERR_MSG_LEN];
     int rc = LSM_ERR_OK;
@@ -984,30 +505,26 @@ int lsm_local_disk_rpm_get(const char *sd_path, int32_t *rpm,
 
     _lsm_err_msg_clear(err_msg);
 
-    rc = _sg_io_ioctl_open(err_msg, sd_path, &fd);
-    if (rc != LSM_ERR_OK)
-        goto out;
+    _good(_sg_io_open_ro(err_msg, sd_path, &fd), rc, out);
+    _good(_sg_io_vpd(err_msg, fd, _SG_T10_SBC_VPD_BLK_DEV_CHA,  vpd_data),
+          rc, out);
 
-    rc = _sg_io_ioctl_vpd(err_msg, fd, _T10_SBC_VPD_BLK_DEV_CHA,  vpd_data,
-                          _T10_SBC_VPD_BLK_DEV_CHA_MAX_PAGE_LEN);
-    if (rc != LSM_ERR_OK)
-        goto out;
     bdc = (struct t10_sbc_vpd_bdc *) vpd_data;
-    if (bdc->pg_code != _T10_SBC_VPD_BLK_DEV_CHA) {
+    if (bdc->pg_code != _SG_T10_SBC_VPD_BLK_DEV_CHA) {
         rc = LSM_ERR_LIB_BUG;
         _lsm_err_msg_set(err_msg, "Got corrupted SCSI SBC "
                          "Device Characteristics VPD page, expected page code "
                          "is %d but got % " PRIu8 "",
-                         _T10_SBC_VPD_BLK_DEV_CHA, bdc->pg_code);
+                         _SG_T10_SBC_VPD_BLK_DEV_CHA, bdc->pg_code);
         goto out;
     }
 
     *rpm = be16toh(bdc->medium_rotation_rate_be);
     if (((*rpm >= 2) && (*rpm <= 0x400)) || (*rpm == 0xffff) ||
-        (*rpm == _T10_SBC_MEDIUM_ROTATION_NO_SUPPORT))
+        (*rpm == _SG_T10_SBC_MEDIUM_ROTATION_NO_SUPPORT))
         *rpm = LSM_DISK_RPM_NO_SUPPORT;
 
-    if (*rpm == _T10_SBC_MEDIUM_ROTATION_SSD)
+    if (*rpm == _SG_T10_SBC_MEDIUM_ROTATION_SSD)
         *rpm = LSM_DISK_RPM_NON_ROTATING_MEDIUM;
 
  out:
@@ -1151,14 +668,14 @@ int lsm_local_disk_link_type_get(const char *disk_path,
                                  lsm_disk_link_type *link_type,
                                  lsm_error **lsm_err)
 {
-    unsigned char vpd_sup_data[_T10_SPC_VPD_SUP_VPD_PGS_MAX_PAGE_LEN];
-    unsigned char vpd_di_data[_T10_SPC_VPD_DI_MAX_LEN];
+    unsigned char vpd_sup_data[_SG_T10_SPC_VPD_MAX_LEN];
+    unsigned char vpd_di_data[_SG_T10_SPC_VPD_MAX_LEN];
     int fd = -1;
     char err_msg[_LSM_ERR_MSG_LEN];
     int rc = LSM_ERR_OK;
-    struct t10_vpd83_dp **dps = NULL;
+    struct _sg_t10_vpd83_dp **dps = NULL;
     uint16_t dp_count = 0;
-    uint8_t protocol_id = _T10_SPC_PROTOCOL_ID_OBSOLETE;
+    uint8_t protocol_id = _SG_T10_SPC_PROTOCOL_ID_OBSOLETE;
     uint16_t i = 0;
 
     _lsm_err_msg_clear(err_msg);
@@ -1170,33 +687,27 @@ int lsm_local_disk_link_type_get(const char *disk_path,
     *link_type = LSM_DISK_LINK_TYPE_NO_SUPPORT;
     *lsm_err = NULL;
 
-    _good(_sg_io_ioctl_open(err_msg, disk_path, &fd), rc, out);
-    _good(_sg_io_ioctl_vpd(err_msg, fd, _T10_SPC_VPD_SUP_VPD_PGS,
-                          vpd_sup_data, _T10_SPC_VPD_SUP_VPD_PGS_MAX_PAGE_LEN),
+    _good(_sg_io_open_ro(err_msg, disk_path, &fd), rc, out);
+    _good(_sg_io_vpd(err_msg, fd, _SG_T10_SPC_VPD_SUP_VPD_PGS, vpd_sup_data),
           rc, out);
 
-    if (_is_vpd_page_supported(vpd_sup_data,
-                               _T10_SPC_VPD_SUP_VPD_PGS_MAX_PAGE_LEN,
-                               _T10_SPC_VPD_ATA_INFO) == true) {
+    if (_sg_is_vpd_page_supported(vpd_sup_data,
+                                  _SG_T10_SPC_VPD_ATA_INFO) == true) {
         *link_type = LSM_DISK_LINK_TYPE_ATA;
         goto out;
     }
 
-    _good(_sg_io_ioctl_vpd(err_msg, fd, _T10_SPC_VPD_DI, vpd_di_data,
-                           _T10_SPC_VPD_DI_MAX_LEN),
-          rc, out);
+    _good(_sg_io_vpd(err_msg, fd, _SG_T10_SPC_VPD_DI, vpd_di_data), rc, out);
 
-    _good(_parse_vpd_83(err_msg, vpd_di_data, _T10_SPC_VPD_DI_MAX_LEN, &dps,
-                        &dp_count),
-          rc, out);
+    _good(_sg_parse_vpd_83(err_msg, vpd_di_data, &dps, &dp_count), rc, out);
 
     for (; i < dp_count; ++i) {
-        if ((dps[i]->header.association != _T10_SPC_ASSOCIATION_TGT_PORT) ||
+        if ((dps[i]->header.association != _SG_T10_SPC_ASSOCIATION_TGT_PORT) ||
             (dps[i]->header.piv != 1))
             continue;
         protocol_id = dps[i]->header.protocol_id;
-        if ((protocol_id == _T10_SPC_PROTOCOL_ID_OBSOLETE) ||
-            (protocol_id >= _T10_SPC_PROTOCOL_ID_RESERVED)) {
+        if ((protocol_id == _SG_T10_SPC_PROTOCOL_ID_OBSOLETE) ||
+            (protocol_id >= _SG_T10_SPC_PROTOCOL_ID_RESERVED)) {
             rc = LSM_ERR_LIB_BUG;
             _lsm_err_msg_set(err_msg, "Got unknown protocol ID: %02x",
                              protocol_id);
@@ -1211,7 +722,7 @@ int lsm_local_disk_link_type_get(const char *disk_path,
         close(fd);
 
     if (dps != NULL)
-        _t10_vpd83_dp_array_free(dps, dp_count);
+        _sg_t10_vpd83_dp_array_free(dps, dp_count);
 
     if (rc != LSM_ERR_OK) {
         if (lsm_err != NULL)

--- a/c_binding/lsm_local_disk.c
+++ b/c_binding/lsm_local_disk.c
@@ -514,7 +514,7 @@ int lsm_local_disk_rpm_get(const char *sd_path, int32_t *rpm,
         rc = LSM_ERR_LIB_BUG;
         _lsm_err_msg_set(err_msg, "Got corrupted SCSI SBC "
                          "Device Characteristics VPD page, expected page code "
-                         "is %d but got % " PRIu8 "",
+                         "is %d but got %" PRIu8 "",
                          _SG_T10_SBC_VPD_BLK_DEV_CHA, bdc->pg_code);
         goto out;
     }

--- a/c_binding/utils.c
+++ b/c_binding/utils.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#include "utils.h"
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+
+int _check_null_ptr(char *err_msg, int arg_count, ...)
+{
+    int rc = LSM_ERR_OK;
+    va_list arg;
+    int i = 0;
+    void *ptr = NULL;
+
+    assert(err_msg != NULL);
+
+    va_start(arg, arg_count);
+
+    for (; i < arg_count; ++i) {
+        ptr = va_arg(arg, void*);
+        if (ptr == NULL) {
+            _lsm_err_msg_set(err_msg, "Got NULL pointer in arguments");
+            rc = LSM_ERR_INVALID_ARGUMENT;
+            goto out;
+        }
+    }
+
+ out:
+    va_end(arg);
+    return rc;
+}
+
+void _be_raw_to_hex(uint8_t *raw, size_t len, char *out)
+{
+    size_t i = 0;
+
+    assert(raw != NULL);
+    assert(out != NULL);
+
+    for (; i < len; ++i) {
+        snprintf(out + (i * 2), 3, "%02x", raw[i]);
+    }
+    out[len * 2] = 0;
+
+}
+
+bool _file_exists(const char *path)
+{
+    int fd = 0;
+
+    assert(path != NULL);
+
+    fd = open(path, O_RDONLY);
+    if (fd == -1) {
+        return false;
+    }
+    close(fd);
+    return true;
+}
+
+int _read_file(const char *path, uint8_t *buff, ssize_t *size, size_t max_size)
+{
+    int fd = -1;
+
+    assert(path != NULL);
+    assert(buff != NULL);
+    assert(size != NULL);
+
+    *size = 0;
+    memset(buff, 0, max_size);
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return errno;
+    *size = read(fd, buff, max_size);
+    close(fd);
+
+    if (*size < 0)
+        return errno;
+    return 0;
+}

--- a/c_binding/utils.h
+++ b/c_binding/utils.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+#ifndef _LIB_UTILS_H_
+#define _LIB_UTILS_H_
+
+#include "libstoragemgmt/libstoragemgmt_error.h"
+
+#include <stdio.h>
+#include <stdbool.h>
+
+#define _LSM_ERR_MSG_LEN                255
+
+#define _good(rc, rc_val, out) \
+        do { \
+                rc_val = rc; \
+                if (rc_val != LSM_ERR_OK) \
+                        goto out; \
+        } while(0)
+
+#define _lsm_string_list_foreach(l, i, d) \
+    for(i = 0; \
+        (l != NULL) && (i < lsm_string_list_size(l)) && \
+        (d = lsm_string_list_elem_get(l, i)); \
+        ++i)
+
+#define _lsm_err_msg_clear(err_msg) memset(err_msg, 0, _LSM_ERR_MSG_LEN)
+
+#define _alloc_null_check(err_msg, ptr, rc, goto_out) \
+    do { \
+        if (ptr == NULL) { \
+            rc = LSM_ERR_NO_MEMORY; \
+            _lsm_err_msg_set(err_msg, "No memory"); \
+            goto goto_out; \
+        } \
+    } while(0)
+
+#define _lsm_err_msg_set(err_msg, format, ...) \
+    snprintf(err_msg, _LSM_ERR_MSG_LEN, format, ##__VA_ARGS__)
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *
+ * Check whether pointers are NULL.
+ * If found any NULL pointer, set error message and return
+ * LSM_ERR_INVALID_ARGUMENT.
+ * Return LSM_ERR_OK if no NULL pointer.
+ */
+LSM_DLL_LOCAL int _check_null_ptr(char *err_msg, int arg_count, ...);
+
+/*
+ * Preconditions:
+ *  raw != NULL
+ *  out != NULL
+ *
+ * Input big-endian uint8_t array, output has hex string.
+ * No check on output memory size or boundary, make sure before invoke.
+ */
+LSM_DLL_LOCAL void _be_raw_to_hex(uint8_t *raw, size_t len, char *out);
+
+/*
+ * Preconditions:
+ *  path != NULL
+ *
+ * Try to open provided path file or folder, return true if file could be open,
+ * or false.
+ */
+LSM_DLL_LOCAL bool _file_exists(const char *path);
+
+/*
+ * Preconditions:
+ *  path != NULL
+ *  buff != NULL
+ *  size != NULL
+ *
+ * Return the errno of open() if failed.
+ */
+LSM_DLL_LOCAL int _read_file(const char *path, uint8_t *buff, ssize_t *size,
+                             size_t max_size);
+
+#endif  /* End of _LIB_UTILS_H_ */

--- a/doc/man/lsmcli.1.in
+++ b/doc/man/lsmcli.1.in
@@ -655,6 +655,38 @@ Required. \fBWB\fR for write back mode, \fBWT\fR for write through mode,
 \fBAUTO\fR for auto mode which use \fBWB\fR mode when any battery is OK and use
 \fBWT\fR mode else.
 
+.SS local-disk-ident-led-on
+Turn on the identification LED for specified disk path.
+Require permission to open disk path as read-write, normally root user or disk
+group would have sufficient permission.
+.TP 15
+\fB--path\fR \fI<DISK_PATH>\fR
+Required. Disk path, like \fB/dev/sdb\fR.
+
+.SS local-disk-ident-led-off
+Turn off the identification LED for specified disk path.
+Require permission to open disk path as read-write, normally root user or disk
+group would have sufficient permission.
+.TP 15
+\fB--path\fR \fI<DISK_PATH>\fR
+Required. Disk path, like \fB/dev/sdb\fR.
+
+.SS local-disk-fault-led-on
+Turn on the fault LED for specified disk path.
+Require permission to open disk path as read-write, normally root user or disk
+group would have sufficient permission.
+.TP 15
+\fB--path\fR \fI<DISK_PATH>\fR
+Required. Disk path, like \fB/dev/sdb\fR.
+
+.SS local-disk-fault-led-off
+Turn off the fault LED for specified disk path.
+Require permission to open disk path as read-write, normally root user or disk
+group would have sufficient permission.
+.TP 15
+\fB--path\fR \fI<DISK_PATH>\fR
+Required. Disk path, like \fB/dev/sdb\fR.
+
 .IP
 .SH ALIAS
 .SS ls
@@ -719,6 +751,14 @@ Alias of 'volume-phy-disk-cache-update'
 Alias of 'volume-read-cache-policy-update'
 .SS vwcpu
 Alias of 'volume-write-cache-policy-update'
+.SS ldilon
+Alias of 'local-disk-ident-led-on'
+.SS ldiloff
+Alias of 'local-disk-ident-led-off'
+.SS ldflon
+Alias of 'local-disk-fault-led-on'
+.SS ldfloff
+Alias of 'local-disk-fault-led-off'
 
 .IP
 .SH SIZE OPTION

--- a/python_binding/lsm/_local_disk.py
+++ b/python_binding/lsm/_local_disk.py
@@ -16,7 +16,9 @@
 
 from lsm._clib import (_local_disk_vpd83_search, _local_disk_vpd83_get,
                        _local_disk_rpm_get, _local_disk_list,
-                       _local_disk_link_type_get)
+                       _local_disk_link_type_get, _local_disk_ident_led_on,
+                       _local_disk_ident_led_off, _local_disk_fault_led_on,
+                       _local_disk_fault_led_off)
 from lsm import LsmError, ErrorNumber
 
 
@@ -218,3 +220,117 @@ class LocalDisk(object):
                 No capability required as this is a library level method.
         """
         return _use_c_lib_function(_local_disk_link_type_get, disk_path)
+
+    @staticmethod
+    def ident_led_on(disk_path):
+        """
+        Version:
+            1.3
+        Usage:
+            Turn on the identification LED for specified disk.
+        Parameters:
+            disk_path (string)
+                The disk path, example '/dev/sdb'.
+        Returns:
+            None
+        SpecialExceptions:
+            LsmError
+                ErrorNumber.LIB_BUG
+                    Internal bug.
+                ErrorNumber.NOT_FOUND_DISK
+                    Provided disk is not found.
+                ErrorNumber.NO_SUPPORT
+                    Provided disk does not support SCSI SPC.
+                ErrorNumber.PERMISSION_DENIED
+                    No sufficient permission to access provided disk path.
+        Capability:
+            N/A
+                No capability required as this is a library level method.
+        """
+        return _use_c_lib_function(_local_disk_ident_led_on, disk_path)
+
+    @staticmethod
+    def ident_led_off(disk_path):
+        """
+        Version:
+            1.3
+        Usage:
+            Turn off the identification LED for specified disk.
+        Parameters:
+            disk_path (string)
+                The disk path, example '/dev/sdb'.
+        Returns:
+            None
+        SpecialExceptions:
+            LsmError
+                ErrorNumber.LIB_BUG
+                    Internal bug.
+                ErrorNumber.NOT_FOUND_DISK
+                    Provided disk is not found.
+                ErrorNumber.NO_SUPPORT
+                    Provided disk does not support SCSI SPC.
+                ErrorNumber.PERMISSION_DENIED
+                    No sufficient permission to access provided disk path.
+        Capability:
+            N/A
+                No capability required as this is a library level method.
+        """
+        return _use_c_lib_function(_local_disk_ident_led_off, disk_path)
+
+    @staticmethod
+    def fault_led_on(disk_path):
+        """
+        Version:
+            1.3
+        Usage:
+            Turn on the fault LED for specified disk.
+        Parameters:
+            disk_path (string)
+                The disk path, example '/dev/sdb'.
+        Returns:
+            None
+        SpecialExceptions:
+            LsmError
+                ErrorNumber.LIB_BUG
+                    Internal bug.
+                ErrorNumber.NOT_FOUND_DISK
+                    Provided disk is not found.
+                ErrorNumber.NO_SUPPORT
+                    Provided disk does not support SCSI SPC.
+                ErrorNumber.PERMISSION_DENIED
+                    No sufficient permission to access provided disk path.
+        Capability:
+            N/A
+                No capability required as this is a library level method.
+        """
+        return _use_c_lib_function(_local_disk_fault_led_on, disk_path)
+
+    @staticmethod
+    def fault_led_off(disk_path):
+        """
+        Version:
+            1.3
+        Usage:
+            Turn off the fault LED for specified disk.
+        Parameters:
+            disk_path (string)
+                The disk path, example '/dev/sdb'.
+        Returns:
+            None
+        SpecialExceptions:
+            LsmError
+                ErrorNumber.LIB_BUG
+                    Internal bug.
+                ErrorNumber.INVALID_ARGUMENT
+                    Invalid disk_path. Should be like '/dev/sdb'.
+                ErrorNumber.NOT_FOUND_DISK
+                    Provided disk is not found.
+                ErrorNumber.NO_SUPPORT
+                    Provided disk does not support SCSI SPC.
+                ErrorNumber.PERMISSION_DENIED
+                    No sufficient permission to access provided disk path.
+        Capability:
+            N/A
+                No capability required as this is a library level method.
+        """
+        return _use_c_lib_function(_local_disk_fault_led_off, disk_path)

--- a/tools/bash_completion/lsmcli
+++ b/tools/bash_completion/lsmcli
@@ -83,7 +83,11 @@ function _lsm()
                 volume-write-cache-policy-update vwcpu \
                 volume-cache-info vci volume-ident-led-on vilon \
                 volume-ident-led-off viloff local-disk-list ldl \
-                system-read-cache-pct-update srcpu"
+                system-read-cache-pct-update srcpu \
+                local-disk-ident-led-on ldilon \
+                local-disk-ident-led-off ldiloff \
+                local-disk-fault-led-on ldflon \
+                local-disk-fault-led-off ldfloff"
 
     list_args="--type"
     list_type_args="volumes pools fs snapshots exports nfs_client_auth \
@@ -141,6 +145,7 @@ function _lsm()
     volume_cache_info_args="--vol"
     volume_ident_led_on_off_args="--vol"
     system_read_cache_pct_update_args="--vol --read-pct"
+    local_disk_led_args="--path"
 
     # These operations can potentially be slow and cause hangs depending on plugin and configuration
     if [[ ${NO_VALUE_LOOKUP} -ne 0 ]] ; then
@@ -455,6 +460,14 @@ function _lsm()
             ;;
         system-read-cache-pct-update|srcpu)
             possible_args "${system_read_cache_pct_update_args}"
+            COMPREPLY=( $(compgen -W "${potential_args}" -- ${cur}) )
+            return 0
+            ;;
+        local-disk-ident-led-on|ldilon| \
+        local-disk-ident-led-off|ldiloff| \
+        local-disk-fault-led-on|ldflon| \
+        local-disk-fault-led-off|ldfloff)
+            possible_args "${local_disk_led_args}"
             COMPREPLY=( $(compgen -W "${potential_args}" -- ${cur}) )
             return 0
             ;;

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -42,7 +42,11 @@ from lsm.lsmcli.data_display import (
     vol_provision_str_to_type, vol_rep_type_str_to_type, VolumeRAIDInfo,
     PoolRAIDInfo, VcrCap, LocalDiskInfo, VolumeRAMCacheInfo)
 
-_CONNECTION_FREE_COMMANDS = ['local-disk-list']
+_CONNECTION_FREE_COMMANDS = ['local-disk-list',
+                             'local-disk-ident-led-on',
+                             'local-disk-ident-led-off',
+                             'local-disk-fault-led-on',
+                             'local-disk-fault-led-off']
 
 ## Wraps the invocation to the command line
 # @param    c   Object to invoke calls on (optional)
@@ -285,6 +289,9 @@ size_opt = dict(name='--size', metavar='<SIZE>', help=size_help)
 
 tgt_id_opt = dict(name="--tgt", help="Search by target port ID",
                   metavar='<TGT_ID>')
+
+local_disk_path_opt = dict(name='--path', help="Local disk path",
+                           metavar='<DISK_PATH>')
 
 cmds = (
     dict(
@@ -829,6 +836,34 @@ cmds = (
             dict(write_cache_policy_opt),
         ],
     ),
+    dict(
+        name='local-disk-ident-led-on',
+        help='Turn on the identification LED for a local disk',
+        args=[
+            dict(local_disk_path_opt),
+        ],
+    ),
+    dict(
+        name='local-disk-ident-led-off',
+        help='Turn off the identification LED for a local disk',
+        args=[
+            dict(local_disk_path_opt),
+        ],
+    ),
+    dict(
+        name='local-disk-fault-led-on',
+        help='Turn on the fault LED for a local disk',
+        args=[
+            dict(local_disk_path_opt),
+        ],
+    ),
+    dict(
+        name='local-disk-fault-led-off',
+        help='Turn off the fault LED for a local disk',
+        args=[
+            dict(local_disk_path_opt),
+        ],
+    ),
 )
 
 aliases = (
@@ -865,6 +900,10 @@ aliases = (
     ['vpdcu', 'volume-phy-disk-cache-update'],
     ['vrcpu', 'volume-read-cache-policy-update'],
     ['vwcpu', 'volume-write-cache-policy-update'],
+    ['ldilon', 'local-disk-ident-led-on'],
+    ['ldiloff', 'local-disk-ident-led-off'],
+    ['ldflon', 'local-disk-fault-led-on'],
+    ['ldfloff', 'local-disk-fault-led-off'],
 )
 
 
@@ -1785,3 +1824,15 @@ class CmdLine:
             [
                 VolumeRAMCacheInfo(
                     lsm_vol.id, *self.c.volume_cache_info(lsm_vol))])
+
+    def local_disk_ident_led_on(self, args):
+        LocalDisk.ident_led_on(args.path)
+
+    def local_disk_ident_led_off(self, args):
+        LocalDisk.ident_led_off(args.path)
+
+    def local_disk_fault_led_on(self, args):
+        LocalDisk.fault_led_on(args.path)
+
+    def local_disk_fault_led_off(self, args):
+        LocalDisk.fault_led_off(args.path)


### PR DESCRIPTION
* Only support SES(SCSI Enclosure Service) yet.
* New functions:
    * C:
        * `lsm_local_disk_ident_led_on()`
        * `lsm_local_disk_ident_led_off()`
        * `lsm_local_disk_fault_led_on()`
        * `lsm_local_disk_fault_led_off()`
    * Python:
        * `lsm.LocalDisk.ident_led_on()`
        * `lsm.LocalDisk.ident_led_off()`
        * `lsm.LocalDisk.fault_led_on()`
        * `lsm.LocalDisk.fault_led_off()`
* Tested on mpt2sas and hpsa enclosure.