### PR TITLE
libstoragemgmt: Add volume status field to volumes

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
@@ -165,6 +165,8 @@ typedef enum {
     /**^ Plug-in allows user to retrieve disk location */
     LSM_CAP_VOLUME_LED = 171,
     /**^ Plugin allows user to set and clear volume LEDs */
+    LSM_CAP_VOLUME_STATUS = 172,
+    /**^ Plugin allows user to retrieve volume health status */
     LSM_CAP_POOLS_QUICK_SEARCH = 210,
     /**^ Seach occurs on array */
     LSM_CAP_VOLUMES_QUICK_SEARCH = 211,

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
@@ -1353,6 +1353,14 @@ int LSM_DLL_EXPORT lsm_system_mode_set(lsm_system *sys,
 const char LSM_DLL_EXPORT *lsm_system_plugin_data_get(lsm_system *s);
 
 /**
+ * New in version 1.3. Set volume status.
+ * @param[in] v             Volume to update.
+ * @param[in] status        Volume status 'lsm_volume_status_type'.
+ * @return LSM_ERR_OK or LSM_ERR_INVALID_ARGUMENT.
+ */
+int LSM_DLL_EXPORT lsm_volume_status_set(lsm_volume *v,
+                                         lsm_volume_status_type status);
+/**
  * Allocates storage for Access_group array
  * @param size      Number of elements to store.
  * @return  NULL on error, else pointer to array for use.

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -179,6 +179,15 @@ typedef enum {
     /**^ Vendor specific RAID type */
 } lsm_volume_raid_type;
 
+    /** lsm_volume_status_type: Types for volume health */
+typedef enum {
+    LSM_VOLUME_STATUS_NO_SUPPORT = 0,
+    LSM_VOLUME_STATUS_OTHER = 1,
+    LSM_VOLUME_STATUS_OK = 2,
+    LSM_VOLUME_STATUS_DEGRADED = 3,
+    LSM_VOLUME_STATUS_RECONSTRUCTING = 4,
+    LSM_VOLUME_STATUS_ERROR = 5,
+} lsm_volume_status_type; 
 
     /**^ \enum lsm_pool_member_type Different types of Pool member*/
 typedef enum {

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_volumes.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_volumes.h
@@ -109,6 +109,36 @@ char LSM_DLL_EXPORT *lsm_volume_system_id_get(lsm_volume *v);
  */
 char LSM_DLL_EXPORT *lsm_volume_pool_id_get(lsm_volume *v);
 
+/**
+ * New in version 1.3. Retrieves volume health status:
+ *      LSM_VOLUME_STATUS_NO_SUPPORT
+ *          The value when the requested method is not supported.
+ *      LSM_VOLUME_STATUS_OTHER
+ *          The volume's status does not map to any statuses known to
+ *          libstoragemgmt.
+ *      LSM_VOLUME_STATUS_OK
+ *          The volume has no known health problems.
+ *      LSM_VOLUME_STATUS_DEGRADED
+ *          One or more of the volume's drives has failed,
+ *          but the volume can be recovered to full health and
+ *          can still execute IO in this state.
+ *      LSM_VOLUME_STATUS_RECONSTRUCTING
+ *          The volume is rebuilding to a fully healthy
+ *          state (a failed device has recovered or has been
+ *          replaced). The volume can still execute IO in this
+ *          state.
+ *      LSM_VOLUME_STATUS_ERROR
+ *          Enough drives have failed behind the volume to
+ *          prevent the volume from executing IO. The volume
+ *          may not be recoverable.
+ * @param       v       Volume to retrieve the status for.
+ * @param[out]  status  Volume status 'lsm_volume_status_type' pointer.
+ * @return LSM_ERR_OK on success, or LSM_ERR_NO_SUPPORT, or
+ *         LSM_ERR_INVALID_ARGUMENT.
+ */
+int LSM_DLL_EXPORT lsm_volume_status_get(lsm_volume *v,
+                                         lsm_volume_status_type *status);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/c_binding/lsm_convert.cpp
+++ b/c_binding/lsm_convert.cpp
@@ -59,6 +59,15 @@ lsm_volume *value_to_volume(Value & vol)
                                      v["system_id"].asString().c_str(),
                                      v["pool_id"].asString().c_str(),
                                      v["plugin_data"].asC_str());
+        if ((rc != NULL) && std_map_has_key(v, "status") &&
+            (v["status"].asInt32_t() != LSM_VOLUME_STATUS_NO_SUPPORT) &&
+            (lsm_volume_status_set(rc, (lsm_volume_status_type)
+                                   v["status"].asInt32_t()))) {
+
+            lsm_volume_record_free(rc);
+            rc= NULL;
+            throw ValueException("value_to_volume: failed to update 'status'");
+        }
     } else {
         throw ValueException("value_to_volume: Not correct type");
     }
@@ -80,6 +89,8 @@ Value volume_to_value(lsm_volume * vol)
         v["system_id"] = Value(vol->system_id);
         v["pool_id"] = Value(vol->pool_id);
         v["plugin_data"] = Value(vol->plugin_data);
+        if (vol->status != LSM_VOLUME_STATUS_NO_SUPPORT)
+            v["status"] = Value(vol->status);
         return Value(v);
     }
     return Value();

--- a/c_binding/lsm_datatypes.cpp
+++ b/c_binding/lsm_datatypes.cpp
@@ -911,6 +911,7 @@ lsm_volume *lsm_volume_record_copy(lsm_volume * vol)
                                      vol->block_size, vol->number_of_blocks,
                                      vol->admin_state, vol->system_id,
                                      vol->pool_id, vol->plugin_data);
+        rc->status = vol->status;
     }
     return rc;
 }
@@ -1075,6 +1076,30 @@ char *lsm_volume_system_id_get(lsm_volume * v)
 char *lsm_volume_pool_id_get(lsm_volume * v)
 {
     MEMBER_GET(v, LSM_IS_VOL, pool_id, NULL);
+}
+
+int lsm_volume_status_set(lsm_volume *v, lsm_volume_status_type status)
+{
+    if ((v == NULL) || (! LSM_IS_VOL(v)) ||
+        (status == LSM_VOLUME_STATUS_NO_SUPPORT))
+        return LSM_ERR_INVALID_ARGUMENT;
+
+    v->status = status;
+
+    return LSM_ERR_OK;
+}
+
+int lsm_volume_status_get(lsm_volume *v, lsm_volume_status_type *status)
+{
+    if ((v == NULL) || (status == NULL) || (! LSM_IS_VOL(v)))
+        return LSM_ERR_INVALID_ARGUMENT;
+
+    *status = v->status;
+
+    if (v->status != LSM_VOLUME_STATUS_NO_SUPPORT)
+        return LSM_ERR_OK;
+    else
+        return LSM_ERR_NO_SUPPORT;
 }
 
 int lsm_disk_location_set(lsm_disk * disk, const char *location)

--- a/c_binding/lsm_datatypes.hpp
+++ b/c_binding/lsm_datatypes.hpp
@@ -63,6 +63,7 @@ return_type name( param_sig )  {\
     char *system_id;                    /**< System this volume belongs */
     char *pool_id;                      /**< Pool this volume is derived from */
     char *plugin_data;                  /**< Private data for plugin */
+    lsm_volume_status_type status;	/**< Health status of this volume */
 };
 
 #define LSM_POOL_MAGIC       0xAA7A0001

--- a/plugin/sim/simarray.py
+++ b/plugin/sim/simarray.py
@@ -135,6 +135,7 @@ class BackStore(object):
     DEFAULT_STRIP_SIZE = 128 * 1024  # 128 KiB
     SYS_MODE = System.MODE_HARDWARE_RAID
     READ_CACHE_PCT = 10
+    VOL_STATUS = Volume.STATUS_OTHER
 
     _LIST_SPLITTER = '#'
 
@@ -1756,7 +1757,7 @@ class SimArray(object):
                       BackStore.BLK_SIZE,
                       int(sim_vol['total_space'] / BackStore.BLK_SIZE),
                       sim_vol['admin_state'], BackStore.SYS_ID,
-                      pool_id)
+                      pool_id, _status=BackStore.VOL_STATUS)
 
     @_handle_errors
     def volumes(self):

--- a/plugin/simc/simc_lsmplugin.c
+++ b/plugin/simc/simc_lsmplugin.c
@@ -758,6 +758,7 @@ static int volume_create(lsm_plugin_ptr c, lsm_pool * pool,
                                    "60a980003246694a412b45673342616e",
                                     BS, allocated_size/BS, 0, sys_id,
                                     lsm_pool_id_get(pool), NULL);
+                lsm_volume_status_set(v, LSM_VOLUME_STATUS_OTHER);
 
                 lsm_volume *to_store = lsm_volume_record_copy(v);
                 struct allocated_volume *av =
@@ -893,6 +894,7 @@ static int volume_resize(lsm_plugin_ptr c, lsm_volume * volume,
                                                     resized_size/BS, 0, sys_id,
                                                     lsm_volume_pool_id_get(volume),
                                                     NULL);
+            lsm_volume_status_set(vp, LSM_VOLUME_STATUS_OTHER);
 
             if( vp ) {
                 av->v = vp;

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -466,6 +466,20 @@ class TestPlugin(unittest.TestCase):
         if flag_created:
             self._volume_delete(volumes[0])
 
+    def test_vol_status_get(self):
+        (volumes, flag_created) = self._find_or_create_volumes()
+        self.assertTrue(len(volumes) > 0, "We need at least 1 volume to test")
+        for s in self.systems:
+            cap = self.c.capabilities(s)
+            if supported(cap, [Cap.VOLUME_STATUS]):
+                for vol in self.c.volumes():
+                    vol_status = vol.status
+                    self.assertTrue(vol_status is not None,
+                                    "Volume status retrieval failed")
+
+        if flag_created:
+            self._volume_delete(volumes[0])
+
     def test_disks_list(self):
         for s in self.systems:
             cap = self.c.capabilities(s)

--- a/test/tester.c
+++ b/test/tester.c
@@ -3032,6 +3032,36 @@ START_TEST(test_volume_raid_info)
 }
 END_TEST
 
+START_TEST(test_volume_status)
+{
+    lsm_volume *volume = NULL;
+    char *job = NULL;
+    lsm_pool *pool = get_test_pool(c);
+
+    int rc = lsm_volume_create(
+        c, pool, "volume_status_test", 20000000,
+        LSM_VOLUME_PROVISION_DEFAULT, &volume, &job, LSM_CLIENT_FLAG_RSVD);
+
+    fail_unless( rc == LSM_ERR_OK || rc == LSM_ERR_JOB_STARTED,
+            "lsmVolumeCreate %d (%s)", rc, error(lsm_error_last_get(c)));
+
+    if( LSM_ERR_JOB_STARTED == rc ) {
+        volume = wait_for_job_vol(c, &job);
+    }
+
+    lsm_volume_status_type status = LSM_VOLUME_STATUS_NO_SUPPORT;
+
+    G(rc, lsm_volume_status_get, volume, &status);
+
+    if (LSM_ERR_OK == rc)
+        printf("Volume status: (%d)\n", status);
+
+    G(rc, lsm_volume_record_free, volume);
+    G(rc, lsm_pool_record_free, pool);
+    volume = NULL;
+}
+END_TEST
+
 START_TEST(test_pool_member_info)
 {
     int rc;
@@ -3431,6 +3461,7 @@ Suite * lsm_suite(void)
     tcase_add_test(basic, test_nfs_exports);
     tcase_add_test(basic, test_invalid_input);
     tcase_add_test(basic, test_volume_raid_info);
+    tcase_add_test(basic, test_volume_status);
     tcase_add_test(basic, test_pool_member_info);
     tcase_add_test(basic, test_volume_raid_create_cap_get);
     tcase_add_test(basic, test_volume_raid_create);

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -174,6 +174,19 @@ def vol_rep_type_str_to_type(vol_rep_type_str):
     return _str_to_enum(vol_rep_type_str, _VOL_REP_TYPE_CONV)
 
 
+_VOL_STATUS_CONV = {
+    Volume.STATUS_OTHER: "OTHER",
+    Volume.STATUS_OK: "OK",
+    Volume.STATUS_DEGRADED: "DEGRADED",
+    Volume.STATUS_RECONSTRUCTING: "RECONSTRUCTING",
+    Volume.STATUS_ERROR: "ERROR",
+}
+
+
+def vol_status_to_str(vol_status):
+    return _VOL_STATUS_CONV.get(vol_status, "")
+
+
 _DISK_TYPE_CONV = {
     Disk.TYPE_UNKNOWN: 'UNKNOWN',
     Disk.TYPE_OTHER: 'Other',
@@ -420,11 +433,13 @@ class DisplayData(object):
     VOL_HEADER['pool_id'] = 'Pool ID'
     VOL_HEADER['system_id'] = 'System ID'
     VOL_HEADER['sd_paths'] = 'Disk Paths'    # This is appended by cmdline.py
+    VOL_HEADER['status'] = 'Status'
 
     VOL_COLUMN_SKIP_KEYS = ['block_size', 'num_of_blocks']
 
     VOL_VALUE_CONV_ENUM = {
-        'admin_state': vol_admin_state_to_str
+        'admin_state': vol_admin_state_to_str,
+        'status': vol_status_to_str,
     }
 
     VOL_VALUE_CONV_HUMAN = ['size_bytes', 'block_size']


### PR DESCRIPTION
This feature allows a user to see the health status of their volumes. Statuses that are handled explicitly: OK, DEGRADED, RECOVERING, and FAILED. Statuses that don't fall into those categories fall into the 'OTHER' status.

Tested on a P840ar in an Apollo 4200.

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>