### PR TITLE
libstoragemgmt flags: add flags to provide volume creation options

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -38,6 +38,16 @@ typedef uint64_t lsm_flag;
 #define LSM_CLIENT_FLAG_RSVD 0
 
 /**
+ * Options for volume settings at creation time.
+ * Bit field to support multiple settings for systems
+ * that can support them simultaneously.
+ */
+#define LSM_CLIENT_FLAG_VOLUME_CREATE_USE_SYSTEM_CACHE		0x00000001
+#define LSM_CLIENT_FLAG_VOLUME_CREATE_USE_IO_PASSTHROUGH	0x00000002
+#define LSM_CLIENT_FLAG_VOLUME_CREATE_DISABLE_SYSTEM_CACHE	0x00000004
+#define LSM_CLIENT_FLAG_VOLUME_CREATE_DISABLE_IO_PASSTHROUGH	0x00000008
+
+/**
  * Opaque data type for a connection.
  */
 typedef struct _lsm_connect lsm_connect;

--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -780,7 +780,8 @@ class SmartArray(IPlugin):
             1. Create LD
                 hpssacli ctrl slot=0 create type=ld \
                     drives=1i:1:13,1i:1:14 size=max raid=1+0 ss=64
-
+                NOTE: This now optionally appends arguments \
+                if certain Client flags are set.
             2. Find out the system ID.
 
             3. Find out the pool fist disk belong.
@@ -818,6 +819,18 @@ class SmartArray(IPlugin):
 
         if strip_size != Volume.VCR_STRIP_SIZE_DEFAULT:
             cmds.append("ss=%d" % int(strip_size / 1024))
+
+        if flags == Client.FLAG_VOLUME_CREATE_USE_SYSTEM_CACHE:
+            cmds.append("aa=enable")
+
+        if flags == Client.FLAG_VOLUME_CREATE_USE_IO_PASSTHROUGH:
+            cmds.append("ssdsmartpath=enable")
+
+        if flags == Client.FLAG_VOLUME_CREATE_DISABLE_SYSTEM_CACHE:
+            cmds.append("aa=disable")
+
+        if flags == Client.FLAG_VOLUME_CREATE_DISABLE_IO_PASSTHROUGH:
+            cmds.append("ssdsmartpath=disable")
 
         try:
             self._sacli_exec(cmds, flag_convert=False, flag_force=True)

--- a/python_binding/lsm/_client.py
+++ b/python_binding/lsm/_client.py
@@ -66,6 +66,11 @@ class Client(INetworkAttachedStorage):
     #
     FLAG_RSVD = 0
 
+    FLAG_VOLUME_CREATE_USE_SYSTEM_CACHE = 1 << 0
+    FLAG_VOLUME_CREATE_USE_IO_PASSTHROUGH = 1 << 1
+    FLAG_VOLUME_CREATE_DISABLE_SYSTEM_CACHE = 1 << 2
+    FLAG_VOLUME_CREATE_DISABLE_IO_PASSTHROUGH = 1 << 3
+
     """
     Client side class used for managing storage that utilises RPC mechanism.
     """


### PR DESCRIPTION
Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>

This attempts to address #106. All names are negotiable, but let me know if the concept is acceptable or unacceptable. 

From my perspective, pros:

* keeps the code quite simple
* prevents adding APIs for slight tweaks to existing APIs
* remains extensible and can be applied to non-HPE tech

cons:

* some flags may not map to all systems. How should that be handled and/or messaged to the user?

As always, thoughts are appreciated. This is the last feature I need in 1.3, once this and all outstanding feature pulls go in I think we're in very good shape for all use cases I'm trying to address.