### PR TITLE
Update libstoragemgmt_error documentation

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_disk.h
@@ -29,7 +29,8 @@ extern "C" {
 /**
  * Free the memory for a disk record
  * @param d     Disk memory to free
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ *         Returns LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_disk_record_free(lsm_disk *d);
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_error.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_error.h
@@ -28,105 +28,106 @@ extern "C" {
 /** @file libstoragemgmt_error.h */
 
 
-
-/**< \enum lsm_error_number Possible enumerated return codes from library */
+/** \enum lsm_error_number Possible enumerated return codes from library */
 typedef enum {
+    /** OK */
     LSM_ERR_OK = 0,
-    /**^ OK */
+    /** Library BUG */
     LSM_ERR_LIB_BUG = 1,
-    /**^ Library BUG */
+    /** Plugin BUG */
     LSM_ERR_PLUGIN_BUG = 2,
-    /**^ Plugin BUG */
+    /** Operation has started */
     LSM_ERR_JOB_STARTED = 7,
-    /**^ Operation has started */
+    /** Plug-in is un-responsive */
     LSM_ERR_TIMEOUT = 11,
-    /**^ Plug-in is un-responsive */
+    /** Daemon is not running */
     LSM_ERR_DAEMON_NOT_RUNNING = 12,
-    /**^ Daemon is not running */
 
+    /** Name exists */
     LSM_ERR_NAME_CONFLICT = 50,
-    /**^ Name exists */
+
+    /** Initiator exists in another access group */
     LSM_ERR_EXISTS_INITIATOR = 52,
-    /**^ Initiator exists in another access group */
 
+    /** Precondition checks failed */
     LSM_ERR_INVALID_ARGUMENT = 101,
-    /**^ Precondition checks failed */
 
+    /** Operation completed with no change in array state */
     LSM_ERR_NO_STATE_CHANGE = 125,
-    /**^ Operation completed with no change in array state */
 
+    /** Host on network, but not allowing connection */
     LSM_ERR_NETWORK_CONNREFUSED = 140,
-
-    /**^ Host on network, but not allowing connection */
+    /** Host unreachable on network */
     LSM_ERR_NETWORK_HOSTDOWN = 141,
-    /**^ Host unreachable on network */
+    /** Generic network error */
     LSM_ERR_NETWORK_ERROR = 142,
-    /**^ Generic network error */
 
+    /** Memory allocation failure */
     LSM_ERR_NO_MEMORY = 152,
-    /**^ Memory allocation failure */
+    /** Feature not supported */
     LSM_ERR_NO_SUPPORT = 153,
-    /**^ Feature not supported */
 
+    /** Volume masked to Access Group*/
     LSM_ERR_IS_MASKED = 160,
-    /**^ Volume masked to Access Group*/
 
+    /** Specified access group not found */
     LSM_ERR_NOT_FOUND_ACCESS_GROUP = 200,
 
-    /**^ Specified access group not found */
+    /** Specified FS not found */
     LSM_ERR_NOT_FOUND_FS = 201,
-    /**^ Specified FS not found */
+    /** Specified JOB not found */
     LSM_ERR_NOT_FOUND_JOB = 202,
-    /**^ Specified JOB not found */
+    /** Specified POOL not found */
     LSM_ERR_NOT_FOUND_POOL = 203,
-    /**^ Specified POOL not found */
+    /** Specified snap shot not found */
     LSM_ERR_NOT_FOUND_FS_SS = 204,
-    /**^ Specified snap shot not found */
+    /** Specified volume not found */
     LSM_ERR_NOT_FOUND_VOLUME = 205,
-    /**^ Specified volume not found */
+    /** NFS export not found */
     LSM_ERR_NOT_FOUND_NFS_EXPORT = 206,
 
-    /**^ NFS export not found */
+    /** System not found */
     LSM_ERR_NOT_FOUND_SYSTEM = 208,
-    /**^ System not found */
+    /** Disk not found */
     LSM_ERR_NOT_FOUND_DISK = 209,
-
+    /** Need license for feature */
     LSM_ERR_NOT_LICENSED = 226,
-    /**^ Need license for feature */
 
+    /** Take offline before performing operation */
     LSM_ERR_NO_SUPPORT_ONLINE_CHANGE = 250,
-    /**^ Take offline before performing operation */
+    /** Needs to be online to perform operation */
     LSM_ERR_NO_SUPPORT_OFFLINE_CHANGE = 251,
-    /**^ Needs to be online to perform operation */
 
+    /** Authorization failed */
     LSM_ERR_PLUGIN_AUTH_FAILED = 300,
 
-    /**^ Authorization failed */
+    /** Inter-process communication between client &
+        out of process plug-in encountered connection errors. */
     LSM_ERR_PLUGIN_IPC_FAIL = 301,
-    /**^ Inter-process communication between client &
-      out of process plug-in encountered connection errors.**/
 
+
+    /** Incorrect permission on UNIX domain socket used for IPC */
     LSM_ERR_PLUGIN_SOCKET_PERMISSION = 307,
 
-    /**^ Incorrect permission on UNIX domain socket used for IPC */
+    /** Plug-in does not appear to exist */
     LSM_ERR_PLUGIN_NOT_EXIST = 311,
-    /**^ Plug-in does not appear to exist */
 
+    /** Insufficient space */
     LSM_ERR_NOT_ENOUGH_SPACE = 350,
-    /**^ Insufficient space */
 
+    /** Error comunicating with plug-in */
     LSM_ERR_TRANSPORT_COMMUNICATION = 400,
-    /**^ Error comunicating with plug-in */
+    /** Transport serialization error */
     LSM_ERR_TRANSPORT_SERIALIZATION = 401,
-    /**^ Transport serialization error */
+    /** Parameter transported over IPC is invalid */
     LSM_ERR_TRANSPORT_INVALID_ARG = 402,
-    /**^ Parameter transported over IPC is invalid */
+
 
     LSM_ERR_LAST_INIT_IN_ACCESS_GROUP = 502,
 
-
+    /** Unsupport search key */
     LSM_ERR_UNSUPPORTED_SEARCH_KEY = 510,
-    /**^ Unsupport search key */
+
 
     LSM_ERR_EMPTY_ACCESS_GROUP = 511,
     LSM_ERR_POOL_NOT_READY = 512,

--- a/doc/doxygen.conf.in
+++ b/doc/doxygen.conf.in
@@ -985,7 +985,7 @@ DISABLE_INDEX          = NO
 # This tag can be used to set the number of enum values (range [1..20]) 
 # that doxygen will group on one line in the generated HTML documentation.
 
-ENUM_VALUES_PER_LINE   = 4
+ENUM_VALUES_PER_LINE   = 1
 
 # The GENERATE_TREEVIEW tag is used to specify whether a tree-like index 
 # structure should be generated to display hierarchical information. 


### PR DESCRIPTION
Updated libstoragemgmt_error.h enum documentation comments to fix Doxygen output. Updated error message of function lsm_disk_record_free in file libstoragemgmt_disk.h to refer to error code enum. Updated doxygen.conf to list enum numerical values in a manner easier for users to read.

Signed off by: Blaine Gardner <blaine.gardner@hpe.com>