### PR TITLE
smispy plugin: Numerous improvements

### DIFF
--- a/plugin/smispy/dmtf.py
+++ b/plugin/smispy/dmtf.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2014 Red Hat, Inc.
+# Copyright (C) 2011-2016 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/plugin/smispy/smis.py
+++ b/plugin/smispy/smis.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2014 Red Hat, Inc.
+# Copyright (C) 2011-2016 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -40,7 +40,7 @@ from utils import (merge_list, handle_cim_errors, hex_string_format)
 
 from smis_common import SmisCommon
 
-## Variable Naming scheme:
+# Variable Naming scheme:
 #   cim_xxx         CIMInstance
 #   cim_xxx_path    CIMInstanceName
 #   cim_sys         CIM_ComputerSystem  (root or leaf)
@@ -67,7 +67,7 @@ from smis_common import SmisCommon
 #   pool            Object of LSM Pool
 #   vol             Object of LSM Volume
 
-## Method Naming scheme:
+# Method Naming scheme:
 #   _cim_xxx()
 #       Return CIMInstance without any Associations() call.
 #   _cim_xxx_of(cim_yyy)
@@ -425,7 +425,7 @@ class Smis(IStorageAreaNetwork):
             method_data=volume_name)
 
     def _detach_netapp_e(self, vol, sync):
-        #Get the Configuration service for the system we are interested in.
+        # Get the Configuration service for the system we are interested in.
         cim_scs = self._c.cim_scs_of_sys_id(vol.system_id)
 
         in_params = {'Operation': pywbem.Uint16(2),
@@ -545,9 +545,9 @@ class Smis(IStorageAreaNetwork):
                             if Smis._cim_name_match(item, cim_vol_path):
                                 self._detach(vol, s)
 
-                    elif s['SyncState'] == dmtf.ST_SYNC_STATE_SYNCHRONIZED and \
-                        s['CopyType'] == \
-                        dmtf.ST_CONF_CAP_COPY_TYPE_UNSYNC_ASSOC:
+                    elif s['SyncState'] == dmtf.ST_SYNC_STATE_SYNCHRONIZED \
+                            and s['CopyType'] == \
+                            dmtf.ST_CONF_CAP_COPY_TYPE_UNSYNC_ASSOC:
 
                         if 'SyncedElement' in s:
                             item = s['SyncedElement']
@@ -566,16 +566,16 @@ class Smis(IStorageAreaNetwork):
         cim_scs = self._c.cim_scs_of_sys_id(volume.system_id)
         cim_vol_path = smis_vol.lsm_vol_to_cim_vol_path(self._c, volume)
 
-        #If we actually have an association to delete, the volume will be
-        #deleted with the association, no need to call ReturnToStoragePool
+        # If we actually have an association to delete, the volume will be
+        # deleted with the association, no need to call ReturnToStoragePool
         if not self._deal_volume_associations(volume, cim_vol_path):
             in_params = {'TheElement': cim_vol_path}
 
-            #Delete returns None or Job number
+            # Delete returns None or Job number
             return self._c.invoke_method(
                 'ReturnToStoragePool', cim_scs.path, in_params)[0]
 
-        #Loop to check to see if volume is actually gone yet!
+        # Loop to check to see if volume is actually gone yet!
         try:
             cim_vol = self._c.GetInstance(cim_vol_path, PropertyList=[])
             while cim_vol is not None:
@@ -704,7 +704,7 @@ class Smis(IStorageAreaNetwork):
 
             in_params = {'ElementName': name,
                          'SyncType': sync,
-                         #'Mode': mode,
+                         # 'Mode': mode,
                          'SourceElement': src_cim_vol_path,
                          'WaitForCopyState': dmtf.COPY_STATE_SYNC}
 

--- a/plugin/smispy/smis.py
+++ b/plugin/smispy/smis.py
@@ -18,8 +18,6 @@
 from string import split
 import time
 import copy
-import os
-import re
 
 import pywbem
 from pywbem import CIMError

--- a/plugin/smispy/smis.py
+++ b/plugin/smispy/smis.py
@@ -588,6 +588,19 @@ class Smis(IStorageAreaNetwork):
         """
         Delete a volume
         """
+        # We need to ensure that the volume is not masked before we try to
+        # delete it
+        ag = []
+        try:
+            ag = self.access_groups_granted_to_volume(volume)
+        except LsmError:
+            # We will ignore errors here and try the delete anyway
+            pass
+
+        if len(ag):
+            raise LsmError(ErrorNumber.IS_MASKED,
+                           "Volume is masked to access group")
+
         cim_scs = self._c.cim_scs_of_sys_id(volume.system_id)
 
         cim_vol_path = smis_vol.lsm_vol_to_cim_vol_path(self._c, volume)

--- a/plugin/smispy/smis.py
+++ b/plugin/smispy/smis.py
@@ -189,7 +189,8 @@ class Smis(IStorageAreaNetwork):
         (status (enum), percent_complete(integer), volume (None or Volume))
         """
         completed_item = None
-
+        status = JobStatus.ERROR
+        percent_complete = 0
         error_handler = None
 
         (ignore, retrieve_data, method_data) = SmisCommon.parse_job_id(job_id)
@@ -1761,9 +1762,6 @@ class Smis(IStorageAreaNetwork):
         """
         Return a list of CIMInstanceName of leaf CIM_ComputerSystem
         """
-        max_loop_count = 10   # There is no storage array need 10 layer of
-                              # Computer
-        loop_counter = max_loop_count
         rc = []
         leaf_cim_syss_path = []
         try:

--- a/plugin/smispy/smis_ag.py
+++ b/plugin/smispy/smis_ag.py
@@ -1,4 +1,4 @@
-## Copyright (C) 2014 Red Hat, Inc.
+# Copyright (C) 2014-2016 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/plugin/smispy/smis_ag.py
+++ b/plugin/smispy/smis_ag.py
@@ -56,7 +56,7 @@ def _init_id_and_type_of(cim_inits):
         init_type = init_types[0]
     elif len(init_type_dict) == 2:
         init_type = AccessGroup.INIT_TYPE_ISCSI_WWPN_MIXED
-    return (init_ids, init_type)
+    return init_ids, init_type
 
 
 def cim_spc_pros():

--- a/plugin/smispy/smis_cap.py
+++ b/plugin/smispy/smis_cap.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 Red Hat, Inc.
+# Copyright (C) 2014-2016 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -338,13 +338,12 @@ def get(smis_common, cim_sys, system):
     if smis_common.is_netappe():
         _rs_supported_capabilities(smis_common, system.id, cap)
 
-        #TODO We need to investigate why our interrogation code doesn't
-        #work.
-        #The array is telling us one thing, but when we try to use it, it
-        #doesn't work
+        # TODO We need to investigate why our interrogation code doesn't
+        # work. The array is telling us one thing, but when we try to use it,
+        # it doesn't work
         return cap
 
-     # 'Block Services Package' profile
+    # 'Block Services Package' profile
     _bsp_cap_set(smis_common, system.id, cap)
 
     # 'Disk Drive Lite' profile

--- a/plugin/smispy/smis_cap.py
+++ b/plugin/smispy/smis_cap.py
@@ -355,7 +355,7 @@ def get(smis_common, cim_sys, system):
     if cim_sys.path.classname == 'Clar_StorageSystem':
         mt = MASK_TYPE_MASK
 
-    if mask_type == MASK_TYPE_GROUP:
+    if mt == MASK_TYPE_GROUP:
         _group_mask_map_cap_set(smis_common, cim_sys.path, cap)
     else:
         _mask_map_cap_set(smis_common, cim_sys.path, cap)

--- a/plugin/smispy/smis_common.py
+++ b/plugin/smispy/smis_common.py
@@ -23,7 +23,6 @@
 
 from pywbem import Uint16, CIMError
 import pywbem
-import traceback
 import os
 import datetime
 import time

--- a/plugin/smispy/smis_common.py
+++ b/plugin/smispy/smis_common.py
@@ -216,8 +216,9 @@ class SmisCommon(object):
             self._wbem_conn.debug = True
 
         if namespace.lower() == SmisCommon._MEGARAID_NAMESPACE.lower():
-        # Skip profile register check on MegaRAID for better performance.
-        # MegaRAID SMI-S profile support status will not change for a while.
+            # Skip profile register check on MegaRAID for better performance.
+            # MegaRAID SMI-S profile support status will not change for a
+            # while.
             self._profile_dict = {
                 # Provide a fake profile support status to pass the check.
                 SmisCommon.SNIA_BLK_ROOT_PROFILE: SmisCommon.SMIS_SPEC_VER_1_4,

--- a/plugin/smispy/smis_common.py
+++ b/plugin/smispy/smis_common.py
@@ -483,6 +483,7 @@ class SmisCommon(object):
             CIMInstanceName # expect_class
         If flag_out_array is True, return the first element of out[out_key].
         """
+        cim_job = dict()
         (rc, out) = self._wbem_conn.InvokeMethod(cmd, cim_path, **in_params)
 
         try:

--- a/plugin/smispy/smis_common.py
+++ b/plugin/smispy/smis_common.py
@@ -377,7 +377,7 @@ class SmisCommon(object):
         if len(tmp_list) == 3:
             retrieve_data = int(tmp_list[1])
             method_data = tmp_list[2]
-        return (md5_str, retrieve_data, method_data)
+        return md5_str, retrieve_data, method_data
 
     def _dump_wbem_xml(self, file_prefix):
         """
@@ -512,7 +512,7 @@ class SmisCommon(object):
                 job_pros = ['JobState', 'ErrorDescription',
                             'OperationalStatus']
                 cim_xxxs_path = []
-                while(loop_counter <= SmisCommon._INVOKE_MAX_LOOP_COUNT):
+                while loop_counter <= SmisCommon._INVOKE_MAX_LOOP_COUNT:
                     cim_job = self.GetInstance(cim_job_path,
                                                PropertyList=job_pros)
                     job_state = cim_job['JobState']

--- a/plugin/smispy/smis_disk.py
+++ b/plugin/smispy/smis_disk.py
@@ -1,4 +1,4 @@
-## Copyright (C) 2014 Red Hat, Inc.
+# Copyright (C) 2014-2016 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/plugin/smispy/smis_disk.py
+++ b/plugin/smispy/smis_disk.py
@@ -17,7 +17,6 @@
 from lsm import Disk, md5, LsmError, ErrorNumber
 import dmtf
 from utils import merge_list
-from pywbem import CIM_ERR_NOT_FOUND, CIM_ERR_INVALID_PARAMETER
 from lsm.plugin.smispy.smis_common import SmisCommon
 
 

--- a/plugin/smispy/smis_pool.py
+++ b/plugin/smispy/smis_pool.py
@@ -1,4 +1,4 @@
-## Copyright (C) 2014 Red Hat, Inc.
+# Copyright (C) 2014-2016 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/plugin/smispy/smis_sys.py
+++ b/plugin/smispy/smis_sys.py
@@ -1,4 +1,4 @@
-## Copyright (C) 2014 Red Hat, Inc.
+# Copyright (C) 2014-2016 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/plugin/smispy/smis_vol.py
+++ b/plugin/smispy/smis_vol.py
@@ -19,7 +19,6 @@ This module intends to provide independent methods related to lsm.Volume and
 CIM_StorageVolume.
 """
 
-import re
 import sys
 
 from lsm import md5, Volume, LsmError, ErrorNumber

--- a/plugin/smispy/smis_vol.py
+++ b/plugin/smispy/smis_vol.py
@@ -1,4 +1,4 @@
-## Copyright (C) 2014 Red Hat, Inc.
+# Copyright (C) 2014-2016 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -183,7 +183,7 @@ def cim_vol_to_lsm_vol(cim_vol, pool_id, sys_id):
     if 'ElementName' in cim_vol:
         user_name = cim_vol["ElementName"]
     else:
-        #Better fallback value?
+        # Better fallback value?
         user_name = cim_vol['DeviceID']
 
     vpd_83 = _vpd83_of_cim_vol(cim_vol)
@@ -219,7 +219,8 @@ def lsm_vol_to_cim_vol_path(smis_common, lsm_vol):
 def volume_name_exists(smis_common, volume_name):
     """
     Try to minimize time to search.
-    :param volume_name:    Volume ElementName
+    :param smis_common:     Instance of SmisCommon class
+    :param volume_name:     Volume ElementName
     :return: True if volume exists with 'name', else False
     """
     all_cim_vols = smis_common.EnumerateInstances(

--- a/plugin/smispy/smispy_lsmplugin
+++ b/plugin/smispy/smispy_lsmplugin
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 
-# Copyright (C) 2011-2013 Red Hat, Inc.
+# Copyright (C) 2011-2016 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -27,9 +27,9 @@ try:
     if __name__ == '__main__':
         PluginRunner(Smis, sys.argv).run()
 except Exception:
-    #This should be quite rare, but when it does happen this is pretty
-    #key in understanding what happened, especially when it happens when
-    #running from the daemon.
+    # This should be quite rare, but when it does happen this is pretty
+    # key in understanding what happened, especially when it happens when
+    # running from the daemon.
     msg = str(traceback.format_exc())
     syslog.syslog(syslog.LOG_ERR, msg)
     sys.stderr.write(msg)

--- a/plugin/smispy/utils.py
+++ b/plugin/smispy/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 Red Hat, Inc.
+# Copyright (C) 2014-2016 Red Hat, Inc.
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
@@ -44,7 +44,7 @@ def handle_cim_errors(method):
                                        'Host is down')
                     if 'Errno 104' in desc:
                         raise LsmError(ErrorNumber.NETWORK_CONNREFUSED,
-                                   'Connection reset by peer')
+                                       'Connection reset by peer')
                     # We know we have a socket error of some sort, lets
                     # report a generic network error with the string from the
                     # library.

--- a/plugin/smispy/utils.py
+++ b/plugin/smispy/utils.py
@@ -42,6 +42,13 @@ def handle_cim_errors(method):
                     if 'Errno 113' in desc:
                         raise LsmError(ErrorNumber.NETWORK_HOSTDOWN,
                                        'Host is down')
+                    if 'Errno 104' in desc:
+                        raise LsmError(ErrorNumber.NETWORK_CONNREFUSED,
+                                   'Connection reset by peer')
+                    # We know we have a socket error of some sort, lets
+                    # report a generic network error with the string from the
+                    # library.
+                    raise LsmError(ErrorNumber.NETWORK_ERROR, str(ce))
                 elif 'SSL error' in desc:
                     raise LsmError(ErrorNumber.TRANSPORT_COMMUNICATION,
                                    desc)

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -827,9 +827,9 @@ class TestPlugin(unittest.TestCase):
             match = [x for x in vol_masked if x.id == vol.id]
 
             if masked:
-                self.assertTrue(len(match) == 1)
+                self.assertTrue(len(match) == 1, "len = %d" % len(match))
             else:
-                self.assertTrue(len(match) == 0)
+                self.assertTrue(len(match) == 0, "len = %d" % len(match))
 
         if supported(cap,
                      [Cap.
@@ -840,9 +840,9 @@ class TestPlugin(unittest.TestCase):
             match = [x for x in ag_masked if x.id == ag.id]
 
             if masked:
-                self.assertTrue(len(match) == 1)
+                self.assertTrue(len(match) == 1, "len = %d" % len(match))
             else:
-                self.assertTrue(len(match) == 0)
+                self.assertTrue(len(match) == 0, "len = %d" % len(match))
 
     def test_mask_unmask(self):
         for s in self.systems:
@@ -1536,7 +1536,6 @@ class TestPlugin(unittest.TestCase):
         except lsm.LsmError as le:
             if le.code != ErrorNumber.NOT_FOUND_VOLUME:
                 raise
-
 
     def test_volume_ident_led_on(self):
         for s in self.systems:

--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -342,6 +342,20 @@ class TestPlugin(unittest.TestCase):
                 if supported(cap, [Cap.VOLUME_DELETE]):
                     for v in self.c.volumes():
                         if 'lsm_' in v.name and s.id == v.system_id:
+                            # Check to see if this volume is participating in an
+                            # access group, if it is we will remove the volume
+                            # from it, but we will not delete the access group
+                            # as we likely didn't create it
+                            access_groups = self.c.\
+                                access_groups_granted_to_volume(v)
+                            for ag in access_groups:
+                                try:
+                                    self.c.volume_unmask(ag, v)
+                                except LsmError as le:
+                                    print_stderr(
+                                        "[WARNING] error when unmasking "
+                                        "volume %s\n" % str(le))
+                                    pass
                             try:
                                 self.c.volume_delete(v)
                             except LsmError as le:


### PR DESCRIPTION
This PR addresses the following issues:

1. We were getting errors on one of the SMI-S system in the lab.  Added the case where CopyType ==  dmtf.ST_CONF_CAP_COPY_TYPE_UNSYNC_ASSOC we will then do a call to `ModifyReplicaSynchronization` to return to storage pool (19).  Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1323789
2. Capability was incorrect as we were comparing a function address to an integer
3. On volume delete we need to make sure volume is not masked before we try to delete it, so that we can return the correct error code instead of a plugin bug exception
4. Misc. pep8 clean-up, network error handling and code clean-up