### PR TITLE
Updated LSM_ERR_<reason> documentation.

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt.h
@@ -65,8 +65,8 @@ extern "C" {
  * @param[in] timeout   Time-out in milliseconds, (initial value).
  * @param[out] e        Error data if connection failed.
  * @param[in] flags     Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error
- *         code @see lsm_error_number
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_connect_password(const char *uri,
                                         const char *password,
@@ -77,8 +77,8 @@ int LSM_DLL_EXPORT lsm_connect_password(const char *uri,
  * Closes a connection to a storage provider.
  * @param[in] conn      Valid connection to close
  * @param[in] flags     Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error
- *         code @see lsm_error_number
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_connect_close(lsm_connect *conn, lsm_flag flags);
 
@@ -89,8 +89,8 @@ int LSM_DLL_EXPORT lsm_connect_close(lsm_connect *conn, lsm_flag flags);
  * @param[out] desc     Plug-in description
  * @param[out] version  Plug-in version
  * @param [in] flags    Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error
- *         code @see lsm_error_number
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success. 
  */
 int LSM_DLL_EXPORT lsm_plugin_info_get(lsm_connect *conn, char **desc,
                                        char **version, lsm_flag flags);
@@ -101,8 +101,8 @@ int LSM_DLL_EXPORT lsm_plugin_info_get(lsm_connect *conn, char **desc,
  * @param[out] plugins    String list of plug-ins with the form
  *                        desc<sep>version
  * @param[in] flags     Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error
- *         code @see lsm_error_number
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_available_plugins_list(const char *sep,
                                               lsm_string_list ** plugins,
@@ -113,7 +113,8 @@ int LSM_DLL_EXPORT lsm_available_plugins_list(const char *sep,
  * @param[in] conn          Valid connection @see lsm_connect_password
  * @param[in] timeout       Time-out (in ms)
  * @param[in] flags         Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_connect_timeout_set(lsm_connect *conn,
                                            uint32_t timeout,
@@ -124,7 +125,8 @@ int LSM_DLL_EXPORT lsm_connect_timeout_set(lsm_connect *conn,
  * @param[in]   conn        Valid connection @see lsm_connect_password
  * @param[out]  timeout     Time-out (in ms)
  * @param[in] flags         Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_connect_timeout_get(lsm_connect *conn,
                                            uint32_t *timeout,
@@ -137,7 +139,8 @@ int LSM_DLL_EXPORT lsm_connect_timeout_get(lsm_connect *conn,
  * @param[out] status           Job Status
  * @param[out] percent_complete  Percent job complete
  * @param[in] flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_job_status_get(lsm_connect *conn,
                                       const char *job_id,
@@ -154,7 +157,8 @@ int LSM_DLL_EXPORT lsm_job_status_get(lsm_connect *conn,
  * @param[out]   percent_complete    Domain 0..100
  * @param[out]   pool       lsm_pool for completed operation
  * @param[in]    flags      Reserved for future use, must be zero
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_job_status_pool_get(lsm_connect *conn,
                                            const char *job_id,
@@ -172,7 +176,8 @@ int LSM_DLL_EXPORT lsm_job_status_pool_get(lsm_connect *conn,
  * @param[out] percent_complete  Domain 0..100
  * @param[out] vol              lsm_volume for completed operation.
  * @param[in] flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_job_status_volume_get(lsm_connect *conn,
                                              const char *job_id,
@@ -190,7 +195,8 @@ int LSM_DLL_EXPORT lsm_job_status_volume_get(lsm_connect *conn,
  * @param[out] percent_complete      Percent of job complete
  * @param[out] fs                   lsm_fs * for the completed operation
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_job_status_fs_get(lsm_connect *conn,
                                          const char *job_id,
@@ -207,7 +213,8 @@ int LSM_DLL_EXPORT lsm_job_status_fs_get(lsm_connect *conn,
  * @param[out] percent_complete      Percent complete
  * @param[out] ss                   Snap shot information
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_job_status_ss_get(lsm_connect *c,
                                          const char *job,
@@ -220,7 +227,8 @@ int LSM_DLL_EXPORT lsm_job_status_ss_get(lsm_connect *c,
  * @param[in] conn          Valid connection pointer
  * @param[in] job_id        Job ID
  * @param[in] flags         Reserved for future use, must be zero.
- * @return LSM_ERR_OK, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_job_free(lsm_connect *conn, char **job_id,
                                 lsm_flag flags);
@@ -234,7 +242,8 @@ int LSM_DLL_EXPORT lsm_job_free(lsm_connect *conn, char **job_id,
  * @param[in]   system  System of interest
  * @param[out]  cap     The storage array capabilities
  * @param[in] flags     Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_capabilities(lsm_connect *conn,
                                     lsm_system *system,
@@ -249,7 +258,8 @@ int LSM_DLL_EXPORT lsm_capabilities(lsm_connect *conn,
  * @param[out]  pool_array      Array of storage pools
  * @param[out]  count           Number of storage pools
  * @param[in]   flags           Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_pool_list(lsm_connect *conn, char *search_key,
                                  char *search_value,
@@ -268,7 +278,8 @@ int LSM_DLL_EXPORT lsm_pool_list(lsm_connect *conn, char *search_key,
  * @param[out]  volumes         An array of lsm_volume
  * @param[out]  count           Number of elements in the lsm_volume array
  * @param[in]   flags           Reserved set to 0
- * @return LSM_ERR_OK on success else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_list(lsm_connect *conn,
                                    const char *search_key,
@@ -285,7 +296,8 @@ int LSM_DLL_EXPORT lsm_volume_list(lsm_connect *conn,
  * @param [out]     disks           An array of lsm_disk types
  * @param [out]     count           Number of disks
  * @param [in]      flags           Reserved set to zero
- * @return LSM_ERR_OK on success else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_disk_list(lsm_connect *conn,
                                  const char *search_key,
@@ -306,8 +318,9 @@ int LSM_DLL_EXPORT lsm_disk_list(lsm_connect *conn,
  * @param[out]  new_volume      Valid volume @see lsm_volume
  * @param[out]  job             Indicates job id
  * @param[in] flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async. , else error
- *         code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_volume_create(lsm_connect *conn,
                                      lsm_pool * pool,
@@ -325,8 +338,9 @@ int LSM_DLL_EXPORT lsm_volume_create(lsm_connect *conn,
  * @param[out]  resized_volume  Pointer to newly re-sized lun.
  * @param[out]  job             Indicates job id
  * @param[in] flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async. , else error
- *         code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async. 
  */
 int LSM_DLL_EXPORT lsm_volume_resize(lsm_connect *conn,
                                      lsm_volume * volume,
@@ -345,8 +359,9 @@ int LSM_DLL_EXPORT lsm_volume_resize(lsm_connect *conn,
  * @param[out] new_replicant    New replicated volume lsm_volume_t
  * @param[out] job              Indicates job id
  * @param[in] flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async. , else error
- *         code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_volume_replicate(lsm_connect *conn,
                                         lsm_pool *pool,
@@ -362,7 +377,8 @@ int LSM_DLL_EXPORT lsm_volume_replicate(lsm_connect *conn,
  * @param[in] system                Valid lsm_system
  * @param[out] bs                   Block size
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT
     lsm_volume_replicate_range_block_size(lsm_connect *conn,
@@ -380,8 +396,9 @@ int LSM_DLL_EXPORT
  * @param[in] num_ranges            Number of entries in ranges.
  * @param[out] job                  Indicates job id
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async., else error
- *         code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_volume_replicate_range(lsm_connect *conn,
                                               lsm_replication_type rep_type,
@@ -397,8 +414,9 @@ int LSM_DLL_EXPORT lsm_volume_replicate_range(lsm_connect *conn,
  * @param[in]   volume          Volume that is to be deleted.
  * @param[out]  job             Indicates job id
  * @param[in] flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async. , else error
- *         code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_volume_delete(lsm_connect *conn,
                                      lsm_volume *volume, char **job,
@@ -409,8 +427,8 @@ int LSM_DLL_EXPORT lsm_volume_delete(lsm_connect *conn,
  * @param[in] conn                  Valid connection @see lsm_connect_password
  * @param[in] volume                Volume that is to be placed online
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error
- *         code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success. 
  */
 int LSM_DLL_EXPORT lsm_volume_enable(lsm_connect *conn, lsm_volume *volume,
                                      lsm_flag flags);
@@ -420,8 +438,8 @@ int LSM_DLL_EXPORT lsm_volume_enable(lsm_connect *conn, lsm_volume *volume,
  * @param[in] conn                  Valid connection @see lsm_connect_password
  * @param[in] volume                Volume that is to be placed online
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error
- *         code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_disable(lsm_connect *conn,
                                       lsm_volume * volume, lsm_flag flags);
@@ -435,8 +453,8 @@ int LSM_DLL_EXPORT lsm_volume_disable(lsm_connect *conn,
  * @param out_user                  outbound user name
  * @param out_password              outbound password
  * @param flags                     Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error
- *         code.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_iscsi_chap_auth(lsm_connect *conn,
                                        const char *init_id,
@@ -454,7 +472,8 @@ int LSM_DLL_EXPORT lsm_iscsi_chap_auth(lsm_connect *conn,
  * @param[out] groups           Array of access groups
  * @param[out] group_count      Size of array
  * @param[in] flags             Reserved set to zero
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_access_group_list(lsm_connect *conn,
                                          const char *search_key,
@@ -472,7 +491,8 @@ int LSM_DLL_EXPORT lsm_access_group_list(lsm_connect *conn,
  * @param[in] system                System to create access group for
  * @param[out] access_group         Returned access group
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT
     lsm_access_group_create(lsm_connect *conn, const char *name,
@@ -486,7 +506,8 @@ int LSM_DLL_EXPORT
  * @param[in] conn                  Valid connection @see lsm_connect_password
  * @param[in] access_group          Group to delete
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_access_group_delete(lsm_connect *conn,
                                            lsm_access_group *
@@ -500,7 +521,8 @@ int LSM_DLL_EXPORT lsm_access_group_delete(lsm_connect *conn,
  * @param[in] init_type             Type of initiator
  * @param[out] updated_access_group Updated access group
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT \
     lsm_access_group_initiator_add(lsm_connect *conn,
@@ -518,7 +540,8 @@ int LSM_DLL_EXPORT \
  * @param[in] init_type             Type of initiator, enumerated type
  * @param[out] updated_access_group Updated access group
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return[in] LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT
     lsm_access_group_initiator_delete(lsm_connect *conn,
@@ -534,7 +557,8 @@ int LSM_DLL_EXPORT
  * @param[in] access_group          Valid group pointer
  * @param[in] volume                Valid volume pointer
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_mask(lsm_connect *conn,
                                    lsm_access_group *access_group,
@@ -546,7 +570,8 @@ int LSM_DLL_EXPORT lsm_volume_mask(lsm_connect *conn,
  * @param[in] access_group          Valid group pointer
  * @param[in] volume                Valid volume pointer
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_unmask(lsm_connect *conn,
                                      lsm_access_group *access_group,
@@ -559,7 +584,8 @@ int LSM_DLL_EXPORT lsm_volume_unmask(lsm_connect *conn,
  * @param[out] volumes              An array of volumes
  * @param[out] count                Number of volumes
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT
     lsm_volumes_accessible_by_access_group(lsm_connect *conn,
@@ -574,7 +600,8 @@ int LSM_DLL_EXPORT
  * @param[out] groups               An array of access groups
  * @param[out] group_count          Number of access groups
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT
     lsm_access_groups_granted_to_volume(lsm_connect *conn,
@@ -589,7 +616,8 @@ int LSM_DLL_EXPORT
  * @param[in] volume                Valid volume
  * @param[out] yes                  1 == Yes, 0 == No
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_child_dependency(lsm_connect *conn,
                                                lsm_volume *volume,
@@ -603,7 +631,8 @@ int LSM_DLL_EXPORT lsm_volume_child_dependency(lsm_connect *conn,
  * @param[in] volume                Valid volume
  * @param[out] job                  Job id
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT \
     lsm_volume_child_dependency_delete(lsm_connect *conn, lsm_volume *volume,
@@ -616,7 +645,8 @@ int LSM_DLL_EXPORT \
  * @param[out] systems              Array of lsm_system
  * @param[out] system_count         Number of systems
  * @param[in]  flags                Reserved set to zero
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_system_list(lsm_connect *conn,
                                    lsm_system ** systems[],
@@ -630,7 +660,8 @@ int LSM_DLL_EXPORT lsm_system_list(lsm_connect *conn,
  * @param[out] fs                   Array of lsm_fs
  * @param[out] fs_count             Number of file systems
  * @param[in]  flags                Reserved set to zero
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_fs_list(lsm_connect *conn, const char *search_key,
                                const char *search_value, lsm_fs **fs[],
@@ -658,8 +689,9 @@ int LSM_DLL_EXPORT lsm_fs_create(lsm_connect *conn, lsm_pool * pool,
  * @param fs                    File system to delete
  * @param job                   Job id if job is created async.
  * @param[in] flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async. ,
- * else error code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async. 
  */
 int LSM_DLL_EXPORT lsm_fs_delete(lsm_connect *conn, lsm_fs *fs,
                                  char **job, lsm_flag flags);
@@ -673,8 +705,9 @@ int LSM_DLL_EXPORT lsm_fs_delete(lsm_connect *conn, lsm_fs *fs,
  * @param cloned_fs             Newly cloned file system record
  * @param job                   Job id if operation is async.
  * @param[in] flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on succees, LSM_ERR_JOB_STARTED if async., else
- * error code.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_fs_clone(lsm_connect *conn, lsm_fs *src_fs,
                                 const char *name, lsm_fs_ss *optional_ss,
@@ -688,8 +721,9 @@ int LSM_DLL_EXPORT lsm_fs_clone(lsm_connect *conn, lsm_fs *src_fs,
  * @param[in] files                 Specific files to check (NULL OK)
  * @param[out] yes                  Zero indicates no, else yes
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error
- *         code.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_fs_child_dependency(lsm_connect *conn, lsm_fs *fs,
                                            lsm_string_list *files,
@@ -703,8 +737,9 @@ int LSM_DLL_EXPORT lsm_fs_child_dependency(lsm_connect *conn, lsm_fs *fs,
  * @param[in] files                 Specific files to check (NULL OK)
  * @param[out] job                  Job id for async. identification
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async. ,
- * else error code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT
     lsm_fs_child_dependency_delete(lsm_connect *conn, lsm_fs *fs,
@@ -719,8 +754,9 @@ int LSM_DLL_EXPORT
  * @param[out] rfs                  File system information for re-sized fs
  * @param[out] job_id               Job id for async. identification
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async. ,
- * else error code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_fs_resize(lsm_connect *conn, lsm_fs *fs,
                                  uint64_t new_size_bytes, lsm_fs **rfs,
@@ -735,8 +771,9 @@ int LSM_DLL_EXPORT lsm_fs_resize(lsm_connect *conn, lsm_fs *fs,
  * @param[in] snapshot              Optional backing snapshot
  * @param[out] job                  Job id for async. operation
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async. ,
- * else error code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_fs_file_clone(lsm_connect *conn, lsm_fs *fs,
                                      const char *src_file_name,
@@ -751,7 +788,8 @@ int LSM_DLL_EXPORT lsm_fs_file_clone(lsm_connect *conn, lsm_fs *fs,
  * @param[out] ss           An array of snapshot pointers
  * @param[out] ss_count     Number of elements in the array
  * @param[in]  flags        Reserved set to zero
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_fs_ss_list(lsm_connect *conn, lsm_fs *fs,
                                   lsm_fs_ss ** ss[], uint32_t * ss_count,
@@ -765,8 +803,9 @@ int LSM_DLL_EXPORT lsm_fs_ss_list(lsm_connect *conn, lsm_fs *fs,
  * @param[out] snapshot             Snapshot that was created
  * @param[out] job                  Job id if the operation is async.
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async.,
- * else error code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_fs_ss_create(lsm_connect *c, lsm_fs *fs,
                                     const char *name, lsm_fs_ss **snapshot,
@@ -779,8 +818,9 @@ int LSM_DLL_EXPORT lsm_fs_ss_create(lsm_connect *c, lsm_fs *fs,
  * @param[in] ss                Snapshot to delete
  * @param[out] job              Job id if the operation is async.
  * @param[in] flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async., else error
- * code.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_fs_ss_delete(lsm_connect *c, lsm_fs *fs,
                                     lsm_fs_ss *ss, char **job, lsm_flag flags);
@@ -796,8 +836,9 @@ int LSM_DLL_EXPORT lsm_fs_ss_delete(lsm_connect *c, lsm_fs *fs,
  * @param all_files             0 = False else True
  * @param job                   Job id if operation is async.
  * @param[in] flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, LSM_ERR_JOB_STARTED if async., else error
- *         code
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_JOB_STARTED if async.
  */
 int LSM_DLL_EXPORT lsm_fs_ss_restore(lsm_connect *c, lsm_fs *fs, lsm_fs_ss *ss,
                                      lsm_string_list *files,
@@ -809,7 +850,8 @@ int LSM_DLL_EXPORT lsm_fs_ss_restore(lsm_connect *c, lsm_fs *fs, lsm_fs_ss *ss,
  * @param[in] c                     Valid connection
  * @param[out] types                List of types
  * @param[in] flags                 Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error code.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_nfs_auth_types(lsm_connect *c, lsm_string_list **types,
                                       lsm_flag flags);
@@ -822,7 +864,8 @@ int LSM_DLL_EXPORT lsm_nfs_auth_types(lsm_connect *c, lsm_string_list **types,
  * @param[out] exports              An array of lsm_nfs_export
  * @param[out] count                Number of items in array
  * @param[in]  flags                Reserved set to zero
- * @return LSM_ERR_OK on success else error code.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_nfs_list(lsm_connect *c,
                                 const char *search_key,
@@ -844,7 +887,8 @@ int LSM_DLL_EXPORT lsm_nfs_list(lsm_connect *c,
  * @param[in] options            Array specific options
  * @param[out]  exported         Export record
  * @param[in]  flags             Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_nfs_export_fs(lsm_connect *c,
                                      const char *fs_id,
@@ -864,7 +908,8 @@ int LSM_DLL_EXPORT lsm_nfs_export_fs(lsm_connect *c,
  * @param[in] c             Valid connection
  * @param[in] e             NFS export to remove
  * @param[in] flags         Reserved for future use, must be zero.
- * @return LSM_ERR_OK on success else error code.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_nfs_export_delete(lsm_connect *c,
                                          lsm_nfs_export * e,
@@ -878,7 +923,8 @@ int LSM_DLL_EXPORT lsm_nfs_export_delete(lsm_connect *c,
  * @param[out] target_ports         Array of target ports
  * @param[out] count                Number of target ports
  * @param[in] flags                 Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_target_port_list(lsm_connect *c,
                                         const char *search_key,
@@ -899,7 +945,8 @@ int LSM_DLL_EXPORT lsm_target_port_list(lsm_connect *c,
  * @param[out] opt_io_size  Optimal I/O size, also the preferred I/O size
  *                          of sequential I/O.
  * @param[in] flags         Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_raid_info(lsm_connect *c,
                                         lsm_volume *volume,
@@ -930,7 +977,8 @@ int LSM_DLL_EXPORT lsm_volume_raid_info(lsm_connect *c,
  *                  be NULL.
  *                  Need to use lsm_string_list_free() to free this memory.
  * @param[in] flags         Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_pool_member_info(lsm_connect *c,
                                         lsm_pool *pool,
@@ -961,7 +1009,8 @@ int LSM_DLL_EXPORT lsm_pool_member_info(lsm_connect *c,
  *                  The pointer of uint32_t. Indicate the item count of
  *                  supported_strip_sizes array.
  * @param[in] flags         Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT
     lsm_volume_raid_create_cap_get(lsm_connect *c, lsm_system *system,
@@ -995,7 +1044,8 @@ int LSM_DLL_EXPORT
  *                  Newly created volume, Pointer to the lsm_volume type
  *                  pointer.
  * @param[in] flags         Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_raid_create(lsm_connect *c,
                                           const char *name,
@@ -1012,7 +1062,8 @@ int LSM_DLL_EXPORT lsm_volume_raid_create(lsm_connect *c,
  * @param[in] c				Valid connection
  * @param[in] volume			A single lsm_volume
  * @param[in] flags			Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_ident_led_on(lsm_connect *c,
                                            lsm_volume *volume,
@@ -1024,7 +1075,8 @@ int LSM_DLL_EXPORT lsm_volume_ident_led_on(lsm_connect *c,
  * @param[in] c				Valid connection
  * @param[in] volume			A single lsm_volume
  * @param[in] flags			Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_ident_led_off(lsm_connect *c,
                                             lsm_volume *volume,
@@ -1037,7 +1089,8 @@ int LSM_DLL_EXPORT lsm_volume_ident_led_off(lsm_connect *c,
  * @param[in] system			A single lsm_system
  * @param[in] read_pct			Desired read cache percentage
  * @param[in] flags			Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_system_read_cache_pct_update(lsm_connect *c,
                                                     lsm_system *system,

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_accessgroups.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_accessgroups.h
@@ -30,7 +30,8 @@ extern "C" {
 /**
  * Frees the resources for an access group.
  * @param group     Group to free
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_access_group_record_free(lsm_access_group * group);
 
@@ -38,7 +39,8 @@ int LSM_DLL_EXPORT lsm_access_group_record_free(lsm_access_group * group);
  * Frees the resources for an array of access groups.
  * @param ag        Array of access groups to free resources for
  * @param size      Number of elements in the array.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_access_group_record_array_free(lsm_access_group *ag[],
                                                       uint32_t size);

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_blockrange.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_blockrange.h
@@ -39,7 +39,8 @@ lsm_block_range LSM_DLL_EXPORT *
 /**
  * Frees a block range record.
  * @param br        Block range to free
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_block_range_record_free(lsm_block_range * br);
 
@@ -66,7 +67,8 @@ lsm_block_range LSM_DLL_EXPORT **
  * Frees the memory for the array and all records contained in it.
  * @param br                    Array of block ranges to free
  * @param size                  Number of elements in array.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_block_range_record_array_free(lsm_block_range *br[],
                                                      uint32_t size);

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_capabilities.h
@@ -39,172 +39,174 @@ typedef enum {
 
 /** \enum lsm_capability_value_type Capabilities supported by array */
 typedef enum {
-
+    /** List volumes */
     LSM_CAP_VOLUMES = 20,
-    /**^ List volumes */
+    /** Create volumes */
     LSM_CAP_VOLUME_CREATE = 21,
-    /**^ Create volumes */
+    /** Resize volumes */
     LSM_CAP_VOLUME_RESIZE = 22,
-    /**^ Resize volumes */
 
+    /** Replication is supported */
     LSM_CAP_VOLUME_REPLICATE = 23,
-    /**^ Replication is supported */
+    /** Can make a space efficient copy of volume */
     LSM_CAP_VOLUME_REPLICATE_CLONE = 24,
-    /**^ Can make a space efficient copy of volume */
+    /** Can make a bitwise copy of volume */
     LSM_CAP_VOLUME_REPLICATE_COPY = 25,
-    /**^ Can make a bitwise copy of volume */
+    /** Mirror data with delay */
     LSM_CAP_VOLUME_REPLICATE_MIRROR_ASYNC = 26,
-    /**^ Mirror data with delay */
+    /** Mirror data and always in sync */
     LSM_CAP_VOLUME_REPLICATE_MIRROR_SYNC = 27,
-    /**^ Mirror data and always in sync */
 
+    /** Size of a block for range operations */
     LSM_CAP_VOLUME_COPY_RANGE_BLOCK_SIZE = 28,
-    /**^ Size of a block for range operations */
+    /** Sub volume replication support */
     LSM_CAP_VOLUME_COPY_RANGE = 29,
-    /**^ Sub volume replication support */
+    /** Can space efficient copy a region(s) of a volume*/
     LSM_CAP_VOLUME_COPY_RANGE_CLONE = 30,
-    /**^ Can space efficient copy a region(s) of a volume*/
+    /** Can copy a region(s) of a volume */
     LSM_CAP_VOLUME_COPY_RANGE_COPY = 31,
-    /**^ Can copy a region(s) of a volume */
 
+    /** Can delete a volume */
     LSM_CAP_VOLUME_DELETE = 33,
-    /**^ Can delete a volume */
 
+    /** Enable volume*/
     LSM_CAP_VOLUME_ENABLE = 34,
-    /**^ Enable volume*/
+    /** Disable volume*/
     LSM_CAP_VOLUME_DISABLE = 35,
-    /**^ Disable volume*/
 
+    /** Grant an access group to a volume */
     LSM_CAP_VOLUME_MASK = 36,
-    /**^ Grant an access group to a volume */
+    /** Revoke access for an access group */
     LSM_CAP_VOLUME_UNMASK = 37,
-    /**^ Revoke access for an access group */
+    /** List access groups */
     LSM_CAP_ACCESS_GROUPS = 38,
-    /**^ List access groups */
+    /** Create an access group */
     LSM_CAP_ACCESS_GROUP_CREATE_WWPN = 39,
-    /**^ Create an access group */
+    /** Delete an access group */
     LSM_CAP_ACCESS_GROUP_DELETE = 40,
-    /**^ Delete an access group */
+    /** Add an initiator to an access group */
     LSM_CAP_ACCESS_GROUP_INITIATOR_ADD_WWPN = 41,
-    /**^ Add an initiator to an access group */
+    /** Remove an initiator from an access group */
     LSM_CAP_ACCESS_GROUP_INITIATOR_DELETE = 42,
-    /**^ Remove an initiator from an access group */
 
+    /** Retrieve a list of volumes accessible by an access group */
     LSM_CAP_VOLUMES_ACCESSIBLE_BY_ACCESS_GROUP = 43,
-    /**^ Retrieve a list of volumes accessible by an access group */
-    LSM_CAP_ACCESS_GROUPS_GRANTED_TO_VOLUME = 44,
-    /**^ Retrieve a list of what access groups are accessible for a given
+    /** Retrieve a list of what access groups are accessible for a given
      * volume */
+    LSM_CAP_ACCESS_GROUPS_GRANTED_TO_VOLUME = 44,
 
+
+    /** Used to determine if a volume has any dependencies */
     LSM_CAP_VOLUME_CHILD_DEPENDENCY = 45,
-    /**^ Used to determine if a volume has any dependencies */
+    /** Removes dependendies */
     LSM_CAP_VOLUME_CHILD_DEPENDENCY_RM = 46,
-    /**^ Removes dependendies */
 
+    /** Create iSCSI access group */
     LSM_CAP_ACCESS_GROUP_CREATE_ISCSI_IQN = 47,
-    /**^ Create iSCSI access group */
+    /** For empty access group, this indicates it can add iSCSI IQN to it */
     LSM_CAP_ACCESS_GROUP_INITIATOR_ADD_ISCSI_IQN = 48,
-    /**^ For empty access group, this indicates it can add iSCSI IQN to it */
 
+    /** If you can configure iSCSI chap authentication */
     LSM_CAP_VOLUME_ISCSI_CHAP_AUTHENTICATION = 53,
-    /**^ If you can configure iSCSI chap authentication */
 
-    LSM_CAP_VOLUME_RAID_INFO = 54,
     /** ^ If you can query RAID information from volume */
+    LSM_CAP_VOLUME_RAID_INFO = 54,
 
+    /** Thin provisioned volumes are supported */
     LSM_CAP_VOLUME_THIN = 55,
-    /**^ Thin provisioned volumes are supported */
 
+    /** List file systems */
     LSM_CAP_FS = 100,
-    /**^ List file systems */
+    /** Delete a file system */
     LSM_CAP_FS_DELETE = 101,
-    /**^ Delete a file system */
+    /** Resize a file system */
     LSM_CAP_FS_RESIZE = 102,
-    /**^ Resize a file system */
+    /** Create a file system */
     LSM_CAP_FS_CREATE = 103,
-    /**^ Create a file system */
+    /** Clone a file system */
     LSM_CAP_FS_CLONE = 104,
-    /**^ Clone a file system */
+    /** Clone a file on a file system */
     LSM_CAP_FILE_CLONE = 105,
-    /**^ Clone a file on a file system */
+    /** List FS snapshots */
     LSM_CAP_FS_SNAPSHOTS = 106,
-    /**^ List FS snapshots */
+    /** Create a snapshot */
     LSM_CAP_FS_SNAPSHOT_CREATE = 107,
-    /**^ Create a snapshot */
+    /** Delete a snapshot */
     LSM_CAP_FS_SNAPSHOT_DELETE = 109,
-    /**^ Delete a snapshot */
+    /** Revert the state of a FS to the specified snapshot */
     LSM_CAP_FS_SNAPSHOT_RESTORE = 110,
-    /**^ Revert the state of a FS to the specified snapshot */
+    /** Revert the state of a list of files to a specified snapshot */
     LSM_CAP_FS_SNAPSHOT_RESTORE_SPECIFIC_FILES = 111,
-    /**^ Revert the state of a list of files to a specified snapshot */
+    /** Determine if a child dependency exists for the specified file */
     LSM_CAP_FS_CHILD_DEPENDENCY = 112,
-    /**^ Determine if a child dependency exists for the specified file */
+    /** Remove any dependencies the file system may have */
     LSM_CAP_FS_CHILD_DEPENDENCY_RM = 113,
-    /**^ Remove any dependencies the file system may have */
+    /** Remove any dependencies for specific files */
     LSM_CAP_FS_CHILD_DEPENDENCY_RM_SPECIFIC_FILES = 114,
-    /**^ Remove any dependencies for specific files */
 
+    /** Get a list of supported client authentication types */
     LSM_CAP_EXPORT_AUTH = 120,
-    /**^ Get a list of supported client authentication types */
+    /** List exported file systems */
     LSM_CAP_EXPORTS = 121,
-    /**^ List exported file systems */
+    /** Export a file system */
     LSM_CAP_EXPORT_FS = 122,
-    /**^ Export a file system */
+    /** Remove an export */
     LSM_CAP_EXPORT_REMOVE = 123,
-    /**^ Remove an export */
+    /** Plug-in allows user to define custome export path */
     LSM_CAP_EXPORT_CUSTOM_PATH = 124,
-    /**^ Plug-in allows user to define custome export path */
 
+    /** Plug-in allows user to change system read cache percentage */
     LSM_CAP_SYS_READ_CACHE_PCT_UPDATE = 158,
-    /**^ Plug-in allows user to change system read cache percentage */
+    /** Plug-in allows user to retrieve system read cache percentage */
     LSM_CAP_SYS_READ_CACHE_PCT_GET = 159,
-    /**^ Plug-in allows user to retrieve system read cache percentage */
+    /** Plug-in allows user to retrieve storage firmware version */
     LSM_CAP_SYS_FW_VERSION_GET = 160,
-    /**^ Plug-in allows user to retrieve storage firmware version */
+    /** Plug-in allows user to retrieve storage mode*/
     LSM_CAP_SYS_MODE_GET = 161,
-    /**^ Plug-in allows user to retrieve storage mode*/
+    /** Plug-in allows user to retrieve disk location */
     LSM_CAP_DISK_LOCATION = 163,
-    /**^ Plug-in allows user to retrieve disk location */
+    /** Plug-in allows user to retrieve disk rotation speed */
     LSM_CAP_DISK_RPM = 164,
-    /**^ Plug-in allows user to retrieve disk rotation speed */
+    /** Plug-in allows user to retrieve disk link type */
     LSM_CAP_DISK_LINK_TYPE = 165,
-    /**^ Plug-in allows user to retrieve disk link type */
+    /** Plugin allows user to enable and disable volume LEDs */
     LSM_CAP_VOLUME_LED = 171,
-    /**^ Plugin allows user to enable and disable volume LEDs */
+    /** Seach occurs on array */
     LSM_CAP_POOLS_QUICK_SEARCH = 210,
-    /**^ Seach occurs on array */
+    /** Seach occurs on array */
     LSM_CAP_VOLUMES_QUICK_SEARCH = 211,
-    /**^ Seach occurs on array */
+    /** Seach occurs on array */
     LSM_CAP_DISKS_QUICK_SEARCH = 212,
-    /**^ Seach occurs on array */
+    /** Seach occurs on array */
     LSM_CAP_ACCESS_GROUPS_QUICK_SEARCH = 213,
-    /**^ Seach occurs on array */
+    /** Seach occurs on array */
     LSM_CAP_FS_QUICK_SEARCH = 214,
-    /**^ Seach occurs on array */
+    /** Seach occurs on array */
     LSM_CAP_NFS_EXPORTS_QUICK_SEARCH = 215,
-    /**^ Seach occurs on array */
 
+    /** List target ports */
     LSM_CAP_TARGET_PORTS = 216,
-    /**^ List target ports */
+    /** Filtering occurs on array */
     LSM_CAP_TARGET_PORTS_QUICK_SEARCH = 217,
-    /**^ Filtering occurs on array */
 
+    /** List disk drives */
     LSM_CAP_DISKS = 220,
-    /**^ List disk drives */
+    /** Query pool member information */
     LSM_CAP_POOL_MEMBER_INFO = 221,
-    /**^ Query pool member information */
 
+    /** Create RAID volume */
     LSM_CAP_VOLUME_RAID_CREATE = 222,
-    /**^ Create RAID volume */
 
+    /** Query SCSI VPD83 ID of disk */
     LSM_CAP_DISK_VPD83_GET = 223,
-    /**^ Query SCSI VPD83 ID of disk */
+
 } lsm_capability_type;
 
 /**
  * Free the memory used by the storage capabilities data structure
  * @param cap   Valid storage capability data structure.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_capability_record_free(lsm_storage_capabilities *cap);
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_common.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_common.h
@@ -52,7 +52,8 @@ lsm_string_list LSM_DLL_EXPORT *lsm_string_list_alloc(uint32_t size);
 /**
  * Frees the memory allocated with the lsmStringListFree
  * @param sl    Record to free
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_string_list_free(lsm_string_list *sl);
 
@@ -68,7 +69,8 @@ lsm_string_list LSM_DLL_EXPORT *lsm_string_list_copy(lsm_string_list *src);
  * @param sl        Valid string list pointer
  * @param index      Element position to set value to
  * @param value     Value to use for assignment
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_string_list_elem_set(lsm_string_list *sl,
                                             uint32_t index,
@@ -96,7 +98,8 @@ uint32_t LSM_DLL_EXPORT lsm_string_list_size(lsm_string_list *sl);
  * Appends a char * to the string list, will grow container as needed.
  * @param sl    String list to append to
  * @param add   Character string to add
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_string_list_append(lsm_string_list *sl,
                                           const char *add);
@@ -108,7 +111,8 @@ int LSM_DLL_EXPORT lsm_string_list_append(lsm_string_list *sl,
  * reverse order.
  * @param sl            String list to remove item from
  * @param index         Specified index
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_string_list_delete(lsm_string_list *sl,
                                           uint32_t index);
@@ -118,7 +122,9 @@ int LSM_DLL_EXPORT lsm_string_list_delete(lsm_string_list *sl,
  * @param init_id       Initiator value
  * @param init_type     Type of initiator id, will get modified
  *                      to determined if type passed in is UNKNOWN
- * @return LSM_ERR_OK if initiator id is OK, else LSM_INVALID_ARGUMENT
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK if initiator id is OK.
+ * @retval LSM_INVALID_ARUMENT otherwise.
  */
 int LSM_DLL_EXPORT
     lsm_initiator_id_verify(const char *init_id,
@@ -128,7 +134,9 @@ int LSM_DLL_EXPORT
 /**
  * Checks to see if volume vpd83 is valid
  * @param vpd83         VPD string to check
- * @return LSM_ERR_OK if vpd is OK, else LSM_INVALID_ARGUMENT
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK if vpd is OK
+ * @retval LSM_INVALID_ARGUMENT otherwise.
  */
 int LSM_DLL_EXPORT lsm_volume_vpd83_verify(const char *vpd83);
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_disk.h
@@ -30,7 +30,7 @@ extern "C" {
  * Free the memory for a disk record
  * @param d     Disk memory to free
  * @return Error code as enumerated by \ref lsm_error_number.
- *         Returns LSM_ERR_OK on success.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_disk_record_free(lsm_disk *d);
 
@@ -45,7 +45,8 @@ lsm_disk LSM_DLL_EXPORT *lsm_disk_record_copy(lsm_disk *d);
  * Free an array of disk records
  * @param disk      Array of disk records
  * @param size      Size of disk array
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_disk_record_array_free(lsm_disk *disk[],
                                               uint32_t size);
@@ -109,7 +110,8 @@ uint64_t LSM_DLL_EXPORT lsm_disk_status_get(lsm_disk *d);
  * Do not free returned string, free the struct lsm_disk instead.
  * @param d		Pointer to the disk of interest.
  * @param location	Pointer to the disk's location.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_disk_location_get(lsm_disk *d,
                                          const char **location);

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_error.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_error.h
@@ -152,7 +152,9 @@ lsm_error_ptr LSM_DLL_EXPORT lsm_error_last_get(lsm_connect * c);
 /**
  * Frees the error record!
  * @param err   The error to free!
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_error_free(lsm_error_ptr err);
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_fs.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_fs.h
@@ -28,7 +28,8 @@ extern "C" {
 /**
  * Frees a File system record
  * @param fs    File system to free.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_fs_record_free(lsm_fs *fs);
 
@@ -43,7 +44,8 @@ lsm_fs LSM_DLL_EXPORT *lsm_fs_record_copy(lsm_fs * source);
  * Frees an array of file system records
  * @param fs        Array of file system record pointers
  * @param size      Number in array to free
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_fs_record_array_free(lsm_fs *fs[], uint32_t size);
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_hash.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_hash.h
@@ -39,7 +39,8 @@ lsm_hash LSM_DLL_EXPORT *lsm_hash_alloc(void);
 /**
  * Free a lsm hash
  * @param op    Record to free.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_hash_free(lsm_hash *op);
 
@@ -47,7 +48,8 @@ int LSM_DLL_EXPORT lsm_hash_free(lsm_hash *op);
  * Get the list of 'keys' available in the hash
  * @param [in]  op      Valid optional data pointer
  * @param [out] l       String list pointer
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_hash_keys(lsm_hash *op, lsm_string_list **l);
 
@@ -67,7 +69,8 @@ const char LSM_DLL_EXPORT *lsm_hash_string_get(lsm_hash *op,
  * @param [in]  op      Valid optional data pointer
  * @param [in]  key     Key to set value for (key is duped)
  * @param [in]  value   Value of new key (string is duped)
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_hash_string_set(lsm_hash *op,
                                        const char *key, const char *value);

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
@@ -42,10 +42,11 @@ extern "C" {
  *                  Output pointer of lsm_error. Error message could be
  *                  retrieved via lsm_error_message_get(). Memory should be
  *                  freed by lsm_error_free().
- * @return LSM_ERR_OK                   on success or not found.
- *         LSM_ERR_INVALID_ARGUMENT     when any argument is NULL.
- *         LSM_ERR_NO_MEMORY            when no memory.
- *         LSM_ERR_LIB_BUG              when something unexpected happens.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK               on success or not found.
+ * @retval LSM_ERR_INVALID_ARGUMENT when any argument is NULL.
+ * @retval LSM_ERR_NO_MEMORY        when no memory.
+ * @retval LSM_ERR_LIB_BUG          when something unexpected happens.
  */
 int LSM_DLL_EXPORT lsm_local_disk_vpd83_search(const char *vpd83,
                                                lsm_string_list **disk_path_list,
@@ -62,12 +63,13 @@ int LSM_DLL_EXPORT lsm_local_disk_vpd83_search(const char *vpd83,
  *                  Output pointer of lsm_error. Error message could be
  *                  retrieved via lsm_error_message_get(). Memory should be
  *                  freed by lsm_error_free().
- * @return LSM_ERR_OK                   on success.
- *         LSM_ERR_INVALID_ARGUMENT     when any argument is NULL or
- *                                      illegal sd_path.
- *         LSM_ERR_NO_MEMORY            when no memory.
- *         LSM_ERR_LIB_BUG              when something unexpected happens.
- *         LSM_ERR_NOT_FOUND_DISK       When provided disk path not found.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK               on success or not found.
+ * @retval LSM_ERR_INVALID_ARGUMENT when any argument is NULL or 
+ *                                  illegal sd_path.
+ * @retval LSM_ERR_NO_MEMORY        when no memory.
+ * @retval LSM_ERR_LIB_BUG          when something unexpected happens.
+ * @retval LSM_ERR_NOT_FOUND_DISK   when provided disk path not found.
  */
 int LSM_DLL_EXPORT lsm_local_disk_vpd83_get(const char *sd_path,
                                             char **vpd83,
@@ -94,12 +96,13 @@ int LSM_DLL_EXPORT lsm_local_disk_vpd83_get(const char *sd_path,
  *                      Output pointer of lsm_error. Error message could be
  *                      retrieved via lsm_error_message_get(). Memory should be
  *                      freed by lsm_error_free().
- * @return LSM_ERR_OK                   On success.
- *         LSM_ERR_INVALID_ARGUMENT     When any argument is NULL.
- *         LSM_ERR_LIB_BUG              When something unexpected happens.
- *         LSM_ERR_NOT_FOUND_DISK       When provided disk path not found.
- *         LSM_ERR_PERMISSION_DENIED    No sufficient permission to access
- *                                      provided disk path.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK               on success or not found.
+ * @retval LSM_ERR_INVALID_ARGUMENT when any argument is NULL.
+ * @retval LSM_ERR_LIB_BUG          when something unexpected happens.
+ * @retval LSM_ERR_NOT_FOUND_DISK   when provided disk path not found.
+ * @retval LSM_ERR_PERMISSION_DENIED no sufficient permission to access
+ *                                   provided disk path.
  */
 int LSM_DLL_EXPORT lsm_local_disk_rpm_get(const char *disk_path, int32_t *rpm,
                                           lsm_error **lsm_err);
@@ -119,9 +122,10 @@ int LSM_DLL_EXPORT lsm_local_disk_rpm_get(const char *disk_path, int32_t *rpm,
  *                      Output pointer of lsm_error. Error message could be
  *                      retrieved via lsm_error_message_get(). Memory should be
  *                      freed by lsm_error_free().
- * @return LSM_ERR_OK                   On success.
- *         LSM_ERR_INVALID_ARGUMENT     When any argument is NULL.
- *         LSM_ERR_LIB_BUG              When something unexpected happens.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK               on success or not found.
+ * @retval LSM_ERR_INVALID_ARGUMENT when any argument is NULL.
+ * @retval LSM_ERR_LIB_BUG          when something unexpected happens.
  */
 int LSM_DLL_EXPORT lsm_local_disk_list(lsm_string_list **disk_paths,
                                        lsm_error **lsm_err);
@@ -165,12 +169,13 @@ int LSM_DLL_EXPORT lsm_local_disk_list(lsm_string_list **disk_paths,
  * @param[out] lsm_err  Output pointer of lsm_error. Error message could be
  *                      retrieved via lsm_error_message_get(). Memory should
  *                      be freed by lsm_error_free().
- * @return LSM_ERR_OK                   On success.
- *         LSM_ERR_INVALID_ARGUMENT     When any argument is NULL.
- *         LSM_ERR_LIB_BUG              When something unexpected happens.
- *         LSM_ERR_NOT_FOUND_DISK       When provided disk path not found.
- *         LSM_ERR_PERMISSION_DENIED    Insufficient permission to access
- *                                      provided disk path.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK               on success or not found.
+ * @retval LSM_ERR_INVALID_ARGUMENT when any argument is NULL.
+ * @retval LSM_ERR_LIB_BUG          when something unexpected happens.
+ * @retval LSM_ERR_NOT_FOUND_DISK   when provided disk path not found.
+ * @retval LSM_ERR_PERMISSION_DENIED insufficient permission to access
+ *                                   provided disk path.
  */
 int LSM_DLL_EXPORT lsm_local_disk_link_type_get(const char *disk_path,
                                                 lsm_disk_link_type *link_type,

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_nfsexport.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_nfsexport.h
@@ -75,7 +75,8 @@ lsm_nfs_export LSM_DLL_EXPORT **
 /**
  * Frees the memory for a NFS export record.
  * @param exp
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_nfs_export_record_free(lsm_nfs_export *exp);
 
@@ -83,7 +84,8 @@ int LSM_DLL_EXPORT lsm_nfs_export_record_free(lsm_nfs_export *exp);
  * Frees the memory for the NFS export array and the memory for each entry
  * @param exps          Memory to free
  * @param size          Number of entries
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  *  */
 int LSM_DLL_EXPORT lsm_nfs_export_record_array_free(lsm_nfs_export * exps[],
                                                     uint32_t size);

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
@@ -76,7 +76,8 @@ typedef lsm_plugin *lsm_plugin_ptr;
  * @param   password    Plain text password
  * @param   timeout     Plug-in timeout to array
  * @param   flags       Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plugin_register) (lsm_plugin_ptr c, const char *uri,
                                     const char *password,
@@ -86,7 +87,8 @@ typedef int (*lsm_plugin_register) (lsm_plugin_ptr c, const char *uri,
  * Plug-in unregister callback function signature
  * @param   c           Valid lsm plugin pointer
  * @param   flags       Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plugin_unregister) (lsm_plugin_ptr c, lsm_flag flags);
 
@@ -95,7 +97,8 @@ typedef int (*lsm_plugin_unregister) (lsm_plugin_ptr c, lsm_flag flags);
  * @param   c           Valid lsm plug-in pointer
  * @param   timeout     timeout value in milliseconds
  * @param   flags       Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_tmo_set) (lsm_plugin_ptr c, uint32_t timeout,
                                  lsm_flag flags);
@@ -105,7 +108,8 @@ typedef int (*lsm_plug_tmo_set) (lsm_plugin_ptr c, uint32_t timeout,
  * @param[in]   c           Valid lsm plug-in pointer
  * @param[out]  timeout     Time-out value
  * @param[in]   flags       Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_tmo_get) (lsm_plugin_ptr c, uint32_t *timeout,
                                  lsm_flag flags);
@@ -116,7 +120,8 @@ typedef int (*lsm_plug_tmo_get) (lsm_plugin_ptr c, uint32_t *timeout,
  * @param[in]   sys         System to interrogate
  * @param[out]  cap         Capabilities
  * @param[in]   flags       Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_capabilities) (lsm_plugin_ptr c,
                                       lsm_system *sys,
@@ -131,7 +136,8 @@ typedef int (*lsm_plug_capabilities) (lsm_plugin_ptr c,
  * @param[out]  type            Type of result
  * @param[out]  value           Value of result
  * @param[in]   flags           Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 
 typedef int (*lsm_plug_Job_status) (lsm_plugin_ptr c, const char *job,
@@ -145,7 +151,8 @@ typedef int (*lsm_plug_Job_status) (lsm_plugin_ptr c, const char *job,
  * @param[in]   c               Valid lsm plug-in pointer
  * @param[in]   job_id          Job ID to free memory for
  * @param[in]   flags           Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_job_free) (lsm_plugin_ptr c, char *job_id,
                                   lsm_flag flags);
@@ -158,7 +165,8 @@ typedef int (*lsm_plug_job_free) (lsm_plugin_ptr c, char *job_id,
  * @param[out]  pool_array      List of pools
  * @param[out]  count           Number of items in array
  * @param[in]   flags           Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_pool_list) (lsm_plugin_ptr c,
                                    const char *search_key,
@@ -172,7 +180,8 @@ typedef int (*lsm_plug_pool_list) (lsm_plugin_ptr c,
  * @param[out]  systems         List of systems
  * @param[out]  system_count     Number of systems
  * @param[out]  flags           Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_system_list) (lsm_plugin_ptr c,
                                      lsm_system **systems[],
@@ -199,7 +208,8 @@ struct lsm_mgmt_ops_v1 {
  * @param[out]  vol_array        Array of volumes
  * @param[out]  count           Number of volumes
  * @param[in]   flags           Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_list) (lsm_plugin_ptr c,
                                      const char *search_key,
@@ -215,7 +225,8 @@ typedef int (*lsm_plug_volume_list) (lsm_plugin_ptr c,
  * @param[out]  disk_array       Array of disk pointers
  * @param[out]  count           Number of disks
  * @param[in]   flags           Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_disk_list) (lsm_plugin_ptr c,
                                    const char *search_key,
@@ -231,7 +242,8 @@ typedef int (*lsm_plug_disk_list) (lsm_plugin_ptr c,
  * @param[out]  target_port_array   Array of target port pointers
  * @param[out]  count               Number of target ports
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_target_port_list)
     (lsm_plugin_ptr c, const char *search_key, const char *search_value,
@@ -247,7 +259,8 @@ typedef int (*lsm_plug_target_port_list)
  * @param[out] new_volume           Information on newly created volume
  * @param[out]  job                 Job ID
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_create) (lsm_plugin_ptr c,
                                        lsm_pool *pool,
@@ -267,7 +280,8 @@ typedef int (*lsm_plug_volume_create) (lsm_plugin_ptr c,
  * @param[out] new_replicant        Newly replicated volume
  * @param job
  * @param flags
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_replicate) (lsm_plugin_ptr c,
                                           lsm_pool *pool,
@@ -283,7 +297,8 @@ typedef int (*lsm_plug_volume_replicate) (lsm_plugin_ptr c,
  * @param[in]   system              System to query against
  * @param[out]  bs                  Block size
  * @param[out]  flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_replicate_range_block_size)
     (lsm_plugin_ptr c, lsm_system * system, uint32_t *bs, lsm_flag flags);
@@ -299,7 +314,8 @@ typedef int (*lsm_plug_volume_replicate_range_block_size)
  * @param[in]   num_ranges          Number of items in array
  * @param[out]  job                 Job ID
  * @param flags
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_replicate_range) (lsm_plugin_ptr c,
                                                 lsm_replication_type rep_type,
@@ -317,7 +333,8 @@ typedef int (*lsm_plug_volume_replicate_range) (lsm_plugin_ptr c,
  * @param[in]   resized_volume      Information about newly re-sized volume
  * @param[out]  job                 The job ID
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_resize) (lsm_plugin_ptr c,
                                        lsm_volume *volume,
@@ -331,7 +348,8 @@ typedef int (*lsm_plug_volume_resize) (lsm_plugin_ptr c,
  * @param[in]   volume              Volume to be deleted
  * @param[out]  job                 Job ID
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_delete) (lsm_plugin_ptr c,
                                        lsm_volume *volume, char **job,
@@ -341,7 +359,8 @@ typedef int (*lsm_plug_volume_delete) (lsm_plugin_ptr c,
  * @param[in]   c                   Valid lsm plug-in pointer
  * @param[in]   v                   Volume to place online
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_enable) (lsm_plugin_ptr c,
                                        lsm_volume *v, lsm_flag flags);
@@ -351,7 +370,8 @@ typedef int (*lsm_plug_volume_enable) (lsm_plugin_ptr c,
  * @param[in]   c                   Valid lsm plug-in pointer
  * @param v
  * @param flags
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_disable) (lsm_plugin_ptr c,
                                         lsm_volume *v, lsm_flag flags);
@@ -366,7 +386,8 @@ typedef int (*lsm_plug_volume_disable) (lsm_plugin_ptr c,
  * @param[in]   out_user            CHAP outbound user name
  * @param[in]   out_password        CHAP outbound user name
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_iscsi_chap_auth) (lsm_plugin_ptr c,
                                          const char *init_id,
@@ -384,7 +405,8 @@ typedef int (*lsm_plug_iscsi_chap_auth) (lsm_plugin_ptr c,
  * @param[out]  groups              Array of groups
  * @param[out]  group_count          Number of groups
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_access_group_list) (lsm_plugin_ptr c,
                                            const char *search_key,
@@ -401,7 +423,8 @@ typedef int (*lsm_plug_access_group_list) (lsm_plugin_ptr c,
  * @param[in]   system              System to create group for
  * @param[out]  access_group        Newly created access group
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_access_group_create)
     (lsm_plugin_ptr c, const char *name, const char *initiator_id,
@@ -413,7 +436,8 @@ typedef int (*lsm_plug_access_group_create)
  * @param[in]   c                   Valid lsm plug-in pointer
  * @param[in]   group               Access group to be deleted
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_access_group_delete) (lsm_plugin_ptr c,
                                              lsm_access_group *group,
@@ -427,7 +451,8 @@ typedef int (*lsm_plug_access_group_delete) (lsm_plugin_ptr c,
  * @param[in]   id_type                 Initiator type
  * @param[out]  updated_access_group    Updated access group
  * @param[in]   flags                   Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_access_group_initiator_add)
     (lsm_plugin_ptr c, lsm_access_group *access_group,
@@ -442,7 +467,8 @@ typedef int (*lsm_plug_access_group_initiator_add)
  * @param[in]   id_type                 Initiator type
  * @param[out]  updated_access_group    Updated access group
  * @param[in]   flags                   Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_access_group_initiator_delete)
     (lsm_plugin_ptr c, lsm_access_group *access_group,
@@ -456,7 +482,8 @@ typedef int (*lsm_plug_access_group_initiator_delete)
  * @param[in]   group               Group to be granted access
  * @param[in]   volume              Volume to be given access too
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_mask) (lsm_plugin_ptr c,
                                      lsm_access_group *group,
@@ -470,7 +497,8 @@ typedef int (*lsm_plug_volume_mask) (lsm_plugin_ptr c,
  * @param[in]   volume              Volume to which will no longer be
  *                                  accessible by group
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_unmask) (lsm_plugin_ptr c,
                                        lsm_access_group * group,
@@ -484,7 +512,8 @@ typedef int (*lsm_plug_volume_unmask) (lsm_plugin_ptr c,
  * @param[out]  volumes             Array of volumes
  * @param[out]  count               Number of volumes
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volumes_accessible_by_access_group)
     (lsm_plugin_ptr c, lsm_access_group *group, lsm_volume **volumes[],
@@ -498,7 +527,8 @@ typedef int (*lsm_plug_volumes_accessible_by_access_group)
  * @param[out]  groups              Array of access groups
  * @param[out]  group_count          Number of access groups
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_access_groups_granted_to_volume)
     (lsm_plugin_ptr c, lsm_volume *volume, lsm_access_group **groups[],
@@ -510,7 +540,8 @@ typedef int (*lsm_plug_access_groups_granted_to_volume)
  * @param[in]   volume              Volume to query
  * @param[out]  yes                 Boolean
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_child_dependency)
     (lsm_plugin_ptr c, lsm_volume *volume, uint8_t *yes, lsm_flag flags);
@@ -521,7 +552,8 @@ typedef int (*lsm_plug_volume_child_dependency)
  * @param[in]   volume              Volume to remove dependency for
  * @param[out]  job                 Job ID
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_child_dependency_delete)
     (lsm_plugin_ptr c, lsm_volume *volume, char **job, lsm_flag flags);
@@ -534,7 +566,8 @@ typedef int (*lsm_plug_volume_child_dependency_delete)
  * @param[out]  fs                  An array of file systems
  * @param[out]  fs_count             Number of file systems
  * @param[in] flags                 Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_fs_list) (lsm_plugin_ptr c,
                                  const char *search_key,
@@ -551,7 +584,8 @@ typedef int (*lsm_plug_fs_list) (lsm_plugin_ptr c,
  * @param[out]  fs                  Newly created file system
  * @param[out]  job                 Job ID
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_fs_create) (lsm_plugin_ptr c, lsm_pool *pool,
                                    const char *name,
@@ -564,7 +598,8 @@ typedef int (*lsm_plug_fs_create) (lsm_plugin_ptr c, lsm_pool *pool,
  * @param[in]   fs                  File system to delete
  * @param[out]  job                 Job ID
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_fs_delete) (lsm_plugin_ptr c, lsm_fs *fs,
                                    char **job, lsm_flag flags);
@@ -577,7 +612,8 @@ typedef int (*lsm_plug_fs_delete) (lsm_plugin_ptr c, lsm_fs *fs,
  * @param[in]   optional_snapshot   Basis of clone
  * @param[out]  job                 Job ID
  * @param[in]   flags               reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_fs_clone) (lsm_plugin_ptr c, lsm_fs *src_fs,
                                   const char *dest_fs_name,
@@ -590,7 +626,8 @@ typedef int (*lsm_plug_fs_clone) (lsm_plugin_ptr c, lsm_fs *src_fs,
  * @param[in]   fs                  File system to check
  * @param[in]   files               Specific files to check
  * @param[out]  yes                 Boolean
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_fs_child_dependency) (lsm_plugin_ptr c,
                                              lsm_fs *fs,
@@ -604,7 +641,8 @@ typedef int (*lsm_plug_fs_child_dependency) (lsm_plugin_ptr c,
  * @param[in]   files               Specific files to remove dependencies for
  * @param[out]  job                 Job ID
  * @param[out]  flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_fs_child_dependency_delete) (lsm_plugin_ptr c,
                                                     lsm_fs *fs,
@@ -620,7 +658,8 @@ typedef int (*lsm_plug_fs_child_dependency_delete) (lsm_plugin_ptr c,
  * @param[out]  rfs                 Re-sized file system
  * @param[out]  job                 Job ID
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_fs_resize) (lsm_plugin_ptr c, lsm_fs *fs,
                                    uint64_t new_size_bytes,
@@ -724,7 +763,8 @@ typedef int (*lsm_plug_nfs_auth_types) (lsm_plugin_ptr c,
  * @param[out]  exports             An array of exported file systems
  * @param[out]  count               Number of exported file systems
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_nfs_list) (lsm_plugin_ptr c,
                                   const char *search_key,
@@ -745,7 +785,8 @@ typedef int (*lsm_plug_nfs_list) (lsm_plugin_ptr c,
  * @param[in]   options             Options
  * @param[out]  exported            Newly created export
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_nfs_export_fs) (lsm_plugin_ptr c,
                                        const char *fs_id,
@@ -765,7 +806,8 @@ typedef int (*lsm_plug_nfs_export_fs) (lsm_plugin_ptr c,
  * @param[in]   c                   Valid lsm plug-in pointer
  * @param[in]   e                   Export to remove
  * @param[in]   flags               Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_nfs_export_remove) (lsm_plugin_ptr c,
                                            lsm_nfs_export *e,
@@ -776,52 +818,52 @@ typedef int (*lsm_plug_nfs_export_remove) (lsm_plugin_ptr c,
  *       compatibility
  */
 struct lsm_san_ops_v1 {
+    /**  retrieving volumes */
     lsm_plug_volume_list vol_get;
-    /**^  retrieving volumes */
+    /**  retrieve disks */
     lsm_plug_disk_list disk_get;
-    /**^  retrieve disks */
+    /**  creating a lun */
     lsm_plug_volume_create vol_create;
-    /**^  creating a lun */
+    /**  replicating lun */
     lsm_plug_volume_replicate vol_replicate;
-    /**^  replicating lun */
+    /**  volume replication range block size */
     lsm_plug_volume_replicate_range_block_size vol_rep_range_bs;
-    /**^  volume replication range block size */
+    /**  volume replication range */
     lsm_plug_volume_replicate_range vol_rep_range;
-    /**^  volume replication range */
+    /**  resizing a volume */
     lsm_plug_volume_resize vol_resize;
-    /**^  resizing a volume */
+    /**  deleting a volume */
     lsm_plug_volume_delete vol_delete;
-    /**^  deleting a volume */
+    /**  volume is accessible */
     lsm_plug_volume_enable vol_enable;
-    /**^  volume is accessible */
+    /**  volume is unaccessible */
     lsm_plug_volume_disable vol_disable;
-    /**^  volume is unaccessible */
+    /**  iscsi chap authentication */
     lsm_plug_iscsi_chap_auth iscsi_chap_auth;
-    /**^  iscsi chap authentication */
+    /**  access groups */
     lsm_plug_access_group_list ag_list;
-    /**^  access groups */
+    /**  access group create */
     lsm_plug_access_group_create ag_create;
-    /**^  access group create */
+    /**  access group delete */
     lsm_plug_access_group_delete ag_delete;
-    /**^  access group delete */
+    /**  adding an initiator to an access group */
     lsm_plug_access_group_initiator_add ag_add_initiator;
-    /**^  adding an initiator to an access group */
+    /**  deleting an initiator from an access group */
     lsm_plug_access_group_initiator_delete ag_del_initiator;
-    /**^  deleting an initiator from an access group */
+    /**  acess group grant */
     lsm_plug_volume_mask ag_grant;
-    /**^  acess group grant */
+    /**  access group revoke */
     lsm_plug_volume_unmask ag_revoke;
-    /**^  access group revoke */
+    /**  volumes accessible by access group */
     lsm_plug_volumes_accessible_by_access_group vol_accessible_by_ag;
-    /**^  volumes accessible by access group */
+    /**  access groups granted to a volume */
     lsm_plug_access_groups_granted_to_volume ag_granted_to_vol;
-    /**^  access groups granted to a volume */
+    /**  volume child dependencies */
     lsm_plug_volume_child_dependency vol_child_depends;
-    /**^  volume child dependencies */
+    /**Callback to remove volume child dependencies */
     lsm_plug_volume_child_dependency_delete vol_child_depends_rm;
-    /**^Callback to remove volume child dependencies */
+    /** Callback to get list of target ports */
     lsm_plug_target_port_list target_port_list;
-    /**^ Callback to get list of target ports */
 };
 
 /** \struct  lsm_fs_ops_v1
@@ -830,30 +872,30 @@ struct lsm_san_ops_v1 {
  *       compatibility
  */
 struct lsm_fs_ops_v1 {
+    /** list file systems */
     lsm_plug_fs_list fs_list;
-    /**^ list file systems */
+    /** create a file system */
     lsm_plug_fs_create fs_create;
-    /**^ create a file system */
+    /** delete a file system */
     lsm_plug_fs_delete fs_delete;
-    /**^ delete a file system */
+    /** resize a file system */
     lsm_plug_fs_resize fs_resize;
-    /**^ resize a file system */
+    /** clone a file system */
     lsm_plug_fs_clone fs_clone;
-    /**^ clone a file system */
+    /** clone files on a file system */
     lsm_plug_fs_file_clone fs_file_clone;
-    /**^ clone files on a file system */
+    /** check file system child dependencies */
     lsm_plug_fs_child_dependency fs_child_dependency;
-    /**^ check file system child dependencies */
+    /** remove file system child dependencies */
     lsm_plug_fs_child_dependency_delete fs_child_dependency_rm;
-    /**^ remove file system child dependencies */
+    /** list snapshots */
     lsm_plug_fs_ss_list fs_ss_list;
-    /**^ list snapshots */
+    /** create a snapshot */
     lsm_plug_fs_ss_create fs_ss_create;
-    /**^ create a snapshot */
+    /** delete a snapshot */
     lsm_plug_fs_ss_delete fs_ss_delete;
-    /**^ delete a snapshot */
+    /** restore a snapshot */
     lsm_plug_fs_ss_restore fs_ss_restore;
-    /**^ restore a snapshot */
 };
 
 /** \struct lsm_nas_ops_v1
@@ -862,14 +904,14 @@ struct lsm_fs_ops_v1 {
  *       compatibility
  */
 struct lsm_nas_ops_v1 {
+    /** List nfs authentication types */
     lsm_plug_nfs_auth_types nfs_auth_types;
-    /**^ List nfs authentication types */
+    /** List nfs exports */
     lsm_plug_nfs_list nfs_list;
-    /**^ List nfs exports */
+    /** Export a file system */
     lsm_plug_nfs_export_fs nfs_export;
-    /**^ Export a file system */
+    /** Remove a file export */
     lsm_plug_nfs_export_remove nfs_export_remove;
-    /**^ Remove a file export */
 };
 
 /**
@@ -886,7 +928,8 @@ struct lsm_nas_ops_v1 {
  * @param[out]  opt_io_size     Optimal I/O size, also the preferred I/O size
  *                              of sequential I/O.
  * @param[in]   flags           Reserved
- * @return LSM_ERR_OK, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_raid_info) (lsm_plugin_ptr c,
                                           lsm_volume *volume,
@@ -916,7 +959,8 @@ typedef int (*lsm_plug_volume_raid_info) (lsm_plugin_ptr c,
  *                  LSM_POOL_MEMBER_TYPE_UNKNOWN, the member_ids should
  *                  be NULL.
  * @param[in] flags         Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_pool_member_info) (lsm_plugin_ptr c, lsm_pool *pool,
                                           lsm_volume_raid_type *raid_type,
@@ -944,7 +988,8 @@ typedef int (*lsm_plug_pool_member_info) (lsm_plugin_ptr c, lsm_pool *pool,
  *                  The pointer of uint32_t. Indicate the item count of
  *                  supported_strip_sizes array.
  * @param[in] flags         Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_raid_create_cap_get)
     (lsm_plugin_ptr c, lsm_system *system, uint32_t **supported_raid_types,
@@ -970,7 +1015,8 @@ typedef int (*lsm_plug_volume_raid_create_cap_get)
  *                  Newly created volume, Pointer to the lsm_volume type
  *                  pointer.
  * @param[in] flags         Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_raid_create) (lsm_plugin_ptr c,
                                             const char *name,
@@ -987,7 +1033,8 @@ typedef int (*lsm_plug_volume_raid_create) (lsm_plugin_ptr c,
  * @param[in] c			Valid lsm plug-in pointer
  * @param[in] volume		A single lsm_volume
  * @param[in] flags         	Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_ident_led_on) (lsm_plugin_ptr c,
                                              lsm_volume * volume,
@@ -999,7 +1046,8 @@ typedef int (*lsm_plug_volume_ident_led_on) (lsm_plugin_ptr c,
  * @param[in] c			Valid lsm plug-in pointer
  * @param[in] volume		A single lsm_volume
  * @param[in] flags         	Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_volume_ident_led_off) (lsm_plugin_ptr c,
                                               lsm_volume * volume,
@@ -1012,7 +1060,8 @@ typedef int (*lsm_plug_volume_ident_led_off) (lsm_plugin_ptr c,
  * @param[in] system		A single lsm_system
  * @param[in] read_pct		Desired read cache percentage
  * @param[in] flags         	Reserved, set to 0
- * @return LSM_ERR_OK on success else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 typedef int (*lsm_plug_system_read_cache_pct_update) (lsm_plugin_ptr c,
                                                       lsm_system *system,
@@ -1023,8 +1072,8 @@ typedef int (*lsm_plug_system_read_cache_pct_update) (lsm_plugin_ptr c,
  * \brief Functions added in version 1.2
  */
 struct lsm_ops_v1_2 {
+    /** Query volume RAID information*/
     lsm_plug_volume_raid_info vol_raid_info;
-    /**^ Query volume RAID information*/
     lsm_plug_pool_member_info pool_member_info;
     lsm_plug_volume_raid_create_cap_get vol_create_raid_cap_get;
     lsm_plug_volume_raid_create vol_create_raid;
@@ -1074,7 +1123,8 @@ int LSM_DLL_EXPORT lsm_plugin_init_v1(int argc, char *argv[],
  * @param san_ops           Function pointers for SAN operations
  * @param fs_ops            Function pointers for file system operations
  * @param nas_ops           Function pointers for NAS operations
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_register_plugin_v1(lsm_plugin_ptr plug,
                                           void *private_data,
@@ -1093,7 +1143,8 @@ int LSM_DLL_EXPORT lsm_register_plugin_v1(lsm_plugin_ptr plug,
  * @param fs_ops            Function pointers for struct lsm_fs_ops_v1
  * @param nas_ops           Function pointers for struct lsm_nas_ops_v1
  * @param ops_v1_2          Function pointers for struct lsm_ops_v1_2
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_register_plugin_v1_2(lsm_plugin_ptr plug,
                                             void *private_data,
@@ -1114,7 +1165,8 @@ int LSM_DLL_EXPORT lsm_register_plugin_v1_2(lsm_plugin_ptr plug,
  * @param nas_ops           Function pointers for struct lsm_nas_ops_v1
  * @param ops_v1_2          Function pointers for struct lsm_ops_v1_2
  * @param ops_v1_3          Function pointers for struct lsm_ops_v1_3
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_register_plugin_v1_3(lsm_plugin_ptr plug,
                                             void *private_data,
@@ -1213,7 +1265,8 @@ void LSM_DLL_EXPORT lsm_pool_free_space_set(lsm_pool *p,
  * @param status_info   Additional textual information on status
  * @param system_id     System id
  * @param plugin_data   Reserved for plugin writer use
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 lsm_pool LSM_DLL_EXPORT *lsm_pool_record_alloc(const char *id,
                                                const char *name,
@@ -1272,7 +1325,8 @@ lsm_disk LSM_DLL_EXPORT *lsm_disk_record_alloc(const char *id,
  * New in version 1.3. Set a disk's location.
  * @param disk		Pointer to the disk of interest.
  * @param disk_path	Pointer to the disk's location.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_disk_location_set(lsm_disk *disk,
                                          const char *location);
@@ -1334,7 +1388,9 @@ lsm_system LSM_DLL_EXPORT *lsm_system_record_alloc(const char *id,
  * @param[in] id            Id
  * @param[in] sys           System to update.
  * @param[in] read_pct      Read cache percentage.
- * @return LSM_ERR_OK or LSM_ERR_INVALID_ARGUMENT.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_INVALID_ARGUMENT otherwise.
  */
 int LSM_DLL_EXPORT lsm_system_read_cache_pct_set(lsm_system *sys,
                                                  int read_pct);
@@ -1346,7 +1402,10 @@ int LSM_DLL_EXPORT lsm_system_read_cache_pct_set(lsm_system *sys,
  * @param[in] fw_ver        Firmware version string.
  *                          Caller will get LSM_ERR_INVALID_ARGUMENT for
  *                          empty string('\0').
- * @return LSM_ERR_OK or LSM_ERR_NO_MEMORY or LSM_ERR_INVALID_ARGUMENT.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_NO_MEMORY
+ * @retval LSM_ERR_INVALID_ARGUMENT
  */
 int LSM_DLL_EXPORT lsm_system_fw_version_set(lsm_system *sys,
                                              const char *fw_ver);
@@ -1355,7 +1414,9 @@ int LSM_DLL_EXPORT lsm_system_fw_version_set(lsm_system *sys,
  * New in version 1.3. Set system mode.
  * @param[in] sys           System to update.
  * @param[in] mode          System mode 'lsm_system_mode_type'.
- * @return LSM_ERR_OK or LSM_ERR_INVALID_ARGUMENT.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_INVALID_ARGUMENT otherwise.
  */
 int LSM_DLL_EXPORT lsm_system_mode_set(lsm_system *sys,
                                        lsm_system_mode_type mode);
@@ -1467,7 +1528,8 @@ const char LSM_DLL_EXPORT *lsm_fs_ss_plugin_data_get(lsm_fs_ss * fs_ss);
  * @param cap           Valid capability pointer
  * @param t             Which capability to set
  * @param v             Value of the capability
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_capability_set(lsm_storage_capabilities * cap,
                                       lsm_capability_type t,
@@ -1479,7 +1541,8 @@ int LSM_DLL_EXPORT lsm_capability_set(lsm_storage_capabilities * cap,
  * @param v             The value to set capabilities to
  * @param ...           Which capabilites to set (Make sure to terminate list
  *                      with a -1)
- * @return LSM_ERR_OK on success, else error reason
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_capability_set_n(lsm_storage_capabilities * cap,
                                         lsm_capability_value_type v, ...);
@@ -1502,7 +1565,8 @@ lsm_storage_capabilities LSM_DLL_EXPORT
  * @param[out]  port            returned port
  * @param[out]  path            returned path
  * @param[out]  query_params    returned query params
- * @return LSM_ERR_OK on successful parse, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_uri_parse(const char *uri, char **scheme,
                                  char **user, char **server, int *port,
@@ -1655,7 +1719,9 @@ void LSM_DLL_EXPORT
  * New in version 1.3. Set disk VPD83 ID.
  * @param[in] disk          Disk to update.
  * @param[in] vpd83         VPD83 ID string.
- * @return LSM_ERR_OK or LSM_ERR_INVALID_ARGUMENT.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_INVALID_ARGUMENT otherwise.
  */
 int LSM_DLL_EXPORT lsm_disk_vpd83_set(lsm_disk *disk, const char *vpd83);
 
@@ -1663,7 +1729,9 @@ int LSM_DLL_EXPORT lsm_disk_vpd83_set(lsm_disk *disk, const char *vpd83);
  * New in version 1.3. Set disk rotation speed - revolutions per minute(RPM)
  * @param[in] disk          Disk to update.
  * @param[in] rpm           revolutions per minute(RPM).
- * @return LSM_ERR_OK or LSM_ERR_INVALID_ARGUMENT.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_INVALID_ARGUMENT otherwise.
  */
 int LSM_DLL_EXPORT lsm_disk_rpm_set(lsm_disk *disk, int32_t rpm);
 
@@ -1671,7 +1739,9 @@ int LSM_DLL_EXPORT lsm_disk_rpm_set(lsm_disk *disk, int32_t rpm);
  * New in version 1.3. Set disk link type.
  * @param[in] disk          Disk to update.
  * @param[in] link_type     lsm_disk_link_type
- * @return LSM_ERR_OK or LSM_ERR_INVALID_ARGUMENT.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_INVALID_ARGUMENT otherwise.
  */
 int LSM_DLL_EXPORT lsm_disk_link_type_set(lsm_disk *disk,
                                           lsm_disk_link_type link_type);

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_pool.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_pool.h
@@ -29,14 +29,16 @@ extern "C" {
  * Frees the memory for each of the pools and then the pool array itself.
  * @param pa    Pool array to free.
  * @param size  Size of the pool array.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_pool_record_array_free(lsm_pool *pa[], uint32_t size);
 
 /**
  * Frees the memory for an individual pool
  * @param p Valid pool
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_pool_record_free(lsm_pool *p);
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_snapshot.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_snapshot.h
@@ -28,7 +28,8 @@ extern "C" {
 /**
  * Frees a file system snapshot record.
  * @param ss    Snapshot record
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_fs_ss_record_free(lsm_fs_ss *ss);
 
@@ -43,7 +44,8 @@ lsm_fs_ss LSM_DLL_EXPORT *lsm_fs_ss_record_copy(lsm_fs_ss *source);
  * Frees an array of snapshot record.
  * @param ss        An array of snapshot record pointers.
  * @param size      Number of snapshot records.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_fs_ss_record_array_free(lsm_fs_ss *ss[], uint32_t size);
 

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_systems.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_systems.h
@@ -39,7 +39,8 @@ lsm_system LSM_DLL_EXPORT *lsm_system_record_copy(lsm_system *s);
 /**
  * Frees the resources for a lsm_system
  * @param s Record to release
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_system_record_free(lsm_system *s);
 
@@ -47,8 +48,9 @@ int LSM_DLL_EXPORT lsm_system_record_free(lsm_system *s);
  * Frees the resources for an array for lsm_system
  * @param s     Array to release memory for
  * @param size  Number of elements.
- * @return LSM_ERR_OK on success, else error reason.
- *  */
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ */
 int LSM_DLL_EXPORT lsm_system_record_array_free(lsm_system *s[], uint32_t size);
 
 /**
@@ -73,8 +75,10 @@ const char LSM_DLL_EXPORT *lsm_system_name_get(lsm_system *s);
  * New in version 1.3. Retrieves read cache percentage of the specified system.
  * @param       s      		System to retrieve read cache percentage for.
  * @param[out]  read_pct  	Read cache percentage.
- * @return LSM_ERR_OK on success, or LSM_ERR_NO_SUPPORT, or
- *         LSM_ERR_INVALID_ARGUMENT.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_NO_SUPPORT
+ * @retval LSM_ERR_INVALID_ARGUMENT
  */
 int LSM_DLL_EXPORT lsm_system_read_cache_pct_get(lsm_system *s,
                                                  int *read_pct);
@@ -93,8 +97,10 @@ uint32_t LSM_DLL_EXPORT lsm_system_status_get(lsm_system *s);
  * lsm_system_record_free() or lsm_system_record_array_free() is called.
  * @param       s       System to retrieve firmware version for.
  * @param[out]  fw_ver  Firmware version string.
- * @return LSM_ERR_OK on success, or LSM_ERR_NO_SUPPORT, or
- *         LSM_ERR_INVALID_ARGUMENT.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_NO_SUPPORT
+ * @retval LSM_ERR_INVALID_ARGUMENT
  */
 int LSM_DLL_EXPORT lsm_system_fw_version_get(lsm_system *s,
                                              const char **fw_ver);
@@ -115,8 +121,10 @@ int LSM_DLL_EXPORT lsm_system_fw_version_get(lsm_system *s,
  *          configurations. SCSI enclosure service might be exposed to OS also.
  * @param       s       System to retrieve firmware version for.
  * @param[out]  mode    System mode 'lsm_system_mode_type' pointer.
- * @return LSM_ERR_OK on success, or LSM_ERR_NO_SUPPORT, or
- *         LSM_ERR_INVALID_ARGUMENT.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
+ * @retval LSM_ERR_NO_SUPPORT
+ * @retval LSM_ERR_INVALID_ARGUMENT 
  */
 int LSM_DLL_EXPORT lsm_system_mode_get(lsm_system *s,
                                        lsm_system_mode_type *mode);

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_targetport.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_targetport.h
@@ -37,7 +37,8 @@ lsm_target_port LSM_DLL_EXPORT *lsm_target_port_copy(lsm_target_port *tp);
 /**
  * Frees the resources for a lsm_system
  * @param tp        Record to release
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_target_port_record_free(lsm_target_port *tp);
 
@@ -45,7 +46,8 @@ int LSM_DLL_EXPORT lsm_target_port_record_free(lsm_target_port *tp);
  * Frees the resources for an array for lsm_target_port
  * @param tp        Array to release memory for
  * @param size      Number of elements.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  *  */
 int LSM_DLL_EXPORT lsm_target_port_record_array_free(lsm_target_port *
                                                      tp[], uint32_t size);

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -123,88 +123,88 @@ typedef struct _lsm_hash lsm_hash;
  */
 typedef struct _lsm_target_port lsm_target_port;
 
-/**< \enum lsm_replication_type Different types of replications that can be
+/** \enum lsm_replication_type Different types of replications that can be
  * created */
 typedef enum {
+    /** Unknown replicate */
     LSM_VOLUME_REPLICATE_UNKNOWN = -1,
-    /**^ Unknown replicate */
+    /** Space efficient copy */
     LSM_VOLUME_REPLICATE_CLONE = 2,
-    /**^ Space efficient copy */
+    /** Full bitwise copy */
     LSM_VOLUME_REPLICATE_COPY = 3,
-    /**^ Full bitwise copy */
+    /** Mirrors always in sync */
     LSM_VOLUME_REPLICATE_MIRROR_SYNC = 4,
-    /**^ Mirrors always in sync */
+    /** Mirror partner updated with delay */
     LSM_VOLUME_REPLICATE_MIRROR_ASYNC = 5
-    /**^ Mirror partner updated with delay */
 } lsm_replication_type;
 
-/**< \enum lsm_volume_provision_type Different types of provisioning */
+/** \enum lsm_volume_provision_type Different types of provisioning */
 typedef enum {
+    /** Unknown */
     LSM_VOLUME_PROVISION_UNKNOWN = -1,
-    /**^ Unknown */
+    /** Thin provisioning */
     LSM_VOLUME_PROVISION_THIN = 1,
-    /**^ Thin provisioning */
+    /** Thick provisioning */
     LSM_VOLUME_PROVISION_FULL = 2,
-    /**^ Thick provisioning */
+    /** Default provisioning */
     LSM_VOLUME_PROVISION_DEFAULT = 3
-    /**^ Default provisioning */
 } lsm_volume_provision_type;
 
 
-    /**^ \enum lsm_volume_raid_type Different types of RAID */
+/** \enum lsm_volume_raid_type Different types of RAID */
 typedef enum {
+    /** Unknown */
     LSM_VOLUME_RAID_TYPE_UNKNOWN = -1,
-    /**^ Unknown */
+    /** Stripe */
     LSM_VOLUME_RAID_TYPE_RAID0 = 0,
-    /**^ Stripe */
+    /** Mirror between two disks. For 4 disks or more, they are RAID10.*/
     LSM_VOLUME_RAID_TYPE_RAID1 = 1,
-    /**^ Mirror between two disks. For 4 disks or more, they are RAID10.*/
+    /** Byte-level striping with dedicated parity */
     LSM_VOLUME_RAID_TYPE_RAID3 = 3,
-    /**^ Byte-level striping with dedicated parity */
+    /** Block-level striping with dedicated parity */
     LSM_VOLUME_RAID_TYPE_RAID4 = 4,
-    /**^ Block-level striping with dedicated parity */
+    /** Block-level striping with distributed parity */
     LSM_VOLUME_RAID_TYPE_RAID5 = 5,
-    /**^ Block-level striping with distributed parity */
+    /** Block-level striping with two distributed parities, aka, RAID-DP */
     LSM_VOLUME_RAID_TYPE_RAID6 = 6,
-    /**^ Block-level striping with two distributed parities, aka, RAID-DP */
+    /** Stripe of mirrors */
     LSM_VOLUME_RAID_TYPE_RAID10 = 10,
-    /**^ Stripe of mirrors */
+    /** Parity of mirrors */
     LSM_VOLUME_RAID_TYPE_RAID15 = 15,
-    /**^ Parity of mirrors */
+    /** Dual parity of mirrors */
     LSM_VOLUME_RAID_TYPE_RAID16 = 16,
-    /**^ Dual parity of mirrors */
+    /** Stripe of parities */
     LSM_VOLUME_RAID_TYPE_RAID50 = 50,
-    /**^ Stripe of parities */
+    /** Stripe of dual parities */
     LSM_VOLUME_RAID_TYPE_RAID60 = 60,
-    /**^ Stripe of dual parities */
+    /** Mirror of parities */
     LSM_VOLUME_RAID_TYPE_RAID51 = 51,
-    /**^ Mirror of parities */
+    /** Mirror of dual parities */
     LSM_VOLUME_RAID_TYPE_RAID61 = 61,
-    /**^ Mirror of dual parities */
+    /** Just bunch of disks, no parity, no striping. */
     LSM_VOLUME_RAID_TYPE_JBOD = 20,
-    /**^ Just bunch of disks, no parity, no striping. */
+    /** This volume contains multiple RAID settings. */
     LSM_VOLUME_RAID_TYPE_MIXED = 21,
-    /**^ This volume contains multiple RAID settings. */
+    /** Vendor specific RAID type */
     LSM_VOLUME_RAID_TYPE_OTHER = 22,
-    /**^ Vendor specific RAID type */
 } lsm_volume_raid_type;
 
 
-    /**^ \enum lsm_pool_member_type Different types of Pool member*/
+/** \enum lsm_pool_member_type Different types of Pool member*/
 typedef enum {
+    /** Plugin failed to detect the RAID member type. */
     LSM_POOL_MEMBER_TYPE_UNKNOWN = 0,
-    /**^ Plugin failed to detect the RAID member type. */
+    /** Vendor specific RAID member type. */
     LSM_POOL_MEMBER_TYPE_OTHER = 1,
-    /**^ Vendor specific RAID member type. */
+    /** Pool is created from RAID group using whole disks. */
     LSM_POOL_MEMBER_TYPE_DISK = 2,
-    /**^ Pool is created from RAID group using whole disks. */
-    LSM_POOL_MEMBER_TYPE_POOL = 3,
-    /**^
+    /**
      * Current pool(also known as sub-pool) is allocated from other
      * pool(parent pool).
      * The 'raid_type' will set to RAID_TYPE_OTHER unless certain RAID system
      * support RAID using space of parent pools.
      */
+    LSM_POOL_MEMBER_TYPE_POOL = 3,
 } lsm_pool_member_type;
 
 #define LSM_VOLUME_STRIP_SIZE_UNKNOWN       0
@@ -215,51 +215,51 @@ typedef enum {
 /**
  * Admin state for volume, enabled or disabled
  */
+    /** Volume accessible */
 #define LSM_VOLUME_ADMIN_STATE_ENABLED      0x1
-    /**^ Volume accessible */
+    /** Volume unaccessible */
 #define LSM_VOLUME_ADMIN_STATE_DISABLED     0x0
-    /**^ Volume unaccessible */
+
 
 /**
  * Different states a system status can be in.
  * Bit field, can be in multiple states at the same time.
  */
+    /** Unknown */
 #define LSM_SYSTEM_STATUS_UNKNOWN               0x00000001
-    /**^ Unknown */
+    /** OK */
 #define LSM_SYSTEM_STATUS_OK                    0x00000002
-    /**^ OK */
+    /** Error(s) exist */
 #define LSM_SYSTEM_STATUS_ERROR                 0x00000004
-    /**^ Error(s) exist */
+    /** Degraded */
 #define LSM_SYSTEM_STATUS_DEGRADED              0x00000008
-    /**^ Degraded */
+    /** System has predictive failure(s) */
 #define LSM_SYSTEM_STATUS_PREDICTIVE_FAILURE    0x00000010
-    /**^ System has predictive failure(s) */
+    /** Vendor specific */
 #define LSM_SYSTEM_STATUS_OTHER                 0x00000020
-    /**^ Vendor specific */
 
 
 typedef enum {
+    /** Unknown */ 
     LSM_ACCESS_GROUP_INIT_TYPE_UNKNOWN = 0,
-    /**^ Unknown */
+    /** Something not seen before */
     LSM_ACCESS_GROUP_INIT_TYPE_OTHER = 1,
-    /**^ Something not seen before */
+    /** Port name */
     LSM_ACCESS_GROUP_INIT_TYPE_WWPN = 2,
-    /**^ Port name */
+    /** ISCSI IQN */
     LSM_ACCESS_GROUP_INIT_TYPE_ISCSI_IQN = 5,
-    /**^ ISCSI IQN */
+    /** More than 1 type */
     LSM_ACCESS_GROUP_INIT_TYPE_ISCSI_WWPN_MIXED = 7
-    /**^ More than 1 type */
 } lsm_access_group_init_type;
 
-
-    /**^ \enum lsm_job_status Job states */
+/** \enum lsm_job_status Job states */
 typedef enum {
+    /** Job is in progress */
     LSM_JOB_INPROGRESS = 1,
-    /**^ Job is in progress */
+    /** Job is complete */
     LSM_JOB_COMPLETE = 2,
-    /**^ Job is complete */
+    /** Job has errored */
     LSM_JOB_ERROR = 3
-    /**^ Job has errored */
 } lsm_job_status;
 
 typedef enum {
@@ -278,6 +278,7 @@ typedef enum {
     LSM_DISK_TYPE_HYBRID = 54,
 } lsm_disk_type;
 
+/* SPC-5 rev7, Table 444 - PROTOCOL IDENTIFIER field values */
 typedef enum {
     LSM_DISK_LINK_TYPE_NO_SUPPORT = -2,
     LSM_DISK_LINK_TYPE_UNKNOWN =  -1,
@@ -293,7 +294,6 @@ typedef enum {
     LSM_DISK_LINK_TYPE_SOP = 10,
     LSM_DISK_LINK_TYPE_PCIE = 11,
 } lsm_disk_link_type;
-/* ^ SPC-5 rev7, Table 444 - PROTOCOL IDENTIFIER field values */
 
 #define LSM_DISK_STATUS_UNKNOWN                     0x0000000000000001
 #define LSM_DISK_STATUS_OK                          0x0000000000000002
@@ -308,8 +308,7 @@ typedef enum {
 #define LSM_DISK_STATUS_MAINTENANCE_MODE            0x0000000000000400
 #define LSM_DISK_STATUS_SPARE_DISK                  0x0000000000000800
 #define LSM_DISK_STATUS_RECONSTRUCT                 0x0000000000001000
-#define LSM_DISK_STATUS_FREE                        0x0000000000002000
-/**^
+/** <! LSM_DISK_STATUS_FREE >
  * New in version 1.2, New in version 1.2, indicate the whole disk is not
  * holding any data or acting as a dedicate spare disk.
  * This disk could be assigned as a dedicated spare disk or used for creating
@@ -318,20 +317,22 @@ typedef enum {
  * action when assigning to pool, it should be treated as free disk and marked
  * as LSM_DISK_STATUS_FREE|LSM_DISK_STATUS_SPARE_DISK.
  * */
+#define LSM_DISK_STATUS_FREE                        0x0000000000002000
 
 #define LSM_DISK_BLOCK_SIZE_NOT_FOUND               -1
 #define LSM_DISK_BLOCK_COUNT_NOT_FOUND              -1
 
+/* New in version 1.3. */
 #define LSM_DISK_RPM_NO_SUPPORT                     -2
-/* ^ New in version 1.3. */
+/* New in version 1.3. */
 #define LSM_DISK_RPM_UNKNOWN                        -1
-/* ^ New in version 1.3. */
+/* New in version 1.3. */
 #define LSM_DISK_RPM_NON_ROTATING_MEDIUM            0
-/* ^ New in version 1.3. */
-#define LSM_DISK_RPM_ROTATING_UNKNOWN_SPEED         1
-/* ^ New in version 1.3. Indicate given disk is a rotating disk, but speed is
- *   unknown
+/* New in version 1.3. Indicate given disk is a rotating disk, but speed is
+ * unknown
  */
+#define LSM_DISK_RPM_ROTATING_UNKNOWN_SPEED         1
+
 
 #define LSM_POOL_STATUS_UNKNOWN                     0x0000000000000001
 #define LSM_POOL_STATUS_OK                          0x0000000000000002
@@ -365,8 +366,8 @@ typedef enum {
     LSM_TARGET_PORT_TYPE_ISCSI = 4
 } lsm_target_port_type;
 
+/** Plugin and hardware RAID will use their default strip size */
 #define LSM_VOLUME_VCR_STRIP_SIZE_DEFAULT           0
-/** ^ Plugin and hardware RAID will use their default strip size */
 
 typedef enum {
     LSM_SYSTEM_MODE_NO_SUPPORT = 0,

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_volumes.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_volumes.h
@@ -28,7 +28,8 @@ extern "C" {
 /**
  * Frees the memory fro an individual volume
  * @param v     Volume pointer to free.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_record_free(lsm_volume *v);
 
@@ -43,7 +44,8 @@ lsm_volume LSM_DLL_EXPORT *lsm_volume_record_copy(lsm_volume *vol);
  * Frees the memory for each of the volume records and then the array itself.
  * @param init  Array to free.
  * @param size  Size of array.
- * @return LSM_ERR_OK on success, else error reason.
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK on success.
  */
 int LSM_DLL_EXPORT lsm_volume_record_array_free(lsm_volume *init[],
                                                 uint32_t size);


### PR DESCRIPTION
Updated all libstoragemgmt_*.h header doxygen documentation to reference LSM_ERR_<reason> enum. Also fixed all comments of form /**^ comment */ which were below their intended items to be above them.

Signed off by: Blaine Gardner <blaine.gardner@hpe.com>