### PR TITLE
Fix RHEL/Fedora mock build test failure.

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_plug_interface.h
@@ -1213,8 +1213,6 @@ typedef int (*lsm_plug_volume_read_cache_policy_update) (lsm_plugin_ptr c,
 
 /** \struct lsm_ops_v1_3
  * \brief Functions added in version 1.3
- * NOTE: This structure will change during the developement util version 1.3
- *       released.
  */
 struct lsm_ops_v1_3 {
     lsm_plug_volume_ident_led_on vol_ident_on;

--- a/c_binding/lsm_local_disk.c
+++ b/c_binding/lsm_local_disk.c
@@ -634,10 +634,13 @@ int lsm_local_disk_list(lsm_string_list **disk_paths, lsm_error **lsm_err)
         }
         if ((strncmp(disk_path, "/dev/sd", strlen("/dev/sd")) == 0) ||
             (strncmp(disk_path, "/dev/nvme", strlen("/dev/nvme")) == 0)) {
-            rc = lsm_string_list_append(*disk_paths, disk_path);
-            if (rc != LSM_ERR_OK) {
-                udev_device_unref(udev_dev);
-                goto out;
+
+            if (_file_exists(disk_path)) {
+                rc = lsm_string_list_append(*disk_paths, disk_path);
+                if (rc != LSM_ERR_OK) {
+                    udev_device_unref(udev_dev);
+                    goto out;
+                }
             }
         }
         udev_device_unref(udev_dev);

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -95,6 +95,7 @@ Requires(postun): systemd
 BuildRequires:  chrpath
 BuildRequires:  valgrind
 BuildRequires:  python-pyudev
+BuildRequires:  procps
 
 %description
 The libStorageMgmt library will provide a vendor agnostic open source storage


### PR DESCRIPTION
    Problem:
        When running in fakeroot, lsm_local_disk_list() might indicate the
        existence of '/dev/sda' while lsm_ident_led_on() fail with
        NOT_FOUND_DISK error.
    
    Root cause:
        The fakeroot might only have /sys mounted while /dev/ is not.
    
    Fix:
        Make sure the file '/dev/sdX' exists before add it to return list.


Also include a extra patch to remove unstable note on 1.3 plugin interface.