### PR TITLE
Fix lsmcli job-status command on volume creation job.

### DIFF
--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -1443,7 +1443,7 @@ class CmdLine:
 
         if s == JobStatus.COMPLETE:
             if item:
-                self.display_data([item])
+                self.display_data([_add_sd_paths(item)])
 
             self.c.job_free(args.job)
         else:


### PR DESCRIPTION
Problem:

    The 'lsmcli job-status --job <JOB_ID>' will fail on volume
    creation job due to missing 'sd_paths' property.

Fix:

    Call _add_sd_paths() before invoking display_data().

Signed-off-by: Gris Ge <fge@redhat.com>