### PR TITLE
Fix 'make check' on RHEL 6(python 2.6)

### DIFF
--- a/test/plugin_test.py
+++ b/test/plugin_test.py
@@ -1579,8 +1579,8 @@ class TestPlugin(unittest.TestCase):
     def test_invalid_uri(self):
 
         # Make sure we are getting an exception
-        with self.assertRaises(lsm.LsmError):
-            lsm.Client("ontap//root@na-sim", "some_password")
+        self.assertRaises(lsm.LsmError, lsm.Client,
+                          "ontap//root@na-sim", "some_password")
 
         # Make sure exception has the correct error code
         try:


### PR DESCRIPTION
Problem:

    Got blow error when run 'make check' on RHEL/Centos 6.
    ERROR: test_invalid_uri (__main__.TestPlugin)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/tmp/10441/bin//plugin_test.py", line 1582, in test_invalid_uri
        with self.assertRaises(lsm.LsmError):
    TypeError: failUnlessRaises() takes at least 3 arguments (2 given)
    ----------------------------------------------------------------------

Root cause:

    'with self.assertRaises(lsm.LsmError)' is only supported by
    python 2.7+ while RHEL6 only ships python 2.6

Fix:

    Change to:

        self.assertRaises(lsm.LsmError, lsm.Client,
                          "ontap//root@na-sim", "some_password")

Signed-off-by: Gris Ge <fge@redhat.com>