### PR TITLE
Bug fix: lsmcli volume-replicate-range will fail on C plugin.

### DIFF
--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -1488,7 +1488,8 @@ class CmdLine:
 
         ranges = []
         for b in range(len(src_starts)):
-            ranges.append(BlockRange(src_starts[b], dst_starts[b], counts[b]))
+            ranges.append(BlockRange(long(src_starts[b]), long(dst_starts[b]),
+                                     long(counts[b])))
 
         if self.confirm_prompt(False):
             self.c.volume_replicate_range(rep_type, src, dst, ranges)


### PR DESCRIPTION
Problem:

    C plugin will raise/return INVALID_ARGUMENT error on this command:

        lsmcli volume-replicate-range --src-vol VOL_ID_00001 \
            --dst-vol VOL_ID_00002 --rep-type CLONE \
            --src-start 0 --dst-start 0 --count 100 -f

Root cause:

    lsmcli use string instead of int/long to initialize BlockRange
    object which cause value_to_block_range() in C library failed at
    range["src_block"].asUint64_t()

Fix:

    Convert string provided by argument parser to int.

Signed-off-by: Gris Ge <fge@redhat.com>