### PR TITLE
hpsa: Update cacheless variable

### DIFF
--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -469,7 +469,7 @@ class SmartArray(IPlugin):
             else:
                 # Some Smart Arrays don't have cache
                 # This entry is also missing until a volume uses cache
-                read_cache_pct = System.CACHE_PCT_UNKNOWN
+                read_cache_pct = System.READ_CACHE_PCT_UNKNOWN
             if 'Controller Mode' in ctrl_data:
                 hwraid_mode = ctrl_data['Controller Mode']
                 if hwraid_mode == 'RAID':


### PR DESCRIPTION
There was a mistake here that I ran into on an H240 Smart Array card in RAID mode. I used the wrong naming scheme, missed it because my hardware was not available until recently. 

Signed-off-by: Joe Handzik <joseph.t.handzik@hpe.com>