### PR TITLE
C library: Fix missing vpd83 optional property of disk.

### DIFF
--- a/c_binding/lsm_convert.cpp
+++ b/c_binding/lsm_convert.cpp
@@ -210,6 +210,8 @@ Value disk_to_value(lsm_disk * disk)
             d["rpm"] = Value(disk->rpm);
         if (disk->link_type != LSM_DISK_LINK_TYPE_NO_SUPPORT)
             d["link_type"] = Value(disk->link_type);
+        if (disk->vpd83 != NULL)
+            d["vpd83"] = Value(disk->vpd83);
 
         return Value(d);
     }


### PR DESCRIPTION
Problem:
    lsm_disk_vpd83_set() does works when transferring data to Python
    client API(like lsmcli).

Root cause:
    disk_to_value() does not handle vpd83.

Signed-off-by: Gris Ge <fge@redhat.com>