### PR TITLE
Fix anon_uid/anon_gid from C plugin to Python API.

### DIFF
--- a/c_binding/lsm_convert.cpp
+++ b/c_binding/lsm_convert.cpp
@@ -710,8 +710,14 @@ Value nfs_export_to_value(lsm_nfs_export * exp)
         f["root"] = Value(string_list_to_value(exp->root));
         f["rw"] = Value(string_list_to_value(exp->read_write));
         f["ro"] = Value(string_list_to_value(exp->read_only));
-        f["anonuid"] = Value(exp->anon_uid);
-        f["anongid"] = Value(exp->anon_gid);
+        if (exp->anon_uid == UINT64_MAX)
+            f["anonuid"] = Value(-1);
+        else
+            f["anonuid"] = Value(exp->anon_uid);
+        if (exp->anon_gid == UINT64_MAX)
+            f["anongid"] = Value(-1);
+        else
+            f["anongid"] = Value(exp->anon_gid);
         f["options"] = Value(exp->options);
         f["plugin_data"] = Value(exp->plugin_data);
         return Value(f);


### PR DESCRIPTION
Problem:

    For NFS exports returned by C plugin, the
    LSM_NFS_EXPORT_ANON_UID_GID_NA is incorrectly converted to
    '2 ** 64 -1' in JSON which failed python API, example:
        ===
        [fge@Gris-Laptop lsm]$ lsmenv simc lsmcli list --type exports -s
        Device alias: simc
        URI: simc://
        lsmcli list --type exports -s
        ------------------------------------
        ID            | EXP_ID_00001
        FileSystem ID | FS_ID_00001
        Export Path   | /nfs_exp_5076931fa
        Auth Type     |
        RW Hosts      | localhost
        Anonymous UID | 18446744073709551615
        Anonymous GID | 18446744073709551615
        Options       |
        ------------------------------------
        ===

Root cause:

    The anon_uid/anon_gid is uint64_t in C API(both client and plugin),
    which convert LSM_NFS_EXPORT_ANON_UID_GID_NA(-1) to
    UINT64_MAX('2 ** 64 - 1').

Fix:

    Make sure nfs_export_to_value() in lsm_convert.cpp use -1 instead of
    UINT64_MAX before generating JSON string.

Signed-off-by: Gris Ge <fge@redhat.com>