### PR TITLE
C library: Fix LSM_NFS_EXPORT_ANON_UID_GID_ERROR in lsm_convert.cpp

### DIFF
--- a/c_binding/lsm_convert.cpp
+++ b/c_binding/lsm_convert.cpp
@@ -712,10 +712,14 @@ Value nfs_export_to_value(lsm_nfs_export * exp)
         f["ro"] = Value(string_list_to_value(exp->read_only));
         if (exp->anon_uid == UINT64_MAX)
             f["anonuid"] = Value(-1);
+        else if (exp->anon_uid == UINT64_MAX - 1)
+            f["anonuid"] = Value(-2);
         else
             f["anonuid"] = Value(exp->anon_uid);
         if (exp->anon_gid == UINT64_MAX)
             f["anongid"] = Value(-1);
+        else if (exp->anon_gid == UINT64_MAX - 1)
+            f["anongid"] = Value(-2);
         else
             f["anongid"] = Value(exp->anon_gid);
         f["options"] = Value(exp->options);


### PR DESCRIPTION
Fix the leftover -2 value handler in lsm_convert.cpp for uid/gid.
Please check https://github.com/libstorage/libstoragemgmt/pull/184 for detail.

Signed-off-by: Gris Ge <fge@redhat.com>