### PR TITLE
lsmcli: Fix running on python 2.6.

### DIFF
--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -998,7 +998,7 @@ class CmdLine:
     def alias_help_text():
         rc = "command aliases:\n"
         for k, v in sorted(aliases.items()):
-            rc += "   {:<18}   Alias of '{}'\n".format(k, v)
+            rc += "   {0:<18}   Alias of '{1}'\n".format(k, v)
         return rc
 
 


### PR DESCRIPTION
On Python 2.6, lsmcli will failed with error:
```
ValueError: zero length field name in format
```

Adding field numbers fixed this issue.

Signed-off-by: Gris Ge <fge@redhat.com>