### PR TITLE
C library: Fix anon_uid/anon_gid from C client to plugin.

### DIFF
--- a/c_binding/lsm_mgmt.cpp
+++ b/c_binding/lsm_mgmt.cpp
@@ -2380,8 +2380,18 @@ int lsm_nfs_export_fs(lsm_connect * c,
     p["root_list"] = string_list_to_value(root_list);
     p["rw_list"] = string_list_to_value(rw_list);
     p["ro_list"] = string_list_to_value(ro_list);
-    p["anon_uid"] = Value(anon_uid);
-    p["anon_gid"] = Value(anon_gid);
+    if ((int64_t) anon_uid == LSM_NFS_EXPORT_ANON_UID_GID_NA)
+        p["anon_uid"] = Value(LSM_NFS_EXPORT_ANON_UID_GID_NA);
+    else if ((int64_t) anon_uid == LSM_NFS_EXPORT_ANON_UID_GID_ERROR)
+        p["anon_uid"] = Value(LSM_NFS_EXPORT_ANON_UID_GID_ERROR);
+    else
+        p["anon_uid"] = Value(anon_uid);
+    if ((int64_t) anon_gid == LSM_NFS_EXPORT_ANON_UID_GID_NA)
+        p["anon_gid"] = Value(LSM_NFS_EXPORT_ANON_UID_GID_NA);
+    else if ((int64_t) anon_gid == LSM_NFS_EXPORT_ANON_UID_GID_ERROR)
+        p["anon_gid"] = Value(LSM_NFS_EXPORT_ANON_UID_GID_ERROR);
+    else
+        p["anon_gid"] = Value(anon_gid);
     p["auth_type"] = Value(auth_type);
     p["options"] = Value(options);
     p["flags"] = Value(flags);


### PR DESCRIPTION
Problem:

    When C client API passing LSM_NFS_EXPORT_ANON_UID_GID_NA(-1) to
    plugin, it will be converted to some large number[1].

Fix:

    Change lsm_mgmt.c to use -1 or -2 for JSON in IPC.

[1]: On RHEL 7, it will be UINT64_MAX - 1, on RHEL 6, it will be
     INT64_MAX - 1. For C++ code, I have no idea why the difference.

Signed-off-by: Gris Ge <fge@redhat.com>