### PR TITLE
Improve readability of status_info from HPSA

### DIFF
--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -74,7 +74,7 @@ def _sys_status_of(hp_ctrl_status):
                 status = System.STATUS_OK
             else:
                 status = System.STATUS_OTHER
-            status_info += hp_ctrl_status[key_name]
+            status_info += 'status=[%s]' % str(hp_ctrl_status[key_name])
 
     return status, status_info
 


### PR DESCRIPTION
Since status_info may contain other information besides status, add
clarity to existing info. The form follows that implemented by the
system mode addition, and will now look like below example:

'status=['OK']'

If there is an unknown system mode, it will be changed as below example:

'status=['OK'] mode=['Unknown Mode']'

This will make it easy for other applications to parse and interpret
the outputs.