### PR TITLE
Set universal_newlines=True for Popen calls in hpsa and megaraid plugin utils.py

### DIFF
--- a/plugin/hpsa/utils.py
+++ b/plugin/hpsa/utils.py
@@ -25,7 +25,7 @@ def cmd_exec(cmds):
     """
     cmd_popen = subprocess.Popen(
         cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        env={"PATH": os.getenv("PATH")})
+        env={"PATH": os.getenv("PATH")}, universal_newlines=True)
     str_stdout = "".join(list(cmd_popen.stdout)).strip()
     str_stderr = "".join(list(cmd_popen.stderr)).strip()
     errno = cmd_popen.wait()

--- a/plugin/megaraid/utils.py
+++ b/plugin/megaraid/utils.py
@@ -25,7 +25,7 @@ def cmd_exec(cmds):
     """
     cmd_popen = subprocess.Popen(
         cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        env={"PATH": os.getenv("PATH")})
+        env={"PATH": os.getenv("PATH")}, universal_newlines=True)
     str_stdout = "".join(list(cmd_popen.stdout)).strip()
     str_stderr = "".join(list(cmd_popen.stderr)).strip()
     errno = cmd_popen.wait()


### PR DESCRIPTION
This is necessary to force stdout and stderr to be strings instead of byte
sequences. The code was written assuming that was always true, which it had
been until python3 support was attempted.

Signed-off-by: Joe Handzik <joseph.t.handzik@hpe.com>