### PR TITLE
Add controller, cache, and battery statuses to required sections

### DIFF
--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -107,7 +107,9 @@ def _parse_hpssacli_output(output):
     3. If current line is the start of new section, create an empty dictionary
        where following subsections or data could be stored in.
     """
-    required_sections = ['Array:', 'unassigned', 'HBA Drives', 'array']
+    required_sections = ['Array:', 'unassigned', 'HBA Drives', 'array',
+                         'Controller Status', 'Cache Status',
+                         'Battery/Capacitor Status']
 
     output_lines = [
         l for l in output.split("\n")


### PR DESCRIPTION
There is a bug in the HPSSACLI parsing code that will not get the
key-value pair for (a) properties that are at the end of a section or
(b) properties that appear alone.

In testing, controller status may appear alone and needs to be
whitelisted by adding it to the required sections variable. In the
event that cache status or battery status appear at the end of the
section, I also added those to the whitelist. This fix is non-ideal,
but it needs to appear in the next release, which is very soon.

This issue may rear its head again later, so an overhaul of the
HPSSACLI parsing routine may be appropriate.

Signed-off-by: Blaine Gardner <blaine.gardner@hpe.com>