### PR TITLE
Add specificity to hpsa plugin status info

### DIFF
--- a/plugin/hpsa/hpsa.py
+++ b/plugin/hpsa/hpsa.py
@@ -74,7 +74,8 @@ def _sys_status_of(hp_ctrl_status):
                 status = System.STATUS_OK
             else:
                 status = System.STATUS_OTHER
-            status_info += 'status=[%s]' % str(hp_ctrl_status[key_name])
+            status_info += ' "%s"=[%s]' % (str(key_name),
+                                          str(hp_ctrl_status[key_name]))
 
     return status, status_info
 


### PR DESCRIPTION
Status info is currently reported in such a way that
'status=[OK]status=[OK]status=[OK]' may be returned.

Instead of 'status', report the name of the property in quotes. Also
add white space for readability. New reporting should be:
'"Controller Status"=[OK] "Cache Status"=[OK] "..."=[...]'

Fixes #212

Signed-off-by: Blaine Gardner <blaine.gardner@hpe.com>