### PR TITLE
MegaRAID plugin: Fake timeout support and add missing capability.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.py diff=python
+*.py.in diff=python

--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -332,6 +332,7 @@ class MegaRAID(IPlugin):
 
     def __init__(self):
         self._storcli_bin = None
+        self._tmo_ms = 3000    # TODO(Gris Ge): Not implemented yet.
 
     def _find_storcli(self):
         """
@@ -380,11 +381,11 @@ class MegaRAID(IPlugin):
 
     @_handle_errors
     def time_out_set(self, ms, flags=Client.FLAG_RSVD):
-        raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
+        self._tmo_ms = ms # TODO(Gris Ge): Not implemented yet.
 
     @_handle_errors
     def time_out_get(self, flags=Client.FLAG_RSVD):
-        raise LsmError(ErrorNumber.NO_SUPPORT, "Not supported yet")
+        return self._tmo_ms
 
     @_handle_errors
     def capabilities(self, system, flags=Client.FLAG_RSVD):
@@ -401,6 +402,7 @@ class MegaRAID(IPlugin):
         cap.set(Capabilities.POOL_MEMBER_INFO)
         cap.set(Capabilities.VOLUME_RAID_CREATE)
         cap.set(Capabilities.BATTERIES)
+        cap.set(Capabilities.VOLUME_CACHE_INFO)
         cap.set(Capabilities.VOLUME_PHYSICAL_DISK_CACHE_UPDATE)
         cap.set(Capabilities.VOLUME_WRITE_CACHE_POLICY_UPDATE_WRITE_BACK)
         cap.set(Capabilities.VOLUME_WRITE_CACHE_POLICY_UPDATE_AUTO)

--- a/test/plugin_test.py.in
+++ b/test/plugin_test.py.in
@@ -1529,11 +1529,13 @@ class TestPlugin(unittest.TestCase):
         pool_id_to_lsm_vols = dict()
         lsm_vol = None
         s = None
+        cap = None
 
         for s in self.systems:
             cap = self.c.capabilities(s)
             if supported(cap, [Cap.VOLUME_RAID_INFO]):
                 flag_supported = True
+                break
         if flag_supported is False:
             self._skip_current_test(
                 "Skip test: current system does not support "
@@ -1548,8 +1550,9 @@ class TestPlugin(unittest.TestCase):
                 pool_id_to_lsm_vols[pool_id] = lsm_vol
 
         lsm_vols = list(pool_id_to_lsm_vols.values())
-        created_lsm_vol = self._volume_create(s.id)[0]
-        lsm_vols.append(created_lsm_vol)
+        if supported(cap, [Cap.VOLUME_CREATE]):
+            created_lsm_vol = self._volume_create(s.id)[0]
+            lsm_vols.append(created_lsm_vol)
 
         for lsm_vol in lsm_vols:
             [raid_type, strip_size, disk_count, min_io_size, opt_io_size] = \
@@ -1563,12 +1566,13 @@ class TestPlugin(unittest.TestCase):
             self.assertTrue(opt_io_size is not None)
 
         # Test NOT_FOUND_VOLUME error.
-        self._volume_delete(created_lsm_vol)
-        try:
-            self.c.volume_raid_info(lsm_vol)
-        except lsm.LsmError as le:
-            if le.code != ErrorNumber.NOT_FOUND_VOLUME:
-                raise
+        if supported(cap, [Cap.VOLUME_CREATE, Cap.VOLUME_DELETE]):
+            self._volume_delete(created_lsm_vol)
+            try:
+                self.c.volume_raid_info(lsm_vol)
+            except lsm.LsmError as le:
+                if le.code != ErrorNumber.NOT_FOUND_VOLUME:
+                    raise
 
     def test_volume_ident_led_on(self):
         for s in self.systems:


### PR DESCRIPTION
- Fake timeout support in order to pass plugin test.
- Add missing `VOLUME_CACHE_INFO` capability.

Note: If you edit the pull request text section, you will get the unit tests to re-run.  Not sure if this is good or not, but it does help with testing CI infrastructure.
