### PR TITLE
Local disk link speed query

### DIFF
--- a/c_binding/Makefile.am
+++ b/c_binding/Makefile.am
@@ -15,4 +15,6 @@ libstoragemgmt_la_SOURCES= \
 	lsm_mgmt.cpp lsm_datatypes.hpp lsm_datatypes.cpp lsm_convert.hpp \
 	lsm_convert.cpp lsm_ipc.hpp lsm_ipc.cpp lsm_plugin_ipc.hpp \
 	lsm_plugin_ipc.cpp util/qparams.c util/qparams.h \
-	utils.c utils.h libsg.c libsg.h lsm_local_disk.c libses.c libses.h
+	utils.c utils.h libsg.c libsg.h lsm_local_disk.c libses.c libses.h \
+	libata.c libata.h libsas.c libsas.h libfc.c libfc.h \
+	libiscsi.c libiscsi.h

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
@@ -315,6 +315,32 @@ int LSM_DLL_EXPORT lsm_local_disk_fault_led_off(const char *disk_path,
 int LSM_DLL_EXPORT lsm_local_disk_led_status_get(const char *disk_path,
                                                  uint32_t *led_status,
                                                  lsm_error **lsm_err);
+/**
+ * New in version 1.4.
+ * Query the current negotiated disk link speed.
+ * Requires permission to open disk path(root user or disk group).
+ * @param[in]  disk_path
+ *                      String. The path of block device, example: "/dev/sdb",
+ *                      "/dev/nvme0n1".
+ * @param[out] link_speed
+ *                      Output pointer of link speed in Mbps.
+ *                      For example, 3.0 Gbps will get 3000.
+ *                      Set to 0(LSM_DISK_LINK_SPEED_UNKNOWN) if error.
+ * @param[out] lsm_err
+ *                      Output pointer of lsm_error. Error message could be
+ *                      retrieved via lsm_error_message_get(). Memory should be
+ *                      freed by lsm_error_free().
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK               on success or not found.
+ * @retval LSM_ERR_INVALID_ARGUMENT when any argument is NULL.
+ * @retval LSM_ERR_LIB_BUG          when something unexpected happens.
+ * @retval LSM_ERR_NOT_FOUND_DISK   when provided disk path not found.
+ * @retval LSM_ERR_NO_SUPPORT       Specified disk is not supported yet.
+ * @retval LSM_ERR_PERMISSION_DENIED no sufficient permission to access
+ *                                   provided disk path.
+ */
+int LSM_DLL_EXPORT lsm_local_disk_link_speed_get
+    (const char *disk_path, uint32_t *link_speed, lsm_error **lsm_err);
 
 #ifdef __cplusplus
 }

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -347,6 +347,8 @@ typedef enum {
 #define LSM_DISK_LED_STATUS_FAULT_OFF               0x0000000000000020
 #define LSM_DISK_LED_STATUS_FAULT_UNKNOWN           0x0000000000000040
 
+#define LSM_DISK_LINK_SPEED_UNKNOWN                 0
+/* New in version 1.4. Indicate failed to query link speed of specified disk */
 
 #define LSM_POOL_STATUS_UNKNOWN                     0x0000000000000001
 #define LSM_POOL_STATUS_OK                          0x0000000000000002

--- a/c_binding/libata.c
+++ b/c_binding/libata.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#include "libata.h"
+#include "utils.h"
+
+#include "libstoragemgmt/libstoragemgmt_error.h"
+#include "libstoragemgmt/libstoragemgmt_types.h"
+
+#include <stdint.h>
+#include <assert.h>
+
+/*
+ * Serial ATA Additional Capabilities
+ */
+#define _ATA_SATA_ADD_CAP_WORD                      77
+#define _ATA_SPEED_UNKNOWN              0
+#define _ATA_SPEED_GEN1_0               1
+/* SATA revision 1.0 -- 1.5 Gbps */
+#define _ATA_SPEED_GEN2_0               2
+/* SATA revision 2.0 -- 3 Gbps */
+#define _ATA_SPEED_GEN3_0               3
+/* SATA revision 3.0 -- 6 Gbps */
+
+#pragma pack(push, 1)
+struct _ata_sata_add_cap {
+    uint8_t zero            : 1;
+    uint8_t cur_speed       : 3;
+    uint8_t we_dont_care_0  : 8;
+    uint8_t we_dont_care_1  : 4;
+};
+#pragma pack(pop)
+
+
+int _ata_cur_speed_get(char *err_msg, uint8_t *id_dev_data,
+                       uint32_t *link_speed)
+{
+    int rc = LSM_ERR_OK;
+    struct _ata_sata_add_cap *add_cap = NULL;
+
+    assert(id_dev_data != NULL);
+    assert(link_speed != NULL);
+
+    add_cap = (struct _ata_sata_add_cap *)
+        (id_dev_data + _ATA_SATA_ADD_CAP_WORD * 2);
+
+    *link_speed = LSM_DISK_LINK_SPEED_UNKNOWN;
+
+    switch(add_cap->cur_speed) {
+    case _ATA_SPEED_UNKNOWN:
+        rc = LSM_ERR_NO_SUPPORT;
+        _lsm_err_msg_set(err_msg, "No support: specified disk does not "
+                         "expose SATA speed information in 'Serial ATA "
+                         "Capabilities' word");
+        break;
+    case _ATA_SPEED_GEN1_0:
+        *link_speed = 1500;
+        break;
+    case _ATA_SPEED_GEN2_0:
+        *link_speed = 3000;
+        break;
+    case _ATA_SPEED_GEN3_0:
+        *link_speed = 6000;
+        break;
+    default:
+        rc = LSM_ERR_LIB_BUG;
+        _lsm_err_msg_set(err_msg,
+                         "BUG: Got unexpected ATA speed code 0x%02x",
+                         add_cap->cur_speed);
+    }
+
+    return rc;
+}

--- a/c_binding/libata.h
+++ b/c_binding/libata.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#ifndef _LIBATA_H_
+#define _LIBATA_H_
+
+#include <stdint.h>
+#include "libstoragemgmt/libstoragemgmt_common.h"
+
+#define _ATA_IDENTIFY_DEVICE_DATA_LEN   512
+
+/*
+ * Preconditions:
+ *  id_dev_data != NULL
+ *  id_dev_data is uint8_t[_LIBATA_IDENTIFY_DEVICE_DATA_LEN]
+ *  link_speed != NULL;
+ * Return:
+ *  LSM_ERR_XXX.
+ */
+LSM_DLL_LOCAL int _ata_cur_speed_get(char *err_msg, uint8_t *id_dev_data,
+                                     uint32_t *link_speed);
+
+#endif  /* End of _LIBATA_H_ */

--- a/c_binding/libfc.c
+++ b/c_binding/libfc.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#include <stdint.h>
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+
+#include "libfc.h"
+#include "utils.h"
+#include "libstoragemgmt/libstoragemgmt_error.h"
+
+#define _SYSFS_FC_HOST_SPEED_PATH_STR_MAX_LEN       128
+/* ^ The max host number is 4294967295 which has 14 digits.
+ *   The sysfs path is "/sys/class/fc_host/host<host_no>/speed"
+ *   Hence we got max 45 char count, The 128 should works for a long time.
+ */
+
+int _fc_host_speed_get(char *err_msg, unsigned int host_no,
+                       uint32_t *link_speed)
+{
+    int rc = LSM_ERR_OK;
+    char sysfs_path[_SYSFS_FC_HOST_SPEED_PATH_STR_MAX_LEN];
+
+    assert(link_speed != NULL);
+
+    *link_speed = LSM_DISK_LINK_SPEED_UNKNOWN;
+
+    if (host_no == UINT_MAX) {
+        rc = LSM_ERR_LIB_BUG;
+        _lsm_err_msg_set(err_msg, "BUG: _fc_host_speed_get(): "
+                         "Got unknown(UINT_MAX) fc host number");
+        goto out;
+    }
+
+    snprintf(sysfs_path, _SYSFS_FC_HOST_SPEED_PATH_STR_MAX_LEN,
+             "/sys/class/fc_host/host%u/speed", host_no);
+
+    _good(_sysfs_host_speed_get(err_msg, sysfs_path, link_speed), rc, out);
+
+ out:
+    return rc;
+}

--- a/c_binding/libfc.h
+++ b/c_binding/libfc.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#ifndef _LIBFC_H_
+#define _LIBFC_H_
+
+#include <stdint.h>
+#include "libstoragemgmt/libstoragemgmt_common.h"
+
+/*
+ * Retrieve FC host speed via /sys/class/fc_host/host<host_no>/speed
+ * Preconditions:
+ *  err_msg != NULL
+ *  link_speed != NULL
+ * Return:
+ *  LSM_ERR_OK or other LSM error code.
+ */
+LSM_DLL_LOCAL int _fc_host_speed_get(char *err_msg, unsigned int host_no,
+                                     uint32_t *link_speed);
+
+#endif  /* End of _LIBFC_H_ */

--- a/c_binding/libiscsi.c
+++ b/c_binding/libiscsi.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#include <stdint.h>
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+
+#include "libiscsi.h"
+#include "utils.h"
+#include "libstoragemgmt/libstoragemgmt_error.h"
+
+#define _SYSFS_ISCSI_HOST_SPEED_PATH_STR_MAX_LEN       128
+/* ^ The max host number is 4294967295 which has 14 digits.
+ *   The sysfs path is "/sys/class/scsi_host/host<host_no>/port_speed"
+ *   Hence we got max 45 char count, The 128 should works for a long time.
+ */
+
+int _iscsi_host_speed_get(char *err_msg, unsigned int host_no,
+                          uint32_t *link_speed)
+{
+    int rc = LSM_ERR_OK;
+    char sysfs_path[_SYSFS_ISCSI_HOST_SPEED_PATH_STR_MAX_LEN];
+
+    assert(link_speed != NULL);
+
+    *link_speed = LSM_DISK_LINK_SPEED_UNKNOWN;
+
+    if (host_no == UINT_MAX) {
+        rc = LSM_ERR_LIB_BUG;
+        _lsm_err_msg_set(err_msg, "BUG: _iscsi_host_speed_get(): "
+                         "Got unknown(UINT_MAX) iSCSI host number");
+        goto out;
+    }
+
+    snprintf(sysfs_path, _SYSFS_ISCSI_HOST_SPEED_PATH_STR_MAX_LEN,
+             "/sys/class/iscsi_host/host%u/port_speed", host_no);
+
+    _good(_sysfs_host_speed_get(err_msg, sysfs_path, link_speed), rc, out);
+
+ out:
+    return rc;
+}

--- a/c_binding/libiscsi.h
+++ b/c_binding/libiscsi.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#ifndef _LIBISCSI_H_
+#define _LIBISCSI_H_
+
+#include <stdint.h>
+#include "libstoragemgmt/libstoragemgmt_common.h"
+
+/*
+ * Retrieve iSCSI host speed via /sys/class/scsi_host/host<host_no>/port_speed
+ * Preconditions:
+ *  err_msg != NULL
+ *  link_speed != NULL
+ * Return:
+ *  LSM_ERR_OK or other LSM error code.
+ */
+LSM_DLL_LOCAL int _iscsi_host_speed_get(char *err_msg, unsigned int host_no,
+                                        uint32_t *link_speed);
+
+#endif  /* End of _LIBISCSI_H_ */

--- a/c_binding/libsas.c
+++ b/c_binding/libsas.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#include "libsas.h"
+#include "libsg.h"
+#include "utils.h"
+
+#include "libstoragemgmt/libstoragemgmt_error.h"
+
+#include <stdint.h>
+#include <assert.h>
+#include <endian.h>
+#include <string.h>
+
+#define _SAS_SPEED_UNKNOWN              0x0
+#define _SAS_SPEED_1_5                  0x8
+#define _SAS_SPEED_3_0                  0x9
+#define _SAS_SPEED_6_0                  0xa
+#define _SAS_SPEED_12_0                 0xb
+#define _SAS_SPEED_22_5                 0xc
+
+#pragma pack(push, 1)
+struct _sas_phy_ctrl_dicov_hdr {
+    uint8_t page_code       : 6;
+    uint8_t spf             : 1;
+    uint8_t ps              : 1;
+    uint8_t sub_page_code;
+    uint16_t len_be;
+    uint8_t reserved_1;
+    uint8_t protocol_id     : 4;
+    uint8_t reserved_2      : 4;
+    uint8_t gen_code;
+    uint8_t num_of_phys;
+};
+
+struct _sas_phy_mode_dp {
+    uint8_t reserved_1;
+    uint8_t phy_id;
+    uint16_t reserved_2;
+    uint8_t we_dont_care_0;
+    uint8_t negotiated_logical_link_rate    : 4;
+    uint8_t we_dont_care_1                  : 4;
+    uint8_t we_dont_care_2[2];
+    uint8_t sas_addr[8];
+    uint8_t we_dont_care_3[32];
+
+};
+#pragma pack(pop)
+
+
+int _sas_cur_speed_get(char *err_msg, uint8_t *mode_sense_data,
+                       const char *sas_addr, uint32_t *link_speed)
+{
+    struct _sas_phy_ctrl_dicov_hdr *phy_header = NULL;
+    uint16_t len = 0;
+    struct _sas_phy_mode_dp *phy_dp = NULL;
+    uint8_t i = 0;
+    uint8_t *end_p = NULL;
+    char cur_sas_addr[_SG_T10_SPL_SAS_ADDR_LEN];
+    uint8_t link_rate = 0;
+    int rc = LSM_ERR_OK;
+
+    assert(mode_sense_data != NULL);
+    assert(sas_addr != NULL);
+    assert(link_speed != NULL);
+
+    *link_speed = LSM_DISK_LINK_SPEED_UNKNOWN;
+
+    phy_header = (struct _sas_phy_ctrl_dicov_hdr *) mode_sense_data;
+
+    len = be16toh(phy_header->len_be);
+    if (len >= _SG_T10_SPC_MODE_SENSE_MAX_LEN - 4)
+        /* Corrupted MODE SENSE data */
+        return rc;
+
+    end_p = mode_sense_data + len + 4;
+
+    for (i = 0; i < phy_header->num_of_phys; ++i) {
+        if (mode_sense_data + sizeof(struct _sas_phy_ctrl_dicov_hdr) +
+            sizeof(struct _sas_phy_mode_dp) * i >= end_p)
+            /* Corrupted MODE SENSE data */
+            return rc;
+        phy_dp = (struct _sas_phy_mode_dp *)
+            (mode_sense_data + sizeof(struct _sas_phy_ctrl_dicov_hdr) +
+             sizeof(struct _sas_phy_mode_dp) * i);
+        _be_raw_to_hex(phy_dp->sas_addr, _SG_T10_SPL_SAS_ADDR_LEN_BITS,
+                       cur_sas_addr);
+        if (strcmp(sas_addr, cur_sas_addr) == 0) {
+            link_rate = phy_dp->negotiated_logical_link_rate;
+            break;
+        }
+    }
+    switch(link_rate) {
+    case _SAS_SPEED_1_5:
+        *link_speed = 1500;
+        break;
+    case _SAS_SPEED_3_0:
+        *link_speed = 3000;
+        break;
+    case _SAS_SPEED_6_0:
+        *link_speed = 6000;
+        break;
+    case _SAS_SPEED_12_0:
+        *link_speed = 12000;
+        break;
+    case _SAS_SPEED_22_5:
+        *link_speed = 22500;
+        break;
+    default:
+        rc = LSM_ERR_LIB_BUG;
+        /* Yes, we treat _SAS_SPEED_UNKNOWN as bug, in that case, the OS
+         * should not have /dev/sdX, hence it's a bug. */
+        _lsm_err_msg_set(err_msg,
+                         "BUG: Got unexpected SAS speed code 0x%02x",
+                         link_rate);
+    }
+
+    return rc;
+}

--- a/c_binding/libsas.h
+++ b/c_binding/libsas.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Gris Ge <fge@redhat.com>
+ */
+
+#ifndef _LIBSAS_H_
+#define _LIBSAS_H_
+
+#include <stdint.h>
+#include "libstoragemgmt/libstoragemgmt_common.h"
+
+/*
+ * Preconditions:
+ *  mode_sense_data != NULL
+ *  mode_sense_data is uint8_t[_SG_T10_SPC_MODE_SENSE_MAX_LEN] retrieved by
+ *  _sg_io_mode_sense on page 0x19 subpage 0x01.
+ *  sas_addr != NULL
+ *  sas_addr is the SAS address of the disk.
+ *  link_speed != NULL
+ * Return:
+ *  LSM_ERR_XXX
+ */
+LSM_DLL_LOCAL int _sas_cur_speed_get(char *err_msg, uint8_t *mode_sense_data,
+                                     const char *sas_addr,
+                                     uint32_t *link_speed);
+
+#endif  /* End of _LIBSAS_H_ */

--- a/c_binding/libsg.c
+++ b/c_binding/libsg.c
@@ -873,8 +873,7 @@ int _sg_io_mode_sense(char *err_msg, int fd, uint8_t page_code,
             goto out;
         }
         block_dp_len = be16toh(mode_hdr->block_dp_header_len_be);
-        if ((block_dp_len == 0) ||
-            (block_dp_len >= _SG_T10_SPC_MODE_SENSE_MAX_LEN -
+        if ((block_dp_len >= _SG_T10_SPC_MODE_SENSE_MAX_LEN -
              sizeof(struct _sg_t10_mode_para_hdr))) {
             rc = LSM_ERR_LIB_BUG;
             _lsm_err_msg_set(err_msg, "BUG: Got illegal SCSI mode page return: "

--- a/c_binding/utils.h
+++ b/c_binding/utils.h
@@ -99,4 +99,16 @@ LSM_DLL_LOCAL int _read_file(const char *path, uint8_t *buff, ssize_t *size,
  * Return NULL if failed.
  */
 LSM_DLL_LOCAL char* _trim_spaces(char *beginning);
+
+/*
+ * Preconditions:
+ * sysfs_path != NULL
+ * link_speed != NULL
+ *
+ * Only support FC and iSCSI SCSI host yet.
+ * Return lsm error number if failed.
+ */
+LSM_DLL_LOCAL int _sysfs_host_speed_get(char *err_msg, const char *sysfs_path,
+                                        uint32_t *link_speed);
+
 #endif  /* End of _LIB_UTILS_H_ */

--- a/python_binding/lsm/_clib.c
+++ b/python_binding/lsm/_clib.c
@@ -334,6 +334,28 @@ static const char local_disk_led_status_get_docstring[] =
     "        err_msg (string)\n"
     "            Error message, empty if no error.\n";
 
+static const char local_disk_link_speed_get_docstring[] =
+    "INTERNAL USE ONLY!\n"
+    "\n"
+    "Usage:\n"
+    "    Get the link speed for given disk.\n"
+    "Parameters:\n"
+    "    disk_path (string)\n"
+    "        The disk path, example '/dev/sdb'. Empty string is failure\n"
+    "Returns:\n"
+    "    [link_speeds, rc, err_msg]\n"
+    "        link_speeds (list of string)\n"
+    "            Empty list is not support. The string is like: '3.0 Gbps'\n"
+    "            or special strings(check libstoragemgmt_types.h for detail):\n"
+    "             * LSM_DISK_LINK_SPEED_UNKNOWN -- 'UNKNOWN'\n"
+    "             * LSM_DISK_LINK_SPEED_DISABLED -- 'DISABLED'\n"
+    "             * LSM_DISK_LINK_SPEED_DISCONNECTED-- 'DISCONNECTED'\n"
+    "        rc (integer)\n"
+    "            Error code, lsm.ErrorNumber.OK if no error\n"
+    "        err_msg (string)\n"
+    "            Error message, empty if no error.\n";
+
+
 static PyObject *local_disk_serial_num_get(PyObject *self, PyObject *args,
                                            PyObject *kwargs);
 
@@ -347,6 +369,8 @@ static PyObject *local_disk_list(PyObject *self, PyObject *args,
                                  PyObject *kwargs);
 static PyObject *local_disk_link_type_get(PyObject *self, PyObject *args,
                                           PyObject *kwargs);
+static PyObject *local_disk_link_speed_get(PyObject *self, PyObject *args,
+                                           PyObject *kwargs);
 static PyObject *_lsm_string_list_to_pylist(lsm_string_list *str_list);
 static PyObject *_c_str_to_py_str(const char *str);
 static PyObject *local_disk_led_status_get(PyObject *self, PyObject *args,
@@ -384,6 +408,8 @@ static PyMethodDef _methods[] = {
      METH_VARARGS | METH_KEYWORDS, local_disk_fault_led_off_docstring},
     {"_local_disk_led_status_get",  (PyCFunction) local_disk_led_status_get,
      METH_VARARGS | METH_KEYWORDS, local_disk_led_status_get_docstring},
+    {"_local_disk_link_speed_get",  (PyCFunction) local_disk_link_speed_get,
+     METH_VARARGS | METH_KEYWORDS, local_disk_link_speed_get_docstring},
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 
@@ -434,6 +460,9 @@ _wrapper(local_disk_link_type_get, lsm_local_disk_link_type_get,
 _wrapper(local_disk_led_status_get, lsm_local_disk_led_status_get,
          const char *, disk_path, uint32_t,
          LSM_DISK_LED_STATUS_UNKNOWN, PyInt_FromLong, _NO_NEED_TO_FREE);
+_wrapper(local_disk_link_speed_get, lsm_local_disk_link_speed_get,
+         const char *, disk_path, uint32_t, LSM_DISK_LINK_SPEED_UNKNOWN,
+         PyInt_FromLong, _NO_NEED_TO_FREE);
 
 static PyObject *local_disk_list(PyObject *self, PyObject *args,
                                  PyObject *kwargs)

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -240,6 +240,8 @@ class Disk(IData):
     LED_STATUS_FAULT_OFF = 1 << 5
     LED_STATUS_FAULT_UNKNOWN = 1 << 6
 
+    LINK_SPEED_UNKNOWN = 0
+
     def __init__(self, _id, _name, _disk_type, _block_size, _num_of_blocks,
                  _status, _system_id, _plugin_data=None, _vpd83='',
                  _location='', _rpm=RPM_NO_SUPPORT,

--- a/python_binding/lsm/_local_disk.py
+++ b/python_binding/lsm/_local_disk.py
@@ -23,7 +23,7 @@ from lsm._clib import (_local_disk_vpd83_search, _local_disk_vpd83_get,
                        _local_disk_link_type_get, _local_disk_ident_led_on,
                        _local_disk_ident_led_off, _local_disk_fault_led_on,
                        _local_disk_fault_led_off, _local_disk_serial_num_get,
-                       _local_disk_led_status_get)
+                       _local_disk_led_status_get, _local_disk_link_speed_get)
 
 
 def _use_c_lib_function(func_ref, arg):
@@ -420,3 +420,35 @@ class LocalDisk(object):
                 No capability required as this is a library level method.
         """
         return _use_c_lib_function(_local_disk_led_status_get, disk_path)
+
+    @staticmethod
+    def link_speed_get(disk_path):
+        """
+        Version:
+            1.4
+        Usage:
+            Get current negotiated logical link speed for specified disk.
+        Parameters:
+            disk_path (string)
+                The disk path, example '/dev/sdb'.
+        Returns:
+            link_speed
+                Integer for link speed in Mbps. For example, '3.0 Gbps' will
+                get 3000.
+        SpecialExceptions:
+            LsmError
+                ErrorNumber.LIB_BUG
+                    Internal bug.
+                ErrorNumber.INVALID_ARGUMENT
+                    Invalid disk_path. Should be like '/dev/sdb'.
+                ErrorNumber.NOT_FOUND_DISK
+                    Provided disk is not found.
+                ErrorNumber.NO_SUPPORT
+                    Provided disk is not supported yet.
+                ErrorNumber.PERMISSION_DENIED
+                    No sufficient permission to access provided disk path.
+        Capability:
+            N/A
+                No capability required as this is a library level method.
+        """
+        return _use_c_lib_function(_local_disk_link_speed_get, disk_path)

--- a/test/tester.c
+++ b/test/tester.c
@@ -3303,13 +3303,12 @@ START_TEST(test_local_disk_list)
     }
 
     rc = lsm_local_disk_list(&disk_paths, &lsm_err);
+    if (lsm_err)
+        lsm_error_free(lsm_err);
     fail_unless(rc == LSM_ERR_OK, "lsm_local_disk_list() failed as %d", rc);
     fail_unless(disk_paths != NULL, "lsm_local_disk_list() return NULL for "
                 "disk_paths");
     lsm_string_list_free(disk_paths);
-    if (lsm_err != NULL)
-        lsm_error_free(lsm_err);
-        /* ^ Just to trick coverity scan. The 'fail_unless' already quit */
 }
 END_TEST
 
@@ -3859,10 +3858,9 @@ do { \
     uint32_t i = 0; \
     const char *disk_path = NULL; \
     rc = lsm_local_disk_list(&disk_paths, &lsm_err); \
-    fail_unless(rc == LSM_ERR_OK, "lsm_local_disk_list() failed as %d", rc); \
     if (lsm_err != NULL) \
         lsm_error_free(lsm_err); \
-        /* ^ Just to trick coverity scan. The 'fail_unless' already quit */ \
+    fail_unless(rc == LSM_ERR_OK, "lsm_local_disk_list() failed as %d", rc); \
     /* Only try maximum 4 disks */ \
     for (; i < lsm_string_list_size(disk_paths) && i < 4; ++i) { \
         disk_path = lsm_string_list_elem_get(disk_paths, i); \
@@ -3927,6 +3925,8 @@ START_TEST(test_local_disk_led_status_get)
     uint32_t led_status = LSM_DISK_LED_STATUS_UNKNOWN;
 
     rc = lsm_local_disk_list(&disk_paths, &lsm_err);
+    if (lsm_err)
+        lsm_error_free(lsm_err);
     fail_unless(rc == LSM_ERR_OK, "lsm_local_disk_list() failed as %d", rc);
     /* Only try maximum 4 disks */
     for (; i < lsm_string_list_size(disk_paths) && i < 4; ++i) {
@@ -3980,6 +3980,8 @@ START_TEST(test_local_disk_link_speed_get)
     uint32_t link_speed = LSM_DISK_LINK_SPEED_UNKNOWN;
 
     rc = lsm_local_disk_list(&disk_paths, &lsm_err);
+    if (lsm_err)
+        lsm_error_free(lsm_err);
     fail_unless(rc == LSM_ERR_OK, "lsm_local_disk_list() failed as %d", rc);
     /* Only try maximum 4 disks */
     for (; i < lsm_string_list_size(disk_paths) && i < 4; ++i) {

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -1800,6 +1800,7 @@ class CmdLine(object):
             "link_type": LocalDisk.link_type_get,
             "serial_num": LocalDisk.serial_num_get,
             "led_status": LocalDisk.led_status_get,
+            "link_speed": LocalDisk.link_speed_get,
         }
         for disk_path in LocalDisk.list():
             info_dict = {
@@ -1808,6 +1809,7 @@ class CmdLine(object):
                 "link_type": Disk.LINK_TYPE_NO_SUPPORT,
                 "serial_num": "",
                 "led_status": Disk.LED_STATUS_UNKNOWN,
+                "link_speed": Disk.LINK_SPEED_UNKNOWN,
             }
             for key in info_dict.keys():
                 try:
@@ -1822,7 +1824,8 @@ class CmdLine(object):
                               info_dict["rpm"],
                               info_dict["link_type"],
                               info_dict["serial_num"],
-                              info_dict["led_status"]))
+                              info_dict["led_status"],
+                              info_dict["link_speed"]))
 
         self.display_data(local_disks)
 

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -308,6 +308,13 @@ _DISK_LED_STATUS_CONV = {
 def disk_led_status_to_str(led_status):
     return _bit_map_to_str(led_status, _DISK_LED_STATUS_CONV)
 
+
+def disk_link_speed_to_str(link_speed):
+    if link_speed == Disk.LINK_SPEED_UNKNOWN:
+        return "Unknown"
+    return "%.1f Gbps" % float(link_speed / 1000.0)
+
+
 class PlugData(object):
     def __init__(self, description, plugin_version):
             self.desc = description
@@ -400,14 +407,15 @@ class LocalDiskInfo(object):
         Disk.LINK_TYPE_PCIE: "PCI-E",
     }
 
-    def __init__(self, sd_path, vpd83, rpm, link_type, serial_num, led_status):
+    def __init__(self, sd_path, vpd83, rpm, link_type, serial_num, led_status,
+                 link_speed):
         self.sd_path = sd_path
         self.vpd83 = vpd83
         self.rpm = rpm
         self.link_type = link_type
         self.serial_num = serial_num
         self.led_status = led_status
-
+        self.link_speed = link_speed
 
 class VolumeRAMCacheInfo(object):
 
@@ -815,13 +823,15 @@ class DisplayData(object):
     LOCAL_DISK_HEADER['link_type'] = 'Link Type'
     LOCAL_DISK_HEADER['serial_num'] = 'Serial Number'
     LOCAL_DISK_HEADER['led_status'] = 'LED Status'
+    LOCAL_DISK_HEADER['link_speed'] = 'Link Speed'
 
-    LOCAL_DISK_COLUMN_SKIP_KEYS = ['rpm', 'led_status']
+    LOCAL_DISK_COLUMN_SKIP_KEYS = ['rpm', 'led_status', 'link_speed']
 
     LOCAL_DISK_VALUE_CONV_ENUM = {
         'rpm': disk_rpm_to_str,
         'link_type': disk_link_type_to_str,
         'led_status': disk_led_status_to_str,
+        'link_speed': disk_link_speed_to_str,
     }
     LOCAL_DISK_VALUE_CONV_HUMAN = []
 


### PR DESCRIPTION
C API: 
```c
int lsm_local_disk_link_speed_get(const char *disk_path,
                                  uint32_t *link_speed,
                                  lsm_error **lsm_err);
```

Python API: `lsm.LocalDisk.link_speed_get()`.

The returned link speed is in Mbps, for example, '3.0 Gbps' is `3000`.

Current, we have FC, SAS, SATA and iSCSI supported.
