### PR TITLE
udev: Fix gcc warning on non-x86 platform.

### DIFF
--- a/tools/udev/scan-scsi-target.c
+++ b/tools/udev/scan-scsi-target.c
@@ -54,7 +54,7 @@ static void __attribute__ ((__noreturn__)) invalid(char **argv, char *devpath)
 
 int main(int argc, char **argv)
 {
-	char	c;
+	int	c;
 	char	*devpath;
 
 	char	*sysfs_path;


### PR DESCRIPTION
* Issue:
    Got failure on s390x:

        scan-scsi-target.c:90:2: error: comparison is always true due to limited
        range of data type [-Werror=type-limits]

* Root cause:
    The error is on these lines:

        char c;
        ...
        while ((c = getopt_long(argc, argv, "rh", longopts, NULL)) != -1) {

  On non-x86 platform, char is unsigned. Which makes the (c != -1)
  always true.

* Fix:
    Take return of getopt_long() as int.

Signed-off-by: Gris Ge <fge@redhat.com>