### PR TITLE
libsg: Fix fixed sense data structure

### DIFF
--- a/c_binding/libsg.c
+++ b/c_binding/libsg.c
@@ -147,7 +147,7 @@ struct _sg_t10_sense_fixed {
     uint8_t obsolete;
     uint8_t sense_key : 4;
     uint8_t we_dont_care_0 : 4;
-    uint8_t we_dont_care_1[3];
+    uint8_t we_dont_care_1[4];
     uint8_t len;
     uint8_t we_dont_care_2[4];
     uint8_t asc;        /* ADDITIONAL SENSE CODE */


### PR DESCRIPTION
There are four bytes in the 'Information' portion of the structure, not three.

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>

Fixes #259 