### PR TITLE
lsm_local_disk: Add SMART Status query method

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2016 Red Hat, Inc.
+ * (C) Copyright (C) 2017 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
@@ -99,6 +99,36 @@ int LSM_DLL_EXPORT lsm_local_disk_vpd83_get(const char *disk_path,
                                             char **vpd83,
                                             lsm_error **lsm_err);
 
+/** New in version 1.5.
+ * Query the health status of a given disk path.
+ * @param[in]   disk_path
+ *                  String. The disk path, example "/dev/sdc".
+ * @param[out]  health_status
+ *                  Output pointer of int32_t.
+ *                          -1 (LSM_DISK_HEALTH_STATUS_UNKNOWN):
+ *                              health status failure.
+ *                           0 (LSM_DISK_HEALTH_STATUS_FAIL):
+ *                              health status failure.
+ *                           1 (LSM_DISK_HEALTH_STATUS_WARN):
+ *                              health status warning.
+ *                           2 (LSM_DISK_HEALTH_STATUS_GOOD):
+ *                              health status good.
+ * @param[out] lsm_err
+ *                  Output pointer of lsm_error. Error message could be
+ *                  retrieved via lsm_error_message_get(). Memory should be
+ *                   by lsm_error_free().
+ * @return Error code as enumerated by \ref lsm_error_number.
+ * @retval LSM_ERR_OK               on success.
+ * @retval LSM_ERR_INVALID_ARGUMENT when any argument is NULL.
+ * @retval LSM_ERR_NO_MEMORY        when no memory is available.
+ * @retval LSM_ERR_NO_SUPPORT       action is not supported.
+ * @retval LSM_ERR_LIB_BUG          when something unexpected happens.
+ * @retval LSM_ERR_NOT_FOUND_DISK   when provided disk path is not found.
+ */
+int LSM_DLL_EXPORT lsm_local_disk_health_status_get(const char *disk_path,
+                                                    int32_t *health_status,
+                                                    lsm_error **lsm_err);
+
 /**
  * New in version 1.3.
  * Query the disk rotation speed - revolutions per minute(RPM) of given disk

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -338,6 +338,14 @@ typedef enum {
  */
 #define LSM_DISK_RPM_ROTATING_UNKNOWN_SPEED         1
 
+/* New in version 1.5 */
+#define LSM_DISK_HEALTH_STATUS_UNKNOWN               -1
+/* New in version 1.5 */
+#define LSM_DISK_HEALTH_STATUS_FAIL                  0
+/* New in version 1.5 */
+#define LSM_DISK_HEALTH_STATUS_WARN                  1
+/* New in version 1.5 */
+#define LSM_DISK_HEALTH_STATUS_GOOD                  2
 
 #define LSM_DISK_LED_STATUS_UNKNOWN                 0x0000000000000001
 #define LSM_DISK_LED_STATUS_IDENT_ON                0x0000000000000002

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_types.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011-2013 Red Hat, Inc.
+ * (C) Copyright (C) 2017 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/c_binding/libata.c
+++ b/c_binding/libata.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Red Hat, Inc.
+ * (C) Copyright (C) 2017 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/c_binding/libata.c
+++ b/c_binding/libata.c
@@ -86,3 +86,45 @@ int _ata_cur_speed_get(char *err_msg, uint8_t *id_dev_data,
 
     return rc;
 }
+
+void _ata_smart_status_fill_registers(uint8_t *ata_cmd, uint8_t cmd,
+                                      uint8_t features, uint8_t lba_high,
+                                      uint8_t lba_mid, uint8_t lba_low,
+                                      uint8_t count, uint8_t device)
+{
+    struct _ata_registers_input_28_bit * input_registers = NULL;
+
+    assert (ata_cmd != NULL);
+
+    input_registers = (struct _ata_registers_input_28_bit *) ata_cmd;
+    input_registers->feature = features;
+    input_registers->count = count;
+    input_registers->lba_low = lba_low;
+    input_registers->lba_mid = lba_mid;
+    input_registers->lba_high = lba_high;
+    input_registers->device = device;
+    input_registers->command = cmd;
+
+    return;
+}
+
+int32_t _ata_smart_status_interpret_output_regs(uint8_t *ata_output_regs) {
+
+    struct _ata_registers_output_28_bit *output_registers = NULL;
+
+    assert(ata_output_regs != NULL);
+
+    output_registers = (struct _ata_registers_output_28_bit *) ata_output_regs;
+
+    if ((output_registers->lba_high == SMART_STATUS_LBA_HIGH_DEFAULT) &&
+        (output_registers->lba_mid == SMART_STATUS_LBA_MID_DEFAULT)) {
+        return LSM_DISK_HEALTH_STATUS_GOOD;
+    } else if ((output_registers->lba_high ==
+                SMART_STATUS_LBA_HIGH_THRESHOLD_EXCEEDED)
+               && (output_registers->lba_mid ==
+                   SMART_STATUS_LBA_MID_THRESHOLD_EXCEEDED)) {
+        return LSM_DISK_HEALTH_STATUS_FAIL;
+    }
+
+    return LSM_DISK_HEALTH_STATUS_UNKNOWN;
+}

--- a/c_binding/libata.h
+++ b/c_binding/libata.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Red Hat, Inc.
+ * (C) Copyright (C) 2017 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/c_binding/libata.h
+++ b/c_binding/libata.h
@@ -22,7 +22,54 @@
 #include <stdint.h>
 #include "libstoragemgmt/libstoragemgmt_common.h"
 
-#define _ATA_IDENTIFY_DEVICE_DATA_LEN   512
+#define _ATA_IDENTIFY_DEVICE_DATA_LEN                        512
+
+#define _ATA_REGISTER_INPUT_28_BIT_LENGTH                    7
+#define _ATA_REGISTER_OUTPUT_28_BIT_LENGTH                   7
+#define ATA_PASS_THROUGH_12_LEN                              12
+#define ATA_PASS_THROUGH_12                                  0xa1
+
+/*
+ * ACS-3 7.48.8 SMART RETURN STATUS
+ */
+#define ATA_SMART_RETURN_STATUS_SUBCOMMAND                   0xda
+#define ATA_SMART_COMMAND                                    0xb0
+
+#define ATA_NON_DATA_COMMAND                                 0
+#define ATA_DATA_IN_COMMAND                                  1
+#define ATA_DATA_OUT_COMMAND                                 2
+
+/*
+ * ACS-3 Table 210
+ */
+#define SMART_STATUS_LBA_MID_THRESHOLD_EXCEEDED              0xf4
+#define SMART_STATUS_LBA_HIGH_THRESHOLD_EXCEEDED             0x2c
+#define SMART_STATUS_LBA_MID_DEFAULT                         0x4f
+#define SMART_STATUS_LBA_HIGH_DEFAULT                        0xc2
+
+#pragma pack(push, 1)
+
+struct _ata_registers_input_28_bit {
+    uint8_t feature;
+    uint8_t count;
+    uint8_t lba_low;
+    uint8_t lba_mid;
+    uint8_t lba_high;
+    uint8_t device;
+    uint8_t command;
+};
+
+struct _ata_registers_output_28_bit {
+    uint8_t error;
+    uint8_t count;
+    uint8_t lba_low;
+    uint8_t lba_mid;
+    uint8_t lba_high;
+    uint8_t device;
+    uint8_t status;
+};
+
+#pragma pack(pop)
 
 /*
  * Preconditions:
@@ -34,5 +81,24 @@
  */
 LSM_DLL_LOCAL int _ata_cur_speed_get(char *err_msg, uint8_t *id_dev_data,
                                      uint32_t *link_speed);
+
+/*
+ * Preconditions:
+ * ata_cmd != NULL
+ */
+LSM_DLL_LOCAL void _ata_smart_status_fill_registers(uint8_t *ata_cmd,
+                                                    uint8_t cmd,
+                                                    uint8_t features,
+                                                    uint8_t lba_high,
+                                                    uint8_t lba_mid,
+                                                    uint8_t lba_low,
+                                                    uint8_t count,
+                                                    uint8_t device);
+
+/*
+ * Preconditions:
+ * ata_output_regs != NULL
+ */
+LSM_DLL_LOCAL int32_t _ata_smart_status_interpret_output_regs(uint8_t *ata_output_regs);
 
 #endif  /* End of _LIBATA_H_ */

--- a/c_binding/libsg.c
+++ b/c_binding/libsg.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Red Hat, Inc.
+ * (C) Copyright (C) 2017 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/c_binding/libsg.c
+++ b/c_binding/libsg.c
@@ -52,6 +52,10 @@
 /* SPC-5 rev7 Table 534 - Supported VPD Pages VPD page */
 #define _T10_SPC_MODE_SENSE_CMD_LEN                     10
 /* SPC-5 rev12 Table 171 - MODE SENSE(10) command */
+#define _T10_SPC_LOG_SENSE_CMD_LEN                      10
+/* SPC-5 rev07 - LOG SENSE command */
+#define _T10_SPC_REQUEST_SENSE_CMD_LEN                  6
+/* SPC-5 rev07 - REQUEST SENSE command */
 #define _T10_SPC_VPD_SUP_VPD_PGS_LIST_OFFSET            4
 
 /* SPC-5 rev7 4.4.2.1 Descriptor format sense data overview
@@ -65,6 +69,26 @@
 /* The max length of char[] required to hold hex dump of sense data */
 #define _T10_SPC_SENSE_DATA_STR_MAX_LENGTH  \
     _T10_SPC_SENSE_DATA_MAX_LENGTH * 2 + 1
+
+/* SPC-5 rev07 Table 300 - Summary of log page codes */
+#define _T10_SPC_INFO_EXCEP_PAGE_CODE                        0x2f
+
+/* SPC-5 rev07 Table 151 - Page control (PC) field */
+#define PAGE_CONTROL_CUMULATIVE_VALS                         0x01
+
+/* SPC-5 rev07 Table E.13 - Mode pages codes */
+#define INFO_EXCEP_CONTROL_PAGE                              0x1c
+
+/* SBC - Method of reporting informational exceptions (MRIE) field */
+#define MRIE_REPORT_INFO_EXCEP_ON_REQUEST                    0x6
+
+/* SPC-5 rev07 Table 49 - ASC and ASCQ assignments */
+#define _T10_SPC_ASC_WARNING                                 0x0b
+#define _T10_SPC_ASC_IMPENDING_FAILURE                       0x5d
+#define _T10_SPC_ASCQ_ATA_PASSTHROUGH                        0x1d
+
+/* SPC-5 rev07 Table 30 - DESCRIPTOR TYPE field */
+#define _T10_ATA_STATUS_RETURN                               0x09
 
 /*
  * SPC-5 rev7 Table 27 - Sense data response codes
@@ -104,6 +128,7 @@ const char * const _T10_SPC_SENSE_KEY_STR[] = {
 /* The offset of ADDITIONAL SENSE LENGTH */
 #define _T10_SPC_SENSE_DATA_LEN_OFFSET                  8
 
+#define _SG_IO_NO_DATA                                  0
 #define _SG_IO_SEND_DATA                                1
 #define _SG_IO_RECV_DATA                                2
 
@@ -156,6 +181,29 @@ struct _sg_t10_sense_fixed {
 };
 
 /*
+ * SPC-5 rev 7 Table 47 - Fixed format sense data
+ * with embedded ATA registers
+ */
+struct _sg_t10_sense_ata_fixed {
+    uint8_t response_code : 7;
+    uint8_t valid : 1;
+    uint8_t obsolete;
+    uint8_t sense_key : 4;
+    uint8_t we_dont_care_0 : 4;
+    uint8_t error;
+    uint8_t status;
+    uint8_t device;
+    uint8_t count;
+    uint8_t len;
+    uint8_t we_dont_care_1;
+    uint8_t lba_low;
+    uint8_t lba_mid;
+    uint8_t lba_high;
+    uint8_t asc;        /* ADDITIONAL SENSE CODE */
+    uint8_t ascq;       /* ADDITIONAL SENSE CODE QUALIFIER */
+};
+
+/*
  * SPC-5 rev 7 Table 28 - Descriptor format sense data
  */
 struct _sg_t10_sense_dp {
@@ -170,10 +218,50 @@ struct _sg_t10_sense_dp {
     /* We don't care the rest of data */
 };
 
+struct _sg_t10_ata_status_return_dp_hdr {
+    uint8_t descriptor_code;
+    uint8_t additional_desc_len;
+};
+
+struct _sg_t10_ata_status_return_dp {
+    uint8_t descriptor_code;
+    uint8_t additional_desc_len;
+    uint8_t rsvd : 7;
+    uint8_t extend : 1;
+    uint8_t error;
+    uint8_t reserved_count;
+    uint8_t count;
+    uint8_t reserved_lba_low;
+    uint8_t lba_low;
+    uint8_t reserved_lba_mid;
+    uint8_t lba_mid;
+    uint8_t reserved_lba_high;
+    uint8_t lba_high;
+    uint8_t device;
+    uint8_t status;
+};
+
 struct _sg_t10_mode_para_hdr {
     uint16_t mode_data_len_be;
     uint8_t we_dont_care_0[4];
     uint16_t block_dp_header_len_be;
+};
+
+struct _sg_t10_log_para_hdr {
+    uint8_t we_dont_care_0[2];
+    uint16_t log_data_len_be;
+};
+
+struct _sg_t10_info_excep_mode_page_0_hdr {
+    uint8_t dont_care[3];
+    uint8_t reserved : 4;
+    uint8_t mrie : 4;
+};
+
+struct _sg_t10_info_excep_general_log_hdr {
+    uint8_t dont_care[4];
+    uint8_t asc;
+    uint8_t ascq;
 };
 
 #pragma pack(pop)
@@ -191,6 +279,12 @@ static struct _sg_t10_vpd83_dp *_sg_t10_vpd83_dp_new(void);
 static int _sg_io_open(char *err_msg, const char *disk_path, int *fd,
                        int oflag);
 
+static int _fill_ata_regs_desc(uint8_t additional_sense_len,
+                               uint8_t *sense_data_desc_list_index,
+                               uint8_t *ata_output_regs);
+
+static int _fill_ata_regs_fixed(uint8_t *ata_output_regs, uint8_t *sense_data);
+
 /*
  * The 'sense_key' is the output pointer.
  * Return 0 if sense_key is _T10_SPC_SENSE_KEY_NO_SENSE or
@@ -207,8 +301,6 @@ static int _sg_io(int fd, uint8_t *cdb, uint8_t cdb_len, uint8_t *data,
 
     assert(cdb != NULL);
     assert(cdb_len != 0);
-    assert(data != NULL);
-    assert(data_len != 0);
 
     memset(&io_hdr, 0, sizeof(struct sg_io_hdr));
     memset(sense_data, 0, _T10_SPC_SENSE_DATA_MAX_LENGTH);
@@ -221,10 +313,13 @@ static int _sg_io(int fd, uint8_t *cdb, uint8_t cdb_len, uint8_t *data,
     io_hdr.mx_sb_len = _T10_SPC_SENSE_DATA_MAX_LENGTH;
     if (direction == _SG_IO_RECV_DATA)
         io_hdr.dxfer_direction = SG_DXFER_FROM_DEV;
-    else
+    else if (direction == _SG_IO_SEND_DATA)
         io_hdr.dxfer_direction = SG_DXFER_TO_DEV;
+    else if (direction == _SG_IO_NO_DATA)
+        io_hdr.dxfer_direction = SG_DXFER_NONE;
 
-    io_hdr.dxferp = (unsigned char *) data;
+    if (data != NULL)
+        io_hdr.dxferp = (unsigned char *) data;
     io_hdr.dxfer_len = data_len;
     io_hdr.timeout = _SG_IO_TMO;
 
@@ -235,7 +330,7 @@ static int _sg_io(int fd, uint8_t *cdb, uint8_t cdb_len, uint8_t *data,
         /* It might possible we got "NO SENSE", so we does not zero the data */
         return -1;
 
-    if (rc != 0)
+    if ((rc != 0) && (data != NULL))
         memset(data, 0, (size_t) data_len);
 
     return rc;
@@ -938,5 +1033,391 @@ int _sg_host_no(char *err_msg, int fd, unsigned int *host_no)
     }
 
  out:
+    return rc;
+}
+
+int _fill_ata_regs_fixed(uint8_t *ata_output_regs, uint8_t *sense_data)
+{
+    struct _ata_registers_output_28_bit *output_registers = NULL;
+    struct _sg_t10_sense_ata_fixed *ata_sense_data = NULL;
+
+    assert(ata_output_regs != NULL);
+    assert(ata_sense_data != NULL);
+
+    output_registers = (struct _ata_registers_output_28_bit *)
+                       ata_output_regs;
+    ata_sense_data = (struct _sg_t10_sense_ata_fixed *) sense_data;
+
+    output_registers->error = ata_sense_data->error;
+    output_registers->status = ata_sense_data->status;
+    output_registers->device = ata_sense_data->device;
+    output_registers->count = ata_sense_data->count;
+    output_registers->lba_low = ata_sense_data->lba_low;
+    output_registers->lba_mid = ata_sense_data->lba_mid;
+    output_registers->lba_high = ata_sense_data->lba_high;
+
+    return 0;
+}
+
+int _fill_ata_regs_desc(uint8_t additional_sense_len,
+                        uint8_t *sense_data_desc_list_index,
+                        uint8_t *ata_output_regs)
+{
+    uint8_t i = 0;
+    struct _ata_registers_output_28_bit *output_registers = NULL;
+    struct _sg_t10_ata_status_return_dp_hdr *current_status_desc = NULL;
+    struct _sg_t10_ata_status_return_dp *ata_status_desc = NULL;
+
+    assert(ata_output_regs != NULL);
+    assert(sense_data_desc_list_index != NULL);
+
+    output_registers = (struct _ata_registers_output_28_bit *)
+                       ata_output_regs;
+    current_status_desc = (struct _sg_t10_ata_status_return_dp_hdr *)
+                          sense_data_desc_list_index;
+
+    while (i < additional_sense_len) {
+
+        if (current_status_desc->descriptor_code == _T10_ATA_STATUS_RETURN)
+            break;
+
+        i = i + current_status_desc->additional_desc_len +
+            sizeof(struct _sg_t10_ata_status_return_dp_hdr);
+        current_status_desc = current_status_desc +
+                          current_status_desc->additional_desc_len +
+                          sizeof(struct _sg_t10_ata_status_return_dp_hdr);
+    }
+
+    if (i > additional_sense_len)
+        return -1;
+
+    ata_status_desc = (struct _sg_t10_ata_status_return_dp *)
+                      current_status_desc;
+
+    output_registers->error = ata_status_desc->error;
+    output_registers->count = ata_status_desc->count;
+    output_registers->lba_low = ata_status_desc->lba_low;
+    output_registers->lba_mid = ata_status_desc->lba_mid;
+    output_registers->lba_high = ata_status_desc->lba_high;
+    output_registers->device = ata_status_desc->device;
+    output_registers->status = ata_status_desc->status;
+
+    return 0;
+}
+
+int _get_ata_output_regs(uint8_t *sense_data, uint8_t *ata_output_regs)
+{
+    int rc = -1;
+    struct _sg_t10_sense_header *sense_hdr = NULL;
+    struct _sg_t10_sense_fixed *sense_fixed = NULL;
+    struct _sg_t10_sense_dp *sense_dp = NULL;
+    uint8_t asc = 0;
+    uint8_t ascq = 0;
+
+    assert(sense_data != NULL);
+    assert(ata_output_regs != NULL);
+
+    sense_hdr = (struct _sg_t10_sense_header*) sense_data;
+
+    switch(sense_hdr->response_code) {
+    case _T10_SPC_SENSE_REPORT_TYPE_CUR_INFO_FIXED:
+    case _T10_SPC_SENSE_REPORT_TYPE_DEF_ERR_FIXED:
+        sense_fixed = (struct _sg_t10_sense_fixed *) sense_data;
+        asc = sense_fixed->asc;
+        ascq = sense_fixed->ascq;
+        if ((asc == 0) && (ascq == _T10_SPC_ASCQ_ATA_PASSTHROUGH)) {
+            rc = _fill_ata_regs_fixed(ata_output_regs, sense_data);
+        }
+        break;
+    case _T10_SPC_SENSE_REPORT_TYPE_CUR_INFO_DP:
+    case _T10_SPC_SENSE_REPORT_TYPE_DEF_ERR_DP:
+        sense_dp = (struct _sg_t10_sense_dp *) sense_data;
+	if (sense_dp->len > 0) {
+            rc = _fill_ata_regs_desc(sense_dp->len, &sense_data[8],
+                                     ata_output_regs);
+        }
+        break;
+    default:
+        goto out;
+    }
+
+ out:
+    return rc;
+}
+
+int _sg_io_ata_passthrough(char *err_msg, int fd, bool need_output_reg,
+                           uint8_t direction, uint8_t *ata_cmd, uint8_t *data,
+                           ssize_t data_len, uint8_t *ata_output_regs)
+{
+    int rc = LSM_ERR_OK;
+    uint8_t cdb[ATA_PASS_THROUGH_12_LEN];
+    uint8_t cmd_len = 0;
+    uint8_t sense_data[_T10_SPC_SENSE_DATA_MAX_LENGTH];
+    int ioctl_errno = 0;
+    char sense_err_msg[_LSM_ERR_MSG_LEN];
+    char strerr_buff[_LSM_ERR_MSG_LEN];
+    uint8_t sense_key = _T10_SPC_SENSE_KEY_NO_SENSE;
+    struct _ata_registers_input_28_bit *input_registers = NULL;
+
+    assert(err_msg != NULL);
+    assert(fd >= 0);
+    assert(ata_cmd != NULL);
+    assert(ata_output_regs != NULL);
+
+    memset(cdb, 0, ATA_PASS_THROUGH_12_LEN);
+    memset(sense_data, 0, _T10_SPC_SENSE_DATA_MAX_LENGTH);
+    memset(sense_err_msg, 0, _LSM_ERR_MSG_LEN);
+
+    //set BYT_BLOK bit to 1 for all commands
+    cdb[2] = 1 << 2;
+
+    //set CK_COND bit
+    if (need_output_reg)
+        cdb[2] = cdb[2] | (1 << 5);
+
+    //set PROTOCOL value as defined in Table 2, and
+    //set T_LENGTH and T_DIR as appropriate.
+    if (direction == ATA_NON_DATA_COMMAND) {
+        cdb[1] = 3 << 1;
+        cdb[2] = cdb[2] | (1 << 3);
+    } else if (direction == ATA_DATA_IN_COMMAND) {
+        cdb[1] = 4 << 1;
+        cdb[2] = cdb[2] | (1 << 3) | 2;
+    } else if (direction == ATA_DATA_OUT_COMMAND) {
+        cdb[1] = 5 << 1;
+        cdb[2] = cdb[2] | 2;
+    }
+
+    input_registers = (struct _ata_registers_input_28_bit *) ata_cmd;
+
+    cdb[0] = ATA_PASS_THROUGH_12;
+    cdb[3] = input_registers->feature;
+    cdb[4] = input_registers->count;
+    cdb[5] = input_registers->lba_low;
+    cdb[6] = input_registers->lba_mid;
+    cdb[7] = input_registers->lba_high;
+    cdb[8] = input_registers->device;
+    cdb[9] = input_registers->command;
+    cmd_len = ATA_PASS_THROUGH_12_LEN;
+
+    ioctl_errno = _sg_io(fd, cdb, cmd_len, data, data_len, sense_data,
+                         _SG_IO_NO_DATA);
+
+    if (ioctl_errno) {
+        rc = _get_ata_output_regs(sense_data, ata_output_regs);
+
+        if (rc) {
+            _check_sense_data(sense_err_msg, sense_data, &sense_key);
+
+            _lsm_err_msg_set(err_msg, "Got error from SGIO ATA PASSTHROUGH: "
+                             "error %d(%s), %s", ioctl_errno,
+                             strerror_r(ioctl_errno, strerr_buff,
+                                        _LSM_ERR_MSG_LEN),
+                             sense_err_msg);
+        }
+    }
+
+    return rc;
+}
+
+int _sg_log_sense(char *err_msg, int fd, uint8_t page_code,
+                  uint8_t sub_page_code, uint8_t *data)
+{
+    int rc = LSM_ERR_OK;
+    uint8_t tmp_data[_T10_SPC_LOG_SENSE_MAX_LEN];
+    uint8_t cdb[_T10_SPC_LOG_SENSE_CMD_LEN];
+    uint8_t sense_data[_T10_SPC_SENSE_DATA_MAX_LENGTH];
+    int ioctl_errno = 0;
+    char strerr_buff[_LSM_ERR_MSG_LEN];
+    uint8_t sense_key = _T10_SPC_SENSE_KEY_NO_SENSE;
+    char sense_err_msg[_LSM_ERR_MSG_LEN];
+    struct _sg_t10_log_para_hdr *log_hdr = NULL;
+    uint16_t log_data_len = 0;
+
+    assert(err_msg != NULL);
+    assert(fd >= 0);
+    assert(data != NULL);
+
+    memset(sense_err_msg, 0, _LSM_ERR_MSG_LEN);
+    memset(cdb, 0, _T10_SPC_LOG_SENSE_CMD_LEN);
+
+    cdb[0] = LOG_SENSE;
+    cdb[2] = (PAGE_CONTROL_CUMULATIVE_VALS << 6) | (page_code & 0x3f);
+    cdb[3] = sub_page_code & UINT8_MAX;
+    cdb[7] = (_T10_SPC_LOG_SENSE_MAX_LEN >> 8) & UINT8_MAX;
+    cdb[8] = _T10_SPC_LOG_SENSE_MAX_LEN & UINT8_MAX;
+
+    ioctl_errno = _sg_io(fd, cdb, _T10_SPC_LOG_SENSE_CMD_LEN, tmp_data,
+                         _T10_SPC_LOG_SENSE_MAX_LEN, sense_data,
+                         _SG_IO_RECV_DATA);
+
+    if (ioctl_errno) {
+        rc = LSM_ERR_LIB_BUG;
+        _check_sense_data(sense_err_msg, sense_data, &sense_key);
+
+        if (sense_key == _T10_SPC_SENSE_KEY_ILLEGAL_REQUEST) {
+            rc = LSM_ERR_NO_SUPPORT;
+            goto out;
+        }
+
+        _lsm_err_msg_set(err_msg, "Got error from SGIO LOG SENSE "
+                         "with error %d(%s), %s", ioctl_errno,
+                         strerror_r(ioctl_errno, strerr_buff, _LSM_ERR_MSG_LEN),
+                         sense_err_msg);
+        goto out;
+    }
+
+    log_hdr = (struct _sg_t10_log_para_hdr *) tmp_data;
+    log_data_len = be16toh(log_hdr->log_data_len_be);
+    if ((log_data_len == 0) ||
+        (log_data_len >= _T10_SPC_LOG_SENSE_MAX_LEN)) {
+        rc = LSM_ERR_LIB_BUG;
+        _lsm_err_msg_set(err_msg, "BUG: Got illegal SCSI log page return: "
+                         "invalid LOG DATA LENGTH %" PRIu16 "\n",
+                         log_data_len);
+        goto out;
+    }
+    memcpy(data, tmp_data + sizeof(struct _sg_t10_log_para_hdr), log_data_len);
+
+out:
+
+    return rc;
+}
+
+int _sg_request_sense(char *err_msg, int fd, uint8_t *returned_sense_data)
+{
+    int rc = LSM_ERR_OK;
+    uint8_t request_sense[_T10_SPC_REQUEST_SENSE_MAX_LEN];
+    uint8_t cdb[_T10_SPC_REQUEST_SENSE_CMD_LEN];
+    uint8_t sense_data[_T10_SPC_SENSE_DATA_MAX_LENGTH];
+    int ioctl_errno = 0;
+    uint8_t sense_key = _T10_SPC_SENSE_KEY_NO_SENSE;
+    char sense_err_msg[_LSM_ERR_MSG_LEN];
+    char strerr_buff[_LSM_ERR_MSG_LEN];
+
+    assert(err_msg != NULL);
+    assert(fd >= 0);
+    assert(returned_sense_data != NULL);
+
+    memset(sense_err_msg, 0, _LSM_ERR_MSG_LEN);
+    memset(cdb, 0, _T10_SPC_REQUEST_SENSE_CMD_LEN);
+
+    cdb[0] = REQUEST_SENSE;
+    cdb[4] = _T10_SPC_REQUEST_SENSE_MAX_LEN & UINT8_MAX;
+
+    ioctl_errno = _sg_io(fd, cdb, _T10_SPC_REQUEST_SENSE_CMD_LEN, request_sense,
+                         _T10_SPC_REQUEST_SENSE_MAX_LEN,
+                         sense_data, _SG_IO_RECV_DATA);
+
+    if (ioctl_errno) {
+        rc = LSM_ERR_LIB_BUG;
+        _check_sense_data(sense_err_msg, sense_data, &sense_key);
+
+        if (sense_key == _T10_SPC_SENSE_KEY_ILLEGAL_REQUEST) {
+            rc = LSM_ERR_NO_SUPPORT;
+            goto out;
+        }
+
+        _lsm_err_msg_set(err_msg, "Got error from SGIO REQUEST SENSE: "
+                         "error %d(%s) %s", ioctl_errno,
+                         strerror_r(ioctl_errno, strerr_buff,
+                                    _LSM_ERR_MSG_LEN),
+                         sense_err_msg);
+        goto out;
+    }
+
+    memcpy(returned_sense_data, sense_data, _T10_SPC_SENSE_DATA_MAX_LENGTH);
+
+out:
+
+    return rc;
+}
+
+int32_t _sg_info_excep_interpret_asc(uint8_t asc)
+{
+    if (asc == _T10_SPC_ASC_IMPENDING_FAILURE)
+        return LSM_DISK_HEALTH_STATUS_FAIL;
+    else if (asc == _T10_SPC_ASC_WARNING)
+        return LSM_DISK_HEALTH_STATUS_WARN;
+    else
+        return LSM_DISK_HEALTH_STATUS_GOOD;
+}
+
+/*
+ * Query a SAS drive to get its health status.
+ * This method will attempt to:
+ * 1. Retrieve the MRIE value of the SAS drive
+ * 2. Depending on the MRIE value, we will either submit a REQUEST SENSE
+ *    command or a LOG SENSE command.
+ * 3. Return the health status to the caller.
+ *
+ * Input *health_status should be a pointer to an int32_t value.
+ * Return LSM_ERR_NO_MEMORY or LSM_ERR_NO_SUPPORT or LSM_ERR_LIB_BUG or
+ * LSM_ERR_NOT_FOUND_DISK.
+ */
+int _sg_sas_health_status(char *err_msg, int fd, int32_t *health_status)
+{
+    int rc = LSM_ERR_OK;
+    uint8_t info_excep_mode_page[_SG_T10_SPC_MODE_SENSE_MAX_LEN];
+    uint8_t info_excep_log_page[_T10_SPC_LOG_SENSE_MAX_LEN];
+    uint8_t asc = 0;
+    uint8_t requested_sense[_T10_SPC_SENSE_DATA_MAX_LENGTH];
+    struct _sg_t10_sense_fixed *sense_fixed = NULL;
+    struct _sg_t10_info_excep_mode_page_0_hdr *ie_mode_hdr = NULL;
+    struct _sg_t10_info_excep_general_log_hdr *ie_log_hdr = NULL;
+
+    _good(_sg_io_mode_sense(err_msg, fd, INFO_EXCEP_CONTROL_PAGE, 0,
+                            info_excep_mode_page), rc, out);
+    ie_mode_hdr = (struct _sg_t10_info_excep_mode_page_0_hdr *)
+                   info_excep_mode_page;
+
+    if (ie_mode_hdr->mrie == MRIE_REPORT_INFO_EXCEP_ON_REQUEST) {
+        _good(_sg_request_sense(err_msg, fd, requested_sense), rc, out);
+        sense_fixed = (struct _sg_t10_sense_fixed *) requested_sense;
+        asc = sense_fixed->asc;
+    } else {
+        _good(_sg_log_sense(err_msg, fd, _T10_SPC_INFO_EXCEP_PAGE_CODE, 0,
+                            info_excep_log_page), rc, out);
+        // SPC5 rev07 - Table 349 - Informational Exceptions General log parameter
+        ie_log_hdr = (struct _sg_t10_info_excep_general_log_hdr *)
+                     info_excep_log_page;
+        asc = ie_log_hdr->asc;
+    }
+
+    *health_status = _sg_info_excep_interpret_asc(asc);
+
+out:
+    return rc;
+}
+
+/*
+ * Query a SATA drive attached via SAS to get its health status.
+ *
+ * Input *health_status should be a pointer to an int32_t value.
+ * Return LSM_ERR_NO_MEMORY or LSM_ERR_NO_SUPPORT or LSM_ERR_LIB_BUG or
+ * LSM_ERR_NOT_FOUND_DISK.
+ */
+int _sg_ata_passthrough_health_status(char *err_msg, int fd,
+                                      int32_t *health_status)
+{
+    int rc = LSM_ERR_OK;
+    uint8_t ata_cmd[_ATA_REGISTER_INPUT_28_BIT_LENGTH];
+    uint8_t ata_output_regs[_ATA_REGISTER_OUTPUT_28_BIT_LENGTH];
+
+
+    memset(ata_cmd, 0, _ATA_REGISTER_INPUT_28_BIT_LENGTH);
+    memset(ata_output_regs, 0, _ATA_REGISTER_OUTPUT_28_BIT_LENGTH);
+
+    _ata_smart_status_fill_registers(ata_cmd, ATA_SMART_COMMAND,
+                                     ATA_SMART_RETURN_STATUS_SUBCOMMAND,
+                                     SMART_STATUS_LBA_HIGH_DEFAULT,
+                                     SMART_STATUS_LBA_MID_DEFAULT, 0, 0, 0);
+
+    rc = _sg_io_ata_passthrough(err_msg, fd, true, ATA_NON_DATA_COMMAND,
+                                ata_cmd, NULL, 0, ata_output_regs);
+
+    if (!rc)
+        *health_status = _ata_smart_status_interpret_output_regs(ata_output_regs);
+
     return rc;
 }

--- a/c_binding/libsg.h
+++ b/c_binding/libsg.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Red Hat, Inc.
+ * (C) Copyright (C) 2017 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/c_binding/libsg.h
+++ b/c_binding/libsg.h
@@ -79,6 +79,12 @@
 #define _SG_T10_SPC_MODE_SENSE_MAX_LEN              0xffff
 /* ^ SPC-5 rev 12, 6.15 MODE SENSE(10) command introduction */
 
+#define _T10_SPC_LOG_SENSE_MAX_LEN                  0xffff
+/* ^ SPC-5 rev07 6.8 LOG SENSE command */
+
+#define _T10_SPC_REQUEST_SENSE_MAX_LEN              0xff
+/* ^ SPC-5 rev07 6.35 REQUEST SENSE command */
+
 #pragma pack(push, 1)
 
 /*
@@ -187,6 +193,49 @@ LSM_DLL_LOCAL int _sg_io_open_rw(char *err_msg, const char *disk_path, int *fd);
  */
 LSM_DLL_LOCAL int _sg_tp_sas_addr_of_disk(char *err_msg, int fd,
                                           char *tp_sas_addr);
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  fd >= 0
+ *  data != NULL
+ *  data is uint8_t[_SG_T10_SPC_LOG_SENSE_MAX_LEN]
+ */
+LSM_DLL_LOCAL int _sg_log_sense(char *err_msg, int fd, uint8_t page_code,
+                                uint8_t sub_page_code, uint8_t *data);
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  fd >= 0
+ *  returned_sense_data != NULL
+ */
+LSM_DLL_LOCAL int _sg_request_sense(char *err_msg, int fd,
+                                    uint8_t *returned_sense_data);
+
+/*
+ * Preconditions:
+ *  None
+ */
+LSM_DLL_LOCAL int32_t _sg_info_excep_interpret_asc(uint8_t asc);
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  fd >= 0
+ *  health_status != NULL
+ */
+LSM_DLL_LOCAL int _sg_sas_health_status(char *err_msg, int fd,
+                                        int32_t *health_status);
+
+/*
+ * Preconditions:
+ *  err_msg != NULL
+ *  fd >= 0
+ *  health_status != NULL
+ */
+LSM_DLL_LOCAL int _sg_ata_passthrough_health_status(char *err_msg, int fd,
+                                                    int32_t *health_status);
 
 /*
  * Preconditions:

--- a/c_binding/lsm_local_disk.c
+++ b/c_binding/lsm_local_disk.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2016 Red Hat, Inc.
+ * (C) Copyright (C) 2017 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/c_binding/lsm_local_disk.c
+++ b/c_binding/lsm_local_disk.c
@@ -839,6 +839,64 @@ int lsm_local_disk_list(lsm_string_list **disk_paths, lsm_error **lsm_err)
 }
 
 /* Workflow:
+ *  * Query VPD supported pages, get ATA information page support and
+ *    check the device id page.
+ *  * Based on that data, decide what type of device it is.
+ *  * Request health status the appropriate way.
+ */
+int lsm_local_disk_health_status_get(const char *disk_path,
+                                     int32_t *health_status,
+                                     lsm_error **lsm_err)
+{
+    int fd = -1;
+    char err_msg[_LSM_ERR_MSG_LEN];
+    int rc = LSM_ERR_OK;
+    lsm_disk_link_type link_type = LSM_DISK_LINK_TYPE_NO_SUPPORT;
+
+    _lsm_err_msg_clear(err_msg);
+
+    _good(_check_null_ptr(err_msg, 3, disk_path, health_status, lsm_err),
+          rc, out);
+
+    *lsm_err = NULL;
+
+    rc = lsm_local_disk_link_type_get(disk_path, &link_type, lsm_err);
+
+    if (rc != LSM_ERR_OK) {
+        _lsm_err_msg_set(err_msg, "%s", lsm_error_message_get(*lsm_err));
+        lsm_error_free(*lsm_err);
+        goto out;
+    }
+
+    _good(_sg_io_open_ro(err_msg, disk_path, &fd), rc, out);
+
+    if (link_type == LSM_DISK_LINK_TYPE_ATA) {
+        _good(_sg_ata_passthrough_health_status(err_msg, fd, health_status),
+              rc, out);
+    } else if (link_type == LSM_DISK_LINK_TYPE_SAS) {
+        _good(_sg_sas_health_status(err_msg, fd, health_status), rc, out);
+    } else {
+        rc = LSM_ERR_NO_SUPPORT;
+        _lsm_err_msg_set(err_msg, "Device link type %d is not supported yet",
+                         link_type);
+        goto out;
+    }
+
+out:
+    if (rc != LSM_ERR_OK) {
+        if (lsm_err != NULL)
+            *lsm_err = LSM_ERROR_CREATE_PLUGIN_MSG(rc, err_msg);
+        if (health_status != NULL)
+            *health_status = LSM_DISK_HEALTH_STATUS_UNKNOWN;
+    }
+
+    if (fd >= 0)
+        close(fd);
+
+    return rc;
+}
+
+/* Workflow:
  *  * Query VPD supported pages, if ATA Information page is supported, then
  *     we got a ATA.
  *    # We check this first as when SATA disk connected to a SAS enclosure

--- a/python_binding/lsm/_clib.c
+++ b/python_binding/lsm/_clib.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2016 Red Hat, Inc.
+ * (C) Copyright (C) 2017 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/python_binding/lsm/_clib.c
+++ b/python_binding/lsm/_clib.c
@@ -181,6 +181,23 @@ static const char local_disk_serial_num_get_docstring[] =
     "        err_msg (string)\n"
     "            Error message, empty if no error.\n";
 
+static const char local_disk_health_status_get_docstring[] =
+    "INTERNAL USE ONLY!\n"
+    "\n"
+    "Usage:\n"
+    "    Query the health status of a given disk path\n"
+    "Parameters:\n"
+    "    disk_path (string)\n"
+    "        The SCSI disk path, example '/dev/sdb'. Empty string is failure\n"
+    "Returns:\n"
+    "    [health_status, rc, err_msg]\n"
+    "        health_status (int)\n"
+    "            health status.\n"
+    "        rc (integer)\n"
+    "            Error code, lsm.ErrorNumber.OK if no error\n"
+    "        err_msg (string)\n"
+    "            Error message, empty if no error.\n";
+
 static const char local_disk_vpd83_get_docstring[] =
     "INTERNAL USE ONLY!\n"
     "\n"
@@ -363,6 +380,8 @@ static PyObject *local_disk_vpd83_search(PyObject *self, PyObject *args,
                                          PyObject *kwargs);
 static PyObject *local_disk_vpd83_get(PyObject *self, PyObject *args,
                                       PyObject *kwargs);
+static PyObject *local_disk_health_status_get(PyObject *self, PyObject *args,
+                                              PyObject *kwargs);
 static PyObject *local_disk_rpm_get(PyObject *self, PyObject *args,
                                     PyObject *kwargs);
 static PyObject *local_disk_list(PyObject *self, PyObject *args,
@@ -392,6 +411,8 @@ static PyMethodDef _methods[] = {
      METH_VARARGS | METH_KEYWORDS, local_disk_vpd83_search_docstring},
     {"_local_disk_vpd83_get",  (PyCFunction) local_disk_vpd83_get,
      METH_VARARGS | METH_KEYWORDS, local_disk_vpd83_get_docstring},
+    {"_local_disk_health_status_get",  (PyCFunction) local_disk_health_status_get,
+     METH_VARARGS | METH_KEYWORDS, local_disk_health_status_get_docstring},
     {"_local_disk_rpm_get",  (PyCFunction) local_disk_rpm_get,
      METH_VARARGS | METH_KEYWORDS, local_disk_rpm_get_docstring},
     {"_local_disk_list",  (PyCFunction) local_disk_list,
@@ -451,6 +472,9 @@ _wrapper(local_disk_vpd83_search, lsm_local_disk_vpd83_search,
 _wrapper(local_disk_vpd83_get, lsm_local_disk_vpd83_get,
          const char *, disk_path, char *, NULL,
          _c_str_to_py_str, free);
+_wrapper(local_disk_health_status_get, lsm_local_disk_health_status_get,
+         const char *, disk_path, int32_t, LSM_DISK_HEALTH_STATUS_UNKNOWN,
+         PyInt_FromLong, _NO_NEED_TO_FREE);
 _wrapper(local_disk_rpm_get, lsm_local_disk_rpm_get,
          const char *, disk_path, int32_t, LSM_DISK_RPM_UNKNOWN,
          PyInt_FromLong, _NO_NEED_TO_FREE);

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2011-2016 Red Hat, Inc.
-# (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -242,6 +242,11 @@ class Disk(IData):
 
     LINK_SPEED_UNKNOWN = 0
 
+    HEALTH_STATUS_UNKNOWN = -1
+    HEALTH_STATUS_FAIL = 0
+    HEALTH_STATUS_WARN = 1
+    HEALTH_STATUS_GOOD = 2
+
     def __init__(self, _id, _name, _disk_type, _block_size, _num_of_blocks,
                  _status, _system_id, _plugin_data=None, _vpd83='',
                  _location='', _rpm=RPM_NO_SUPPORT,

--- a/python_binding/lsm/_local_disk.py
+++ b/python_binding/lsm/_local_disk.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2016 Red Hat, Inc.
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/python_binding/lsm/_local_disk.py
+++ b/python_binding/lsm/_local_disk.py
@@ -19,6 +19,7 @@ import six
 from lsm import LsmError, ErrorNumber
 
 from lsm._clib import (_local_disk_vpd83_search, _local_disk_vpd83_get,
+                       _local_disk_health_status_get,
                        _local_disk_rpm_get, _local_disk_list,
                        _local_disk_link_type_get, _local_disk_ident_led_on,
                        _local_disk_ident_led_off, _local_disk_fault_led_on,
@@ -124,6 +125,45 @@ class LocalDisk(object):
                 No capability required as this is a library level method.
         """
         return _use_c_lib_function(_local_disk_vpd83_get, disk_path)
+
+    @staticmethod
+    def health_status_get(disk_path):
+        """
+        lsm.LocalDisk.health_status_get(disk_path)
+
+        Version:
+            1.5
+        Usage:
+            Retrieve the health status of given disk path.
+        Parameters:
+            disk_path (string)
+                The disk path, example '/dev/sdb'.
+        Returns:
+            health_status (integer)
+                Disk health status:
+                    -1 (lsm.Disk.HEALTH_STATUS_UNKNOWN):
+                        Unknown health status
+                     0 (lsm.Disk.HEALTH_STATUS_FAIL):
+                        health status indicates failure
+                     1 (lsm.Disk.HEALTH_STATUS_WARN):
+                        health status warns of near failure
+                     2 (lsm.Disk.HEALTH_STATUS_GOOD):
+                        health status indicates good health
+        SpecialExceptions:
+            LsmError
+                ErrorNumber.LIB_BUG
+                    Internal bug.
+                ErrorNumber.INVALID_ARGUMENT
+                    Invalid disk_path. Should be like '/dev/sdb'
+                ErrorNumber.NOT_FOUND_DISK
+                    Provided disk is not found.
+                ErrorNumber.NO_SUPPORT
+                    Not supported.
+        Capability:
+            N/A
+                No capability required as this is a library level method.
+        """
+        return _use_c_lib_function(_local_disk_health_status_get, disk_path)
 
     @staticmethod
     def rpm_get(disk_path):

--- a/test/tester.c
+++ b/test/tester.c
@@ -3627,6 +3627,45 @@ START_TEST(test_local_disk_link_type)
 }
 END_TEST
 
+START_TEST(test_local_disk_health_status_get)
+{
+    int rc = 0;
+    int32_t health_status = LSM_DISK_HEALTH_STATUS_UNKNOWN;
+    lsm_error *lsm_err = NULL;
+
+    rc = lsm_local_disk_health_status_get("/dev/sda", &health_status,  &lsm_err);
+    if (rc == LSM_ERR_OK) {
+        fail_unless(health_status == LSM_DISK_HEALTH_STATUS_UNKNOWN,
+                    "lsm_local_disk_health_status_get(): "
+                    "Expecting health_status to be "
+                    "LSM_DISK_HEALTH_STATUS_UNKNOWN "
+                    "when rc == LSM_ERR_OK and the disk "
+                    "type is unknown");
+    } else {
+        lsm_error_free(lsm_err);
+    }
+
+    /* Test disk that does not exist */
+    rc = lsm_local_disk_health_status_get(NOT_EXIST_SD_PATH, &health_status,
+                                         &lsm_err);
+    fail_unless(rc == LSM_ERR_NOT_FOUND_DISK,
+                "lsm_local_disk_health_status_get(): "
+                "Expecting LSM_ERR_NOT_FOUND_DISK error with "
+                "non-existent sd_path");
+    fail_unless(lsm_err != NULL, "lsm_local_disk_health_status_get(): "
+                "Expecting lsm_err not NULL with non-existent sd_path");
+    fail_unless(lsm_error_number_get(lsm_err) == LSM_ERR_NOT_FOUND_DISK,
+                "lsm_local_disk_health_status_get(): "
+                "Expecting error number of lsm_err to be set as "
+                "LSM_ERR_NOT_FOUND_DISK with non-existent sd_path");
+    fail_unless(lsm_error_message_get(lsm_err) != NULL,
+                "lsm_local_disk_health_status_get(): "
+                "Expecting error message of lsm_err to not be NULL "
+                "with non-existent sd_path");
+    lsm_error_free(lsm_err);
+}
+END_TEST
+
 START_TEST(test_batteries)
 {
     uint32_t count = 0;
@@ -4086,6 +4125,7 @@ Suite * lsm_suite(void)
     tcase_add_test(basic, test_local_disk_list);
     tcase_add_test(basic, test_local_disk_rpm_get);
     tcase_add_test(basic, test_local_disk_link_type);
+    tcase_add_test(basic, test_local_disk_health_status_get);
     tcase_add_test(basic, test_batteries);
     tcase_add_test(basic, test_volume_cache_info);
     tcase_add_test(basic, test_volume_pdc_update);

--- a/test/tester.c
+++ b/test/tester.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011-2016 Red Hat, Inc.
- * (C) Copyright 2015-2016 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2015-2017 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2012-2016 Red Hat, Inc.
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -1801,6 +1801,7 @@ class CmdLine(object):
             "serial_num": LocalDisk.serial_num_get,
             "led_status": LocalDisk.led_status_get,
             "link_speed": LocalDisk.link_speed_get,
+            "health_status": LocalDisk.health_status_get,
         }
         for disk_path in LocalDisk.list():
             info_dict = {
@@ -1810,6 +1811,7 @@ class CmdLine(object):
                 "serial_num": "",
                 "led_status": Disk.LED_STATUS_UNKNOWN,
                 "link_speed": Disk.LINK_SPEED_UNKNOWN,
+                "health_status": Disk.HEALTH_STATUS_UNKNOWN,
             }
             for key in info_dict.keys():
                 try:
@@ -1825,7 +1827,8 @@ class CmdLine(object):
                               info_dict["link_type"],
                               info_dict["serial_num"],
                               info_dict["led_status"],
-                              info_dict["link_speed"]))
+                              info_dict["link_speed"],
+                              info_dict["health_status"]))
 
         self.display_data(local_disks)
 

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2014 Red Hat, Inc.
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either

--- a/tools/lsmcli/data_display.py
+++ b/tools/lsmcli/data_display.py
@@ -266,6 +266,19 @@ def disk_link_type_to_str(link_type):
     return _enum_type_to_str(link_type, LocalDiskInfo._LINK_TYPE_MAP)
 
 
+def disk_health_status_to_str(health_status):
+    if health_status == '':
+        return "No Support"
+    if health_status == Disk.HEALTH_STATUS_UNKNOWN:
+        return "Unknown"
+    if health_status == Disk.HEALTH_STATUS_FAIL:
+        return "Failure"
+    if health_status == Disk.HEALTH_STATUS_WARN:
+        return "Warning"
+    if health_status == Disk.HEALTH_STATUS_GOOD:
+        return "Good"
+
+
 _BATTERY_TYPE_CONV = {
     Battery.TYPE_UNKNOWN: "Unknown",
     Battery.TYPE_OTHER: "Other",
@@ -408,7 +421,7 @@ class LocalDiskInfo(object):
     }
 
     def __init__(self, sd_path, vpd83, rpm, link_type, serial_num, led_status,
-                 link_speed):
+                 link_speed, health_status):
         self.sd_path = sd_path
         self.vpd83 = vpd83
         self.rpm = rpm
@@ -416,6 +429,8 @@ class LocalDiskInfo(object):
         self.serial_num = serial_num
         self.led_status = led_status
         self.link_speed = link_speed
+        self.health_status = health_status
+
 
 class VolumeRAMCacheInfo(object):
 
@@ -824,6 +839,7 @@ class DisplayData(object):
     LOCAL_DISK_HEADER['serial_num'] = 'Serial Number'
     LOCAL_DISK_HEADER['led_status'] = 'LED Status'
     LOCAL_DISK_HEADER['link_speed'] = 'Link Speed'
+    LOCAL_DISK_HEADER['health_status'] = 'Health Status'
 
     LOCAL_DISK_COLUMN_SKIP_KEYS = ['rpm', 'led_status', 'link_speed']
 
@@ -832,7 +848,9 @@ class DisplayData(object):
         'link_type': disk_link_type_to_str,
         'led_status': disk_led_status_to_str,
         'link_speed': disk_link_speed_to_str,
+        'health_status': disk_health_status_to_str,
     }
+
     LOCAL_DISK_VALUE_CONV_HUMAN = []
 
     VALUE_CONVERT[LocalDiskInfo] = {


### PR DESCRIPTION
This patch adds the ability to query SMART Status for SAS and SATA drives via the local_disk APIs.

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>
