### PR TITLE
New test cases for Python 2 and Python3 interaction test.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,7 @@ AC_ARG_WITH([python3],
     [])
 
 if test "x$with_python3" = "xyes"; then
+    AC_SUBST(WITH_PYTHON3, yes)
     AC_PATH_PROGS(PYTHON, python3, [Python3 is required])
     AM_PATH_PYTHON([3], [], AC_MSG_ERROR([Python interpreter 3 required]))
     AC_PYTHON_MODULE([lmiwbem], [], [python3])
@@ -225,6 +226,7 @@ please install any of them.])
     fi
     AC_SUBST(PY_VERSION, 3)
 else
+    AC_SUBST(WITH_PYTHON3, no)
     AC_PATH_PROGS(PYTHON, python2.7 python2.6 python, [Python is required])
     AC_MSG_CHECKING([Check for Python major version])
     PYTHON_MAJOR_VERSION=`$PYTHON -c "import sys; print(sys.version_info[[0]])"`

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -235,9 +235,9 @@ TEMPFILE := $(shell mktemp)
 
 $(API_MAN_PAGES): $(HEADER_FILES)
 	cat $(HEADER_FILES) | \
-	    perl doc-preclean.pl > $(TEMPFILE)
-	perl kernel-doc -man $(TEMPFILE) | \
-	    perl split-man.pl api_man
+	    perl $(top_srcdir)/doc/doc-preclean.pl > $(TEMPFILE)
+	perl $(top_srcdir)/doc/kernel-doc -man $(TEMPFILE) | \
+	    perl $(top_srcdir)/doc/split-man.pl api_man
 	-rm -f $(TEMPFILE)
 
 CLEANFILES=$(API_MAN_PAGES)

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -112,7 +112,6 @@ BuildRequires:  python3-six
 BuildRequires:  python3-devel
 %endif
 BuildRequires:  python-six
-BuildRequires:  python-argparse
 BuildRequires:  python-devel
 
 %description

--- a/plugin/sim/simarray.py
+++ b/plugin/sim/simarray.py
@@ -2304,14 +2304,17 @@ class SimArray(object):
         return job_id
 
     @_handle_errors
-    def fs_child_dependency(self, fs_id, files, flags=0):
+    def fs_child_dependency(self, fs_id, files, flags=0, _internal_use=False):
         sim_fs_id = SimArray._sim_fs_id_of(fs_id)
-        self.bs_obj.trans_begin()
+        if _internal_use is False:
+            self.bs_obj.trans_begin()
         if self.bs_obj.clone_dst_sim_fs_ids_of_src(sim_fs_id) == [] and \
            self.bs_obj.sim_fs_snaps(sim_fs_id) == []:
-            self.bs_obj.trans_rollback()
+            if _internal_use is False:
+                self.bs_obj.trans_rollback()
             return False
-        self.bs_obj.trans_rollback()
+        if _internal_use is False:
+            self.bs_obj.trans_rollback()
         return True
 
     @_handle_errors
@@ -2321,7 +2324,7 @@ class SimArray(object):
         all snapshot of this source file system.
         """
         self.bs_obj.trans_begin()
-        if self.fs_child_dependency(fs_id, files) is False:
+        if self.fs_child_dependency(fs_id, files, _internal_use=True) is False:
             raise LsmError(
                 ErrorNumber.NO_STATE_CHANGE,
                 "No snapshot or fs clone target found for this file system")
@@ -2330,7 +2333,7 @@ class SimArray(object):
         self.bs_obj.sim_fs_src_clone_break(src_sim_fs_id)
         self.bs_obj.sim_fs_snap_del_by_fs(src_sim_fs_id)
         job_id = self._job_create()
-        self.bs_obj.trans_begin()
+        self.bs_obj.trans_commit()
         return job_id
 
     @staticmethod

--- a/test/runtests.sh.in
+++ b/test/runtests.sh.in
@@ -71,3 +71,67 @@ if [ "CHK$with_mem_leak_test" == "CHKyes" ];then
     lsm_test_check_memory_leak
 fi
 lsm_test_cleanup
+
+if [ "CHK@WITH_PYTHON3@" == "CHKno" ];then
+    echo -n "Python3 and Python2 interaction test skipped, "
+    echo    "'--with-python3' configure option reuqired"
+    exit;
+fi
+
+# Third round: python3 client communicate with python2 plugins
+py2_base_dir="/tmp/lsm_py2_base_dir_$RANDOM"
+py3_base_dir="/tmp/lsm_py3_base_dir_$RANDOM"
+py2_build_dir="/tmp/lsm_py2_build_dir_$RANDOM"
+py3_build_dir="/tmp/lsm_py3_build_dir_$RANDOM"
+mkdir $py2_build_dir
+cd $py2_build_dir || exit 1
+${src_dir}/configure || exit 1
+make -j5 || exit 1
+mkdir $py3_build_dir
+cd $py3_build_dir || exit 1
+${src_dir}/configure --with-python3 || exit 1
+make -j5 || exit 1
+
+lsm_test_base_install \
+    "$py2_base_dir" "$py2_build_dir" "$src_dir" \
+    ${LSM_TEST_INSTALL_PY_PLUGINS_ONLY}
+
+lsm_test_lsmd_start $LSM_TEST_WITHOUT_MEM_CHECK
+
+PY2_LSM_UDS_PATH=$LSM_UDS_PATH
+PY2_LSM_TEST_DST_DIR=$LSM_TEST_DST_DIR
+
+lsm_test_base_install \
+    "$py3_base_dir" "$py3_build_dir" "$src_dir" \
+    ${LSM_TEST_INSTALL_C_PLUGINS_ONLY}
+
+export LSM_UDS_PATH=$PY2_LSM_UDS_PATH
+lsm_test_cmd_test_run $LSM_TEST_SIM_URI
+lsm_test_plugin_test_run $LSM_TEST_SIM_URI
+export LSM_TEST_DST_DIR=$PY2_LSM_TEST_DST_DIR
+lsm_test_cleanup
+rm $py3_base_dir -rf
+
+# Forth round: python2 client communicate with python3 plugins
+py2_base_dir="/tmp/lsm_py2_base_dir_$RANDOM"
+py3_base_dir="/tmp/lsm_py3_base_dir_$RANDOM"
+
+lsm_test_base_install \
+    "$py3_base_dir" "$py3_build_dir" "$src_dir" \
+    ${LSM_TEST_INSTALL_PY_PLUGINS_ONLY}
+
+lsm_test_lsmd_start $LSM_TEST_WITHOUT_MEM_CHECK
+
+PY3_LSM_UDS_PATH=$LSM_UDS_PATH
+PY3_LSM_TEST_DST_DIR=$LSM_TEST_DST_DIR
+
+lsm_test_base_install \
+    "$py2_base_dir" "$py2_build_dir" "$src_dir" \
+    ${LSM_TEST_INSTALL_C_PLUGINS_ONLY}
+
+export LSM_UDS_PATH=$PY3_LSM_UDS_PATH
+lsm_test_cmd_test_run $LSM_TEST_SIM_URI
+lsm_test_plugin_test_run $LSM_TEST_SIM_URI
+export LSM_TEST_DST_DIR=$PY3_LSM_TEST_DST_DIR
+lsm_test_cleanup
+rm $py2_base_dir -rf

--- a/test/test_include.sh
+++ b/test/test_include.sh
@@ -246,6 +246,10 @@ function lsm_test_base_install
         -type f -name '*.py' \
         -exec install -D "{}" "$LSM_TEST_PY_MODULE_DIR/lsm/" \\\;
 
+    _good find "${build_dir}/python_binding/lsm/" -maxdepth 1 \
+        -type f -name '*.py' \
+        -exec install -D "{}" "$LSM_TEST_PY_MODULE_DIR/lsm/" \\\;
+
     _good find "${src_dir}/python_binding/lsm/external/" -maxdepth 1 \
         -type f -name '*.py' \
         -exec install -D "{}" "$LSM_TEST_PY_MODULE_DIR/lsm/external" \\\;
@@ -253,13 +257,13 @@ function lsm_test_base_install
     _good find "${src_dir}/tools/lsmcli/" -maxdepth 1 -type f -name '*.py' \
         -exec install -D "{}" "$LSM_TEST_PY_MODULE_DIR/lsm/lsmcli/" \\\;
 
-    _good install -D "${src_dir}/tools/lsmcli/lsmcli" \
+    _good install -D "${build_dir}/tools/lsmcli/lsmcli" \
         "${LSM_TEST_BIN_DIR}/lsmcli"
     _good $LIBTOOL_CMD_NO_WARN --mode install \
         install "${build_dir}/test/tester" "${LSM_TEST_BIN_DIR}/tester"
-    _good install "${src_dir}/test/plugin_test.py" \
+    _good install "${build_dir}/test/plugin_test.py" \
         "${LSM_TEST_BIN_DIR}/plugin_test.py"
-    _good install "${src_dir}/test/cmdtest.py" \
+    _good install "${build_dir}/test/cmdtest.py" \
         "${LSM_TEST_BIN_DIR}/cmdtest.py"
 
     _good install "${src_dir}/config/lsmd.conf" \
@@ -273,7 +277,7 @@ function lsm_test_base_install
     if [ "CHK${plugin_type}" == "CHK${LSM_TEST_INSTALL_PY_PLUGINS_ONLY}" ] || \
        [ "CHK${plugin_type}" == "CHK${LSM_TEST_INSTALL_ALL_PLUGINS}" ];then
         _good cp -av ${src_dir}/plugin ${LSM_TEST_PY_MODULE_DIR}/lsm/
-        _good find ${src_dir}/plugin '\( ! -regex ".*/\..*" \)' \
+        _good find ${build_dir}/plugin '\( ! -regex ".*/\..*" \)' \
             -name \*_lsmplugin \
             -exec install -D {} ${LSM_TEST_PLUGIN_DIR} \\\;
         # When source folder is the build folder, above command might also


### PR DESCRIPTION
    Test: Two new test cases for Python 2 and 3 interaction.
    
     * Run python2 version of lsmcli test and plugin test with python3
       version simulator plugin.
    
     * Run python3 version of lsmcli test and plugin test with python2
       version simulator plugin.
    
     * These two tests will be run only when `--with-python3` configure
       option is in use.


Also fixed some issue found by these tests.
