### PR TITLE
lsmcli: Fix bug of fs-snap-restore when restoring the whole file system

### DIFF
--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -1402,6 +1402,9 @@ class CmdLine(object):
         # Get snapshot
         fs = _get_item(self.c.fs(), args.fs, "File System")
         ss = _get_item(self.c.fs_snapshots(fs), args.snap, "Snapshot")
+        files = self.args.file
+        if len(files) == 0:
+            files = None
 
         flag_all_files = True
 
@@ -1416,7 +1419,7 @@ class CmdLine(object):
             self._wait_for_it(
                 'fs-snap-restore',
                 self.c.fs_snapshot_restore(
-                    fs, ss, self.args.file, self.args.fileas, flag_all_files),
+                    fs, ss, files, self.args.fileas, flag_all_files),
                 None)
 
     # Deletes a volume


### PR DESCRIPTION
```
Issue:
    Got error when `lsmcli fs-snap-restore --force  --fs <FS_ID> --snap <SNP_ID`
    against a NetApp ONTAP array:
        INVALID_ARGUMENT(101): Invalid parameter combination 

Root cause:
    In API definition, only when "files == None and all_files = True"
    means all files on the file system are restored. The lsmcli set the
    `files` to [] which is None.

Fix:
    Fix lsmcli to use None for restoring the whole file system.
```