### PR TITLE
Sim and simc plugin: Fix missing disks after volume_delete() on HW RAID volume

### DIFF
--- a/plugin/simc/db.h
+++ b/plugin/simc/db.h
@@ -25,7 +25,7 @@
 #include "vector.h"
 #include "utils.h"
 
-#define _DB_VERSION                                         "4.0"
+#define _DB_VERSION                                         "4.1"
 
 #define _SYS_ID                                             "sim-01"
 

--- a/plugin/simc/db_table_init.h
+++ b/plugin/simc/db_table_init.h
@@ -68,7 +68,7 @@ static const char *_TABLE_INIT =
     "    rpm INTEGER,\n"
     "    link_type INTEGER,\n"
     "    FOREIGN KEY(owner_pool_id)\n"
-    "    REFERENCES pools(id) ON DELETE CASCADE );\n"
+    "    REFERENCES pools(id) ON DELETE SET DEFAULT);\n"
     "CREATE TABLE " _DB_TABLE_VOLS " (\n"
     "    id INTEGER PRIMARY KEY,\n"
     "    vpd83 TEXT NOT NULL,\n"

--- a/test/plugin_test.py.in
+++ b/test/plugin_test.py.in
@@ -1538,6 +1538,21 @@ class TestPlugin(unittest.TestCase):
                 if supported(cap, [Cap.VOLUME_DELETE]):
                     self._volume_delete(new_vol)
 
+                    updated_disks = []
+                    # Check whether disks are been set back to free mode.
+                    for disk in self.c.disks():
+                        if disk.id in list(d.id for d in free_disks):
+                            updated_disks.append(disk)
+                            self.assertTrue(
+                                disk.status & lsm.Disk.STATUS_FREE,
+                                "Disk %s is not restored to free state "
+                                "after volume_delete() on a raid volume"
+                                % disk.id)
+
+                    self.assertTrue(len(updated_disks) == 2,
+                                    "Disk missing after volume_delete() on "
+                                    "a raid volume")
+
             else:
                 self._skip_current_test(
                     "Skip test: not support of VOLUME_RAID_CREATE")


### PR DESCRIPTION
```
Issue:
    When deleting a volume created by `volume_raid_create()`, disks used
    by this volume will also be deleted.

Root cause:

    The `disks` table will remove the disks entry when owner pool delete.
    The sql table line to blame is:

            FOREIGN KEY(owner_pool_id)
                REFERENCES pools(id) ON DELETE CASCADE );

Fix:

    * Change to `ON DELETE SET DEFAULT`.
    * Update disk `role` to NULL when deleting a HW RAID volume.

```