### PR TITLE
C library: Fix bit field endian compatibility issue

### DIFF
--- a/c_binding/libata.c
+++ b/c_binding/libata.c
@@ -40,10 +40,16 @@
 
 #pragma pack(push, 1)
 struct _ata_sata_add_cap {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t zero            : 1;
     uint8_t cur_speed       : 3;
-    uint8_t we_dont_care_0  : 8;
-    uint8_t we_dont_care_1  : 4;
+    uint8_t we_dont_care_0  : 4;
+#else
+    uint8_t we_dont_care_0  : 4;
+    uint8_t cur_speed       : 3;
+    uint8_t zero            : 1;
+#endif
+    uint8_t we_dont_care_1;
 };
 #pragma pack(pop)
 

--- a/c_binding/libsas.c
+++ b/c_binding/libsas.c
@@ -36,14 +36,25 @@
 
 #pragma pack(push, 1)
 struct _sas_phy_ctrl_dicov_hdr {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t page_code       : 6;
     uint8_t spf             : 1;
     uint8_t ps              : 1;
+#else
+    uint8_t ps              : 1;
+    uint8_t spf             : 1;
+    uint8_t page_code       : 6;
+#endif
     uint8_t sub_page_code;
     uint16_t len_be;
     uint8_t reserved_1;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t protocol_id     : 4;
     uint8_t reserved_2      : 4;
+#else
+    uint8_t reserved_2      : 4;
+    uint8_t protocol_id     : 4;
+#endif
     uint8_t gen_code;
     uint8_t num_of_phys;
 };
@@ -53,8 +64,13 @@ struct _sas_phy_mode_dp {
     uint8_t phy_id;
     uint16_t reserved_2;
     uint8_t we_dont_care_0;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t negotiated_logical_link_rate    : 4;
     uint8_t we_dont_care_1                  : 4;
+#else
+    uint8_t we_dont_care_1                  : 4;
+    uint8_t negotiated_logical_link_rate    : 4;
+#endif
     uint8_t we_dont_care_2[2];
     uint8_t sas_addr[8];
     uint8_t we_dont_care_3[32];

--- a/c_binding/libses.c
+++ b/c_binding/libses.c
@@ -88,13 +88,25 @@ struct _ses_add_st {
  * SES-3 rev 11a Table 31 - Additional Element Status descriptor
  */
 struct _ses_add_st_dp {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t protocol_id         : 4;
     uint8_t eip                 : 1;
     uint8_t reserved            : 2;
     uint8_t invalid             : 1;
+#else
+    uint8_t invalid             : 1;
+    uint8_t reserved            : 2;
+    uint8_t eip                 : 1;
+    uint8_t protocol_id         : 4;
+#endif
     uint8_t len;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t eiioe               : 1;
     uint8_t reserved_2          : 7;
+#else
+    uint8_t reserved_2          : 7;
+    uint8_t eiioe               : 1;
+#endif
     uint8_t element_index;
     uint8_t data_begin;
 };
@@ -106,9 +118,15 @@ struct _ses_add_st_dp {
  */
 struct _ses_add_st_dp_sas {
     uint8_t phy_count;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t not_all_phy         : 1;
     uint8_t reserved            : 5;
     uint8_t dp_type             : 2;
+#else
+    uint8_t dp_type             : 2;
+    uint8_t reserved            : 5;
+    uint8_t not_all_phy         : 1;
+#endif
     uint8_t reserved_2;
     uint8_t dev_slot_num;
     uint8_t phy_list;
@@ -118,9 +136,15 @@ struct _ses_add_st_dp_sas {
  * SES-3 rev 11a Table 41 - Phy descriptor
  */
 struct _ses_add_st_sas_phy {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t reserved            : 4;
     uint8_t dev_type            : 3;
     uint8_t reserved_2          : 1;
+#else
+    uint8_t reserved_2          : 1;
+    uint8_t dev_type            : 3;
+    uint8_t reserved            : 4;
+#endif
     uint8_t reserved_3;
     uint8_t we_dont_care_2;
     uint8_t we_dont_care_3;
@@ -134,15 +158,30 @@ struct _ses_add_st_sas_phy {
  * SES-3 rev 11a Table 80 - Array Device Slot control element
  */
 struct _ses_ar_dev_ctrl {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t we_dont_care_0      : 7;
     uint8_t select              : 1;
-    uint8_t we_dont_care_1      : 8;
+    uint8_t we_dont_care_1;
     uint8_t we_dont_care_2      : 1;
     uint8_t rqst_ident          : 1;
     uint8_t we_dont_care_3      : 6;
     uint8_t we_dont_care_4      : 5;
     uint8_t rqst_fault          : 1;
     uint8_t we_dont_care_5      : 2;
+#else
+    uint8_t select              : 1;
+    uint8_t we_dont_care_0      : 7;
+
+    uint8_t we_dont_care_1;
+
+    uint8_t we_dont_care_3      : 6;
+    uint8_t rqst_ident          : 1;
+    uint8_t we_dont_care_2      : 1;
+
+    uint8_t we_dont_care_5      : 2;
+    uint8_t rqst_fault          : 1;
+    uint8_t we_dont_care_4      : 5;
+#endif
 };
 
 struct _ses_ctrl_diag_hdr {

--- a/c_binding/libses.h
+++ b/c_binding/libses.h
@@ -39,6 +39,7 @@
 struct _ses_dev_slot_status {
     uint8_t common_status;
     uint8_t diff_between_dev_slot_and_array_dev_slot;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t report              : 1;
     uint8_t ident               : 1;
     uint8_t rmv                 : 1;
@@ -47,6 +48,7 @@ struct _ses_dev_slot_status {
     uint8_t enc_bypass_a        : 1;
     uint8_t do_not_remove       : 1;
     uint8_t app_bypass_a        : 1;
+
     uint8_t dev_bypass_b        : 1;
     uint8_t dev_bypass_a        : 1;
     uint8_t bypass_b            : 1;
@@ -55,6 +57,25 @@ struct _ses_dev_slot_status {
     uint8_t fault_reqstd        : 1;
     uint8_t fault_sensed        : 1;
     uint8_t app_bypass_b        : 1;
+#else
+    uint8_t app_bypass_a        : 1;
+    uint8_t do_not_remove       : 1;
+    uint8_t enc_bypass_a        : 1;
+    uint8_t enc_bypass_b        : 1;
+    uint8_t ready_to_insert     : 1;
+    uint8_t rmv                 : 1;
+    uint8_t ident               : 1;
+    uint8_t report              : 1;
+
+    uint8_t app_bypass_b        : 1;
+    uint8_t fault_sensed        : 1;
+    uint8_t fault_reqstd        : 1;
+    uint8_t dev_off             : 1;
+    uint8_t bypass_a            : 1;
+    uint8_t bypass_b            : 1;
+    uint8_t dev_bypass_a        : 1;
+    uint8_t dev_bypass_b        : 1;
+#endif
 };
 #pragma pack(pop)
 

--- a/c_binding/libsg.c
+++ b/c_binding/libsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Red Hat, Inc.
+ * Copyright (C) 2016-2017 Red Hat, Inc.
  * (C) Copyright (C) 2017 Hewlett Packard Enterprise Development LP
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -138,15 +138,25 @@ const char * const _T10_SPC_SENSE_KEY_STR[] = {
  * SPC-5 rev 7 Table 589 - Device Identification VPD page
  */
 struct _sg_t10_vpd83_header {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t dev_type : 5;
     uint8_t qualifier : 3;
+#else
+    uint8_t qualifier : 3;
+    uint8_t dev_type : 5;
+#endif
     uint8_t page_code;
     uint16_t page_len_be;
 };
 
 struct _sg_t10_vpd80_header {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t dev_type : 5;
     uint8_t qualifier : 3;
+#else
+    uint8_t qualifier : 3;
+    uint8_t dev_type : 5;
+#endif
     uint8_t page_code;
     uint16_t page_len_be;
 };
@@ -160,19 +170,34 @@ struct _sg_t10_vpd00 {
 
 
 struct _sg_t10_sense_header {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t response_code : 7;
     uint8_t we_dont_care_0 : 1;
+#else
+    uint8_t we_dont_care_0 : 1;
+    uint8_t response_code : 7;
+#endif
 };
 
 /*
  * SPC-5 rev 7 Table 47 - Fixed format sense data
  */
 struct _sg_t10_sense_fixed {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t response_code : 7;
     uint8_t valid : 1;
+#else
+    uint8_t valid : 1;
+    uint8_t response_code : 7;
+#endif
     uint8_t obsolete;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t sense_key : 4;
     uint8_t we_dont_care_0 : 4;
+#else
+    uint8_t we_dont_care_0 : 4;
+    uint8_t sense_key : 4;
+#endif
     uint8_t we_dont_care_1[4];
     uint8_t len;
     uint8_t we_dont_care_2[4];
@@ -186,11 +211,21 @@ struct _sg_t10_sense_fixed {
  * with embedded ATA registers
  */
 struct _sg_t10_sense_ata_fixed {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t response_code : 7;
     uint8_t valid : 1;
+#else
+    uint8_t valid : 1;
+    uint8_t response_code : 7;
+#endif
     uint8_t obsolete;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t sense_key : 4;
     uint8_t we_dont_care_0 : 4;
+#else
+    uint8_t we_dont_care_0 : 4;
+    uint8_t sense_key : 4;
+#endif
     uint8_t error;
     uint8_t status;
     uint8_t device;
@@ -208,10 +243,17 @@ struct _sg_t10_sense_ata_fixed {
  * SPC-5 rev 7 Table 28 - Descriptor format sense data
  */
 struct _sg_t10_sense_dp {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t response_code : 7;
     uint8_t reserved : 1;
     uint8_t sense_key : 4;
     uint8_t we_dont_care_0 : 4;
+#else
+    uint8_t reserved : 1;
+    uint8_t response_code : 7;
+    uint8_t we_dont_care_0 : 4;
+    uint8_t sense_key : 4;
+#endif
     uint8_t asc;        /* ADDITIONAL SENSE CODE */
     uint8_t ascq;       /* ADDITIONAL SENSE CODE QUALIFIER */
     uint8_t we_dont_care_1[3];
@@ -227,8 +269,13 @@ struct _sg_t10_ata_status_return_dp_hdr {
 struct _sg_t10_ata_status_return_dp {
     uint8_t descriptor_code;
     uint8_t additional_desc_len;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t rsvd : 7;
     uint8_t extend : 1;
+#else
+    uint8_t extend : 1;
+    uint8_t rsvd : 7;
+#endif
     uint8_t error;
     uint8_t reserved_count;
     uint8_t count;
@@ -255,8 +302,13 @@ struct _sg_t10_log_para_hdr {
 
 struct _sg_t10_info_excep_mode_page_0_hdr {
     uint8_t dont_care[3];
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t reserved : 4;
     uint8_t mrie : 4;
+#else
+    uint8_t mrie : 4;
+    uint8_t reserved : 4;
+#endif
 };
 
 struct _sg_t10_info_excep_general_log_hdr {

--- a/c_binding/lsm_local_disk.c
+++ b/c_binding/lsm_local_disk.c
@@ -102,8 +102,13 @@ struct t10_sbc_vpd_bdc {
 
 struct t10_proto_port_mode_page_0_hdr {
     uint8_t we_dont_care_0[2];
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t protocol_id     : 4;
     uint8_t we_dont_care_1  : 4;
+#else
+    uint8_t we_dont_care_1  : 4;
+    uint8_t protocol_id     : 4;
+#endif
 };
 /* ^ SPC-5 rev12 Table 457 - Page_0 mode page format Protocol Specific Port mode
  *   page
@@ -111,8 +116,13 @@ struct t10_proto_port_mode_page_0_hdr {
 
 struct t10_proto_port_mode_sub_page_hdr {
     uint8_t we_dont_care_0[5];
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     uint8_t protocol_id     : 4;
     uint8_t we_dont_care_1  : 4;
+#else
+    uint8_t we_dont_care_1  : 4;
+    uint8_t protocol_id     : 4;
+#endif
 };
 /* ^ SPC-5 rev12 Table 458 - Sub_page mode page format Protocol Specific Port
  *   mode page


### PR DESCRIPTION
```
Issue:
    C local disks functions does not work on big-endian
    system(s390x/ppc64/arm/etc).

Root cause:
    Bit field has endian compatibility issue.
    https://stackoverflow.com/questions/6043483/why-bit-endianness-is-an-issue-in-bitfields

Fix:
    Use gcc macro to detect endianness and reorder the struct member
    sequence. It's also the way used by linux kernel tcp module:
        /usr/include/linux/tcp.h
```