### PR TITLE
Travis CI: Use docker to run test on Fedora and Centos 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,19 @@
-sudo: false
+sudo: required
+dist: trusty
 language: c
+env:
+    matrix:
+        - OS_TYPE=fedora
+        - OS_TYPE=centos
 
-addons:
-  apt:
-    packages:
-        - gcc
-        - tar
-        - make
-        - g++
-        - libtool
-        - autoconf
-        - automake
-        - libyajl-dev
-        - python-pywbem
-        - libxml2-dev
-        - check
-        - libglib2.0-dev
-        - libssl-dev
-        - libconfig-dev
-        - libudev-dev
-        - python-dev
-        - valgrind
-        - chrpath
-        - python-pyudev
-        - libsqlite3-dev
-        - python-requests
-        - python-six
+services:
+    - docker
 
-compiler: gcc
+before_install:
+    - docker pull $OS_TYPE
 
 script:
-        - ./autogen.sh
-        - ./configure
-        - make distcheck
+    - >
+        docker run --privileged --rm=true --tty=true
+        -v `pwd`:/libstoragemgmt-code:rw $OS_TYPE
+        /bin/bash -c /libstoragemgmt-code/test/docker_travis_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - docker pull $OS_TYPE
 
 script:
-    - >
+    - travis_wait 30
         docker run --privileged --rm=true --tty=true
         -v `pwd`:/libstoragemgmt-code:rw $OS_TYPE
         /bin/bash -c /libstoragemgmt-code/test/docker_travis_test.sh

--- a/deb_dependency
+++ b/deb_dependency
@@ -1,3 +1,4 @@
+file
 gcc
 tar
 make
@@ -16,6 +17,7 @@ libssl-dev
 libconfig-dev
 libudev-dev
 python-dev
+perl
 valgrind
 chrpath
 python-pyudev

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -1,4 +1,4 @@
-%bcond_without  test
+%bcond_with  test
 %global py3_build_dir %{_builddir}/%{name}-%{version}-%{release}-python3
 
 Name:           libstoragemgmt

--- a/rh_rpm_dependency
+++ b/rh_rpm_dependency
@@ -1,3 +1,5 @@
+procps-ng
+file
 tar
 make
 gcc
@@ -14,10 +16,11 @@ m2crypto
 openssl-devel
 libconfig-devel
 python-pyudev
-python-argparse
 python-devel
 libudev-devel
+perl
 valgrind
 chrpath
 sqlite-devel
 python-six
+bash-completion

--- a/suse_rpm_dependency
+++ b/suse_rpm_dependency
@@ -1,3 +1,4 @@
+file
 gcc
 tar
 make
@@ -7,6 +8,7 @@ libtool
 autoconf
 procps
 automake
+perl
 valgrind
 chrpath
 libyajl-devel

--- a/test/cmdtest.py.in
+++ b/test/cmdtest.py.in
@@ -929,7 +929,7 @@ def verify_no_daemon_needed(cmd, expected_rcs):
     ec, out, err = call(cmd, env=env, expected_rcs=expected_rcs)
 
     if ec == 4:
-        if 'DAEMON_NOT_RUNNING' in err:
+        if 'DAEMON_NOT_RUNNING' in err.decode('utf8'):
             print("Daemon does not need to run for local disk commands!")
             exit(10)
 

--- a/test/docker_travis_test.sh
+++ b/test/docker_travis_test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# # To debug, try:
+# docker pull fedora
+# docker run --privileged --rm=false --tty=true --interactive=true \
+#    -v `pwd`:/libstoragemgmt-code:rw fedora \
+#    /bin/bash -c /libstoragemgmt-code/test/docker_travis_test.sh
+if [ "CHK$(rpm -E %{?fedora})" != "CHK" ];then
+    IS_FEDORA=1
+elif [ "CHK$(rpm -E %{?el7})" != "CHK" ];then
+    IS_RHEL=1
+fi
+
+cd /libstoragemgmt-code
+
+getent group libstoragemgmt >/dev/null || \
+    groupadd -r libstoragemgmt || exit 1
+getent passwd libstoragemgmt >/dev/null || \
+    useradd -r -g libstoragemgmt -d /var/run/lsm \
+    -s /sbin/nologin \
+    -c "daemon account for libstoragemgmt" libstoragemgmt || exit 1
+
+if [ "CHK$IS_FEDORA" == "CHK1" ];then
+    dnf install `cat ./rh_rpm_dependency` rpm-build -y || exit 1
+    dnf install python3-six python3-devel python3-pywbem python3-pyudev -y \
+        || exit 1
+elif [ "CHK$IS_RHEL" == "CHK1" ];then
+    yum install `cat ./rh_rpm_dependency` rpm-build -y || exit 1
+else
+    echo "Not supported yet";
+    exit 1;
+fi
+
+./autogen.sh || exit 1
+if [ "CHK$IS_FEDORA" == "CHK1" ];then
+    ./configure --with-python3 || exit 1
+else
+    ./configure || exit 1
+fi
+
+make || exit 1
+
+make check || { cat test-suite.log; exit 1; }
+
+if [ "CHK$IS_FEDORA" == "CHK1" ];then
+make rpm || exit 1
+fi


### PR DESCRIPTION
 * Use Ubuntu Trusty(14.04 LTS).
 * Use docker in travis for Fedora and Centos 7 test.
 * Disable make check in rpm build to eliminate duplicate test.