### PR TITLE
C library: Switch from sg kernel module to bsg.

### DIFF
--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -1822,7 +1822,9 @@ class CmdLine(object):
                     info_dict[key] = func_dict[key](disk_path)
                 except LsmError as lsm_err:
                     if lsm_err.code != ErrorNumber.NO_SUPPORT:
-                        raise
+                        sys.stderr.write("WARN: %s('%s'): %d %s" %
+                                         (func_dict[key].__name__, disk_path,
+                                          lsm_err.code, lsm_err.msg))
 
             local_disks.append(
                 LocalDiskInfo(disk_path,


### PR DESCRIPTION
 * sg kernel module is not auto-loaded on some(RHEL/Centos 7)
   distribution, while bsg is mostly compiled(RHEL/Fedora/Ubuntu) into kernel.
   So, we use /dev/bsg/<htbl_id> instead of /dev/sgX for SES functions.

 * The bsg only support SG_IO v4(while sg only for V3), hence we have
   new function `_sg_io_v4()` for that.

 * Also ignore error of `lsmcli ldl`, fix issue #291.
