### PR TITLE
Travis CI: Do not specify trusty distribution.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: required
-dist: trusty
 language: c
 env:
     matrix:


### PR DESCRIPTION
It is now the default.

See: https://blog.travis-ci.com/2017-08-31-trusty-as-default-status.

Signed-off-by: mulhern <amulhern@redhat.com>