### PR TITLE
MegaRAID plugin: Use random temperate folder for log of storlci.

### DIFF
--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -19,6 +19,8 @@ import json
 import re
 import errno
 import math
+import tempfile
+import shutil
 
 from lsm import (uri_parse, search_property, size_human_2_size_bytes,
                  Capabilities, LsmError, ErrorNumber, System, Client,
@@ -333,6 +335,10 @@ class MegaRAID(IPlugin):
     def __init__(self):
         self._storcli_bin = None
         self._tmo_ms = 3000    # TODO(Gris Ge): Not implemented yet.
+        self._tmp_dir = tempfile.mkdtemp()
+
+    def __del__(self):
+        shutil.rmtree(self._tmp_dir)
 
     def _find_storcli(self):
         """
@@ -376,10 +382,10 @@ class MegaRAID(IPlugin):
                 "This plugin requires root privilege both daemon and client")
         uri_parsed = uri_parse(uri)
         self._storcli_bin = uri_parsed.get('parameters', {}).get('storcli')
-        # change working dir to "/tmp" as storcli will create a log file
+        # change working dir to tmp folder as storcli will create a log file
         # named as 'MegaSAS.log'.
 
-        os.chdir("/tmp")
+        os.chdir(self._tmp_dir)
         if self._storcli_bin:
             self._storcli_exec(['-v'], flag_json=False)
         else:


### PR DESCRIPTION
Background story is:
https://github.com/libstorage/libstoragemgmt/pull/307#issuecomment-332312221

This patch use random temperate folder to store the log of
storcli/perccli.

Signed-off-by: Gris Ge <fge@redhat.com>

tasleson: CI Kick