### PR TITLE
New error for delete when volume/fs has child dependency

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt.h
@@ -1007,8 +1007,12 @@ int LSM_DLL_EXPORT lsm_volume_replicate_range(lsm_connect *conn,
  *
  * Description:
  *      Deletes a volume/LUN and its data is lost!
- *      If specified volume is a replication source or is masked to any access
- *      group, it could be deleted.
+ *      If specified volume is masked to any access_group, it cannot be deleted.
+ *      You may use `lsm_access_groups_granted_to_volume()` and
+ *      `lsm_volume_unmask()` before `lsm_volume_delete()`.
+ *      If specified volume is has child dependency, it cannot be deleted.
+ *      You may use `lsm_volume_child_dependency()` and
+ *      `lsm_volume_child_dependency_delete()` before `lsm_volume_delete()`.
  *
  * Capability:
  *      LSM_CAP_VOLUME_DELETE
@@ -1040,6 +1044,8 @@ int LSM_DLL_EXPORT lsm_volume_replicate_range(lsm_connect *conn,
  *              Pool is not ready.
  *          * LSM_ERR_NO_SUPPORT
  *              Not supported.
+ *          * LSM_ERR_HAS_CHILD_DEPENDENCY
+ *              Specified volume has child dependencies.
  */
 int LSM_DLL_EXPORT lsm_volume_delete(lsm_connect *conn,
                                      lsm_volume *volume, char **job,
@@ -1838,6 +1844,12 @@ int LSM_DLL_EXPORT lsm_fs_create(lsm_connect *conn, lsm_pool * pool,
  *
  * Description:
  *      Deletes a file system and its data is lost!
+ *      When file system has snapshot attached, all its snapshot will be deleted
+ *      also.
+ *      When file system is exported, all its exports will be deleted also.
+ *      If specified file system is has child dependency, it cannot be deleted.
+ *      You may use `lsm_fs_child_dependency()` and
+ *      `lsm_fs_child_dependency_delete()` before `lsm_fs_delete()`.
  *
  * Capability:
  *      LSM_CAP_FS_DELETE
@@ -1869,6 +1881,8 @@ int LSM_DLL_EXPORT lsm_fs_create(lsm_connect *conn, lsm_pool * pool,
  *              Pool is not ready.
  *          * LSM_ERR_NO_SUPPORT
  *              Not supported.
+ *          * LSM_ERR_HAS_CHILD_DEPENDENCY
+ *              Specified volume has child dependencies.
  */
 int LSM_DLL_EXPORT lsm_fs_delete(lsm_connect *conn, lsm_fs *fs,
                                  char **job, lsm_flag flags);

--- a/c_binding/include/libstoragemgmt/libstoragemgmt_error.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_error.h
@@ -73,6 +73,9 @@ typedef enum {
     /** Volume masked to Access Group*/
     LSM_ERR_IS_MASKED = 160,
 
+    /** Volume/File system is replication source */
+    LSM_ERR_HAS_CHILD_DEPENDENCY = 161,
+
     /** Specified access group not found */
     LSM_ERR_NOT_FOUND_ACCESS_GROUP = 200,
 

--- a/plugin/nstor/nstor.py
+++ b/plugin/nstor/nstor.py
@@ -231,8 +231,10 @@ class NexentaStor(INfs, IStorageAreaNetwork):
 
     @handle_nstor_errors
     def fs_delete(self, fs, flags=0):
+        if self.fs_child_dependency(fs, None):
+            raise LsmError(ErrorNumber.HAS_CHILD_DEPENDENCY,
+                           "File system has child dependency")
         self._request("destroy", "folder", [fs.name, "-r"])
-        return
 
     @handle_nstor_errors
     def fs_snapshots(self, fs, flags=0):
@@ -587,6 +589,10 @@ class NexentaStor(INfs, IStorageAreaNetwork):
         if len(ag):
             raise LsmError(ErrorNumber.IS_MASKED,
                            "Volume is masked to access group")
+
+        if self.volume_child_dependency(volume):
+            raise LsmError(ErrorNumber.HAS_CHILD_DEPENDENCY,
+                           "Volume has child dependency")
 
         self._request("delete_lu", "scsidisk", [volume.id])
         self._request("destroy", "zvol", [volume.id, ''])

--- a/plugin/ontap/na.py
+++ b/plugin/ontap/na.py
@@ -202,6 +202,7 @@ class FilerError(Exception):
     EVDISK_ERROR_SIZE_TOO_SMALL = 9041      # Specified too small a size
     EVDISK_ERROR_SIZE_UNCHANGED = 9042      # requested size is the same.
     EVDISK_ERROR_INITGROUP_HAS_VDISK = 9023     # Already masked
+    EOP_DISALLOWED_ON_CLONE_PARENT = 15894  # NetApp volume is clone source.
 
     def __init__(self, errno, reason, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)

--- a/plugin/ontap/ontap.py
+++ b/plugin/ontap/ontap.py
@@ -704,11 +704,6 @@ class Ontap(IStorageAreaNetwork, INfs):
                            "volume_create(): "
                            "Got 2 or more na_vols: %s" % na_vols)
 
-    def _volume_on_aggr(self, pool, volume):
-        search = Ontap._vol_to_na_volume_name(volume)
-        contained_volumes = self.f.aggregate_volume_names(pool.name)
-        return search in contained_volumes
-
     @handle_ontap_errors
     def volume_replicate(self, pool, rep_type, volume_src, name, flags=0):
         # At the moment we are only supporting space efficient writeable
@@ -718,7 +713,7 @@ class Ontap(IStorageAreaNetwork, INfs):
 
         # Check to see if our volume is on a pool that was passed in or that
         # the pool itself is None
-        if pool is None or self._volume_on_aggr(pool, volume_src):
+        if pool is None or pool.id == volume_src.pool_id:
             # Thin provision copy the logical unit
             dest = os.path.dirname(_lsm_vol_to_na_vol_path(volume_src)) + '/' \
                 + name

--- a/plugin/ontap/ontap.py
+++ b/plugin/ontap/ontap.py
@@ -1019,7 +1019,16 @@ class Ontap(IStorageAreaNetwork, INfs):
 
     @handle_ontap_errors
     def fs_delete(self, fs, flags=0):
-        self.f.volume_delete(fs.name)
+        try:
+            self.f.volume_delete(fs.name)
+        except na.FilerError as fe:
+            if fe.errno == na.FilerError.EOP_DISALLOWED_ON_CLONE_PARENT:
+                raise LsmError(
+                    ErrorNumber.HAS_CHILD_DEPENDENCY,
+                    "Specified file system has child dependency "
+                    "(is source of clone)")
+            else:
+                raise
 
     @handle_ontap_errors
     def fs_resize(self, fs, new_size_bytes, flags=0):

--- a/plugin/sim/simarray.py
+++ b/plugin/sim/simarray.py
@@ -1314,8 +1314,8 @@ class BackStore(object):
                 if dst_sim_vol_id != sim_vol_id:
                     # Don't raise error on volume internal replication.
                     raise LsmError(
-                        ErrorNumber.PLUGIN_BUG,
-                        "Requested volume is a replication source")
+                        ErrorNumber.HAS_CHILD_DEPENDENCY,
+                        "Requested volume has child dependency")
         if sim_vol['is_hw_raid_vol']:
             # Reset disk roles
             for d in self._data_find('disks_view',
@@ -1603,23 +1603,9 @@ class BackStore(object):
     def sim_fs_delete(self, sim_fs_id):
         self.sim_fs_of_id(sim_fs_id)
         if self.clone_dst_sim_fs_ids_of_src(sim_fs_id):
-            # TODO(Gris Ge): API does not have dedicate error for this
-            #                scenario.
             raise LsmError(
-                ErrorNumber.PLUGIN_BUG,
-                "Requested file system is a clone source")
-
-        if self.sim_fs_snaps(sim_fs_id):
-            raise LsmError(
-                ErrorNumber.PLUGIN_BUG,
-                "Requested file system has snapshot attached")
-
-        if self._data_find('exps', 'fs_id="%s"' % sim_fs_id):
-            # TODO(Gris Ge): API does not have dedicate error for this
-            #                scenario
-            raise LsmError(
-                ErrorNumber.PLUGIN_BUG,
-                "Requested file system is exported via NFS")
+                ErrorNumber.HAS_CHILD_DEPENDENCY,
+                "Requested file system has child dependency")
 
         self._data_delete("fss", 'id="%s"' % sim_fs_id)
 

--- a/plugin/simc/san_ops.c
+++ b/plugin/simc/san_ops.c
@@ -334,9 +334,8 @@ int volume_delete(lsm_plugin_ptr c, lsm_volume *volume, char **job,
 
     _good(_db_sql_exec(err_msg, db, sql_cmd, &vec), rc, out);
     if (_vector_size(vec) != 0) {
-        rc = LSM_ERR_PLUGIN_BUG;
-        /* We don't have error number for this yet */
-        _lsm_err_msg_set(err_msg, "Specified volume is replication source");
+        rc = LSM_ERR_HAS_CHILD_DEPENDENCY;
+        _lsm_err_msg_set(err_msg, "Specified volume has child dependency");
         goto out;
     }
 

--- a/python_binding/lsm/_common.py
+++ b/python_binding/lsm/_common.py
@@ -469,6 +469,7 @@ class ErrorNumber(object):
 
     # Deletion related errors
     IS_MASKED = 160             # Volume is masked to access group.
+    HAS_CHILD_DEPENDENCY = 161  # Volume/File system has child dependency.
 
     NOT_FOUND_ACCESS_GROUP = 200
     NOT_FOUND_FS = 201

--- a/test/plugin_test.py.in
+++ b/test/plugin_test.py.in
@@ -142,6 +142,7 @@ class TestProxy(object):
                    lsm.ErrorNumber.NAME_CONFLICT,
                    lsm.ErrorNumber.NO_STATE_CHANGE,
                    lsm.ErrorNumber.IS_MASKED,
+                   lsm.ErrorNumber.HAS_CHILD_DEPENDENCY,
                    lsm.ErrorNumber.EXISTS_INITIATOR]
 
     # Hash of all calls that can be async
@@ -1305,6 +1306,80 @@ class TestPlugin(unittest.TestCase):
                         self.c.volume_delete(vol)
 
                     self.c.access_group_delete(ag)
+
+
+    def test_volume_delete_with_replication(self):
+        for s in self.systems:
+            cap = self.c.capabilities(s)
+            if supported(cap, [Cap.VOLUME_REPLICATE_CLONE,
+                               Cap.VOLUME_CHILD_DEPENDENCY,
+                               Cap.VOLUME_CREATE,
+                               Cap.VOLUME_DELETE]):
+                pool = self._get_pool_by_usage(s.id,
+                                               lsm.Pool.ELEMENT_TYPE_VOLUME)
+                if pool:
+                    vol_size = self._min_size()
+
+                    vol = self.c.volume_create(
+                        pool, rs('v'), vol_size,
+                        lsm.Volume.PROVISION_DEFAULT)[1]
+
+                    clone_vol = self.c.volume_replicate(
+                        pool, lsm.Volume.REPLICATE_CLONE, vol,
+                        rs('test_vd_with_repo_'))[1]
+
+                    if self.c.volume_child_dependency(vol):
+                        got_exception = False
+                        try:
+                            self.c.volume_delete(vol)
+                        except LsmError as le:
+                            if le.code == lsm.ErrorNumber.HAS_CHILD_DEPENDENCY:
+                                got_exception = True
+                            self.assertTrue(
+                                le.code == lsm.ErrorNumber.HAS_CHILD_DEPENDENCY)
+
+                        self.assertTrue(got_exception)
+
+                    # Clean up
+                    self.c.volume_delete(clone_vol)
+                    self.c.volume_delete(vol)
+            else:
+                self._skip_current_test(
+                    "Skip test: current system does not support "
+                    "volume_create() or volume_replicate() with CLONE "
+                    "or volume_delete()")
+
+
+    def test_fs_delete_with_clone(self):
+        for s in self.systems:
+            cap = self.c.capabilities(s)
+
+            if supported(cap, [Cap.FS_CREATE, Cap.FS_CLONE, Cap.FS_DELETE,
+                               Cap.FS_CHILD_DEPENDENCY]):
+                fs, pool = self._fs_create(s.id)
+                self.assertTrue(fs is not None)
+                fs_child = self.c.fs_clone(fs, rs('fs_c_'))[1]
+                if self.c.fs_child_dependency(fs, None):
+                    got_exception = False
+                    try:
+                        self.c.fs_delete(fs)
+                    except LsmError as le:
+                        if le.code == lsm.ErrorNumber.HAS_CHILD_DEPENDENCY:
+                            got_exception = True
+                        self.assertTrue(le.code ==
+                                        lsm.ErrorNumber.HAS_CHILD_DEPENDENCY)
+
+
+                    self.assertTrue(got_exception)
+
+                # Clean up
+                self.c.fs_delete(fs_child)
+                self.c.fs_delete(fs)
+            else:
+                self._skip_current_test(
+                    "Skip test: current system does not support "
+                    "fs_create() or fs_clone() or fs_delete()")
+
 
     def test_volume_vpd83_verify(self):
 


### PR DESCRIPTION
 * New error for volume_delete()/fs_delete() when specified volume/fs ~~is~~
   ~~replication source~~ has child dependency.
    * C:        `LSM_ERR_HAS_CHILD_DEPENDENCY`
    * Python:   `lsm.ErrorNumber.HAS_CHILD_DEPENDENCY`

 * Both simc and sim plugins are respecting this error now.

 * Manpage of C API updated for this error.

     * ONTAP plugin are respecting this error for fs_delete(). For
       volume_delete(), it does not have child dependency, hence no error
       will be raised.

 * Add test case into plugin_test.py for this new error.