### PR TITLE
LocalDisk: Fix incorrect VPD query for 0x89 and 0xb1.

### DIFF
--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -1827,7 +1827,7 @@ class CmdLine(object):
                     info_dict[key] = func_dict[key](disk_path)
                 except LsmError as lsm_err:
                     if lsm_err.code != ErrorNumber.NO_SUPPORT:
-                        sys.stderr.write("WARN: %s('%s'): %d %s" %
+                        sys.stderr.write("WARN: %s('%s'): %d %s\n" %
                                          (func_dict[key].__name__, disk_path,
                                           lsm_err.code, lsm_err.msg))
 


### PR DESCRIPTION
Bug:    https://bugzilla.redhat.com/show_bug.cgi?id=1501367

Root cause:
```
    Incorrect data size for VPD 0x89(ATA information).
    The SPEC only allows 572(0x023c) bytes, we are requesting 0xffff
    bytes.
```

Fix:
```
    Change _sg_io_vpd() to set correct output data buffer size for
    page 0x89(ATA infomation) and 0xb1(Block Device Characteristics).
```

CI Kick

Also add newline to every warning message of lsmcli on stderr.