### PR TITLE
[WIP] Fix gcc warnings on gcc 8.

### DIFF
--- a/c_binding/libsg.c
+++ b/c_binding/libsg.c
@@ -20,6 +20,11 @@
 /* For strerror_r() */
 #define _GNU_SOURCE
 
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+/* gcc is warning _check_sense_data() might be truncated due to print err_msg
+ * into another err_msg , that's expected.
+ */
+
 #include "libsg.h"
 #include "utils.h"
 

--- a/plugin/simc/db.c
+++ b/plugin/simc/db.c
@@ -768,7 +768,7 @@ void _db_sql_trans_rollback(sqlite3 *db)
 int _db_data_add(char *err_msg, sqlite3 *db, const char *table_name, ...)
 {
     int rc = LSM_ERR_OK;
-    char sql_cmd[_BUFF_SIZE];
+    char sql_cmd[_BUFF_SIZE * 4];
     char keys_str[_BUFF_SIZE];
     char values_str[_BUFF_SIZE];
     const char *key_str = NULL;
@@ -809,9 +809,9 @@ int _db_data_add(char *err_msg, sqlite3 *db, const char *table_name, ...)
     keys_str[keys_printed - strlen(", ") + 1] = '\0';
     values_str[values_printed - strlen(", ") + 1] = '\0';
 
-    _snprintf_buff(err_msg, rc, out, sql_cmd,
-                   "INSERT INTO %s (%s) VALUES (%s);", table_name, keys_str,
-                   values_str);
+    snprintf(sql_cmd, sizeof(sql_cmd)/sizeof(char),
+             "INSERT INTO %s (%s) VALUES (%s);", table_name, keys_str,
+             values_str);
 
     _good(_db_sql_exec(err_msg, db, sql_cmd,
                        NULL /* no need to parse output */),

--- a/plugin/simc/mgm_ops.c
+++ b/plugin/simc/mgm_ops.c
@@ -26,6 +26,8 @@
 
 #include <libstoragemgmt/libstoragemgmt_plug_interface.h>
 
+#define _TIME_STAMP_BUFF_LEN                            64
+
 #include "utils.h"
 #include "db.h"
 #include "san_ops.h"
@@ -109,10 +111,10 @@ static const char *time_stamp_str_get(char *buff)
 
     assert(buff != NULL);
 
-    memset(buff, 0, _BUFF_SIZE);
+    memset(buff, 0, _TIME_STAMP_BUFF_LEN);
 
     if (clock_gettime(CLOCK_REALTIME, &ts) == 0)
-        snprintf(buff, _BUFF_SIZE, "%ld.%ld", (long) difftime(ts.tv_sec, 0),
+        snprintf(buff, _TIME_STAMP_BUFF_LEN, "%ld.%ld", (long) difftime(ts.tv_sec, 0),
                  ts.tv_nsec);
 
     return buff;
@@ -318,7 +320,7 @@ int job_status(lsm_plugin_ptr c, const char *job, lsm_job_status *status,
     uint64_t sim_data_id = 0;
     lsm_hash *sim_data = NULL;
     const char *time_stamp_str = NULL;
-    char cur_time_stamp_str[_BUFF_SIZE];
+    char cur_time_stamp_str[_TIME_STAMP_BUFF_LEN];
     double job_start_time = 0;
     double cur_time = 0;
     uint64_t duration = 0;
@@ -544,7 +546,7 @@ int _job_create(char *err_msg, sqlite3 *db, lsm_data_type data_type,
 {
     int rc = LSM_ERR_OK;
     char *duration = NULL;
-    char time_stamp_str[_BUFF_SIZE];
+    char time_stamp_str[_TIME_STAMP_BUFF_LEN];
     char data_type_str[_BUFF_SIZE];
     char sim_id_str[_BUFF_SIZE];
     char job_id_str[_BUFF_SIZE];

--- a/plugin/simc/nfs_ops.c
+++ b/plugin/simc/nfs_ops.c
@@ -159,7 +159,7 @@ int nfs_export_fs(lsm_plugin_ptr c, const char *fs_id, const char *export_path,
     uint64_t sim_fs_id = 0;
     uint64_t sim_exp_id = 0;
     char tmp_export_path[_BUFF_SIZE];
-    char vpd83[_BUFF_SIZE];
+    char vpd83[_VPD_83_LEN];
 
     _UNUSED(flags);
     _lsm_err_msg_clear(err_msg);

--- a/plugin/simc/san_ops.c
+++ b/plugin/simc/san_ops.c
@@ -1111,7 +1111,7 @@ int volume_unmask(lsm_plugin_ptr c, lsm_access_group *group, lsm_volume *volume,
     char err_msg[_LSM_ERR_MSG_LEN];
     char condition[_BUFF_SIZE];
     struct _vector *vec = NULL;
-    char sql_cmd_check_mask[_BUFF_SIZE];
+    char sql_cmd_check_mask[_BUFF_SIZE * 2];
 
      _UNUSED(flags);
     _lsm_err_msg_clear(err_msg);
@@ -1131,8 +1131,8 @@ int volume_unmask(lsm_plugin_ptr c, lsm_access_group *group, lsm_volume *volume,
                    _db_lsm_id_to_sim_id_str(lsm_access_group_id_get(group)),
                    _db_lsm_id_to_sim_id_str(lsm_volume_id_get(volume)));
 
-    _snprintf_buff(err_msg, rc, out, sql_cmd_check_mask, "SELECT * FROM "
-                   _DB_TABLE_VOL_MASKS " WHERE %s;", condition);
+    snprintf(sql_cmd_check_mask, sizeof(sql_cmd_check_mask)/sizeof(char),
+             "SELECT * FROM " _DB_TABLE_VOL_MASKS " WHERE %s;", condition);
 
     _good(_db_sql_exec(err_msg, db, sql_cmd_check_mask, &vec), rc, out);
 

--- a/python_binding/lsm/_clib.c
+++ b/python_binding/lsm/_clib.c
@@ -17,6 +17,13 @@
  * Author: Gris Ge <fge@redhat.com>
  */
 
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+/* ^ This is caused by PyMethodDef is using PyCFunction, but
+ * actually is using PyCFunctionWithKeywords when METH_VARARGS | METH_KEYWORDS.
+ * suspend this gcc warnning.
+ */
+
+
 #include <Python.h>
 #include <stdint.h>
 #include <stdbool.h>


### PR DESCRIPTION
**PLACE HOLDER, GCC 8 NOT RELEASED YET, DON'T COMMIT**

* Just fix the compiling issue on gcc 8.0 of Fedora rawhide (F28).

 * Fix the gcc warnings of gcc 8 on:
    * truncated snprintf():
        Fixed by change the buffer size.
    * function prototype miss match in python c externtion:
        Tell gcc to ignore this as it's python's design choice.