### PR TITLE
Filesystem Hierarchy Standard: Move tools to /usr/libexec/lsm.d folder.

### DIFF
--- a/debian/libstoragemgmt-tools.install
+++ b/debian/libstoragemgmt-tools.install
@@ -1,4 +1,4 @@
 usr/bin/lsmcli
 usr/share/man/man1/lsmcli.1
-usr/bin/lsm.d/find_unused_lun.py
-usr/bin/lsm.d/local_sanity_check.py
+usr/libexec/lsm.d/find_unused_lun.py
+usr/libexec/lsm.d/local_sanity_check.py

--- a/debian/python-libstoragemgmt.install
+++ b/debian/python-libstoragemgmt.install
@@ -2,3 +2,4 @@ usr/lib/python*/dist-packages/lsm/*.py
 usr/lib/python*/dist-packages/lsm/*.pyc
 usr/lib/python*/dist-packages/lsm/_clib.so
 usr/lib/python*/dist-packages/lsm/lsmcli/*.py
+usr/libexec/lsm.d/*.py

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -524,9 +524,9 @@ fi
 %{python3_sitelib}/lsm/lsmcli/data_display.*
 %{python3_sitelib}/lsm/lsmcli/cmdline.*
 %{_bindir}/sim_lsmplugin
-%dir %{_bindir}/lsm.d
-%{_bindir}/lsm.d/find_unused_lun.py
-%{_bindir}/lsm.d/local_sanity_check.py
+%dir %{_libexecdir}/lsm.d
+%{_libexecdir}/lsm.d/find_unused_lun.py*
+%{_libexecdir}/lsm.d/local_sanity_check.py*
 %{_sysconfdir}/lsm/pluginconf.d/sim.conf
 %{_mandir}/man1/sim_lsmplugin.1*
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -4,5 +4,5 @@ SUBDIRS = lsmcli udev utility bash_completion
 
 EXTRA_DIST=use_cases/find_unused_lun.py
 
-lsm_bindir=$(bindir)/lsm.d
+lsm_bindir=$(libexecdir)/lsm.d
 lsm_bin_DATA=sanity_check/local_sanity_check.py use_cases/find_unused_lun.py


### PR DESCRIPTION
According to Filesystem Hierarchy Standard(FHS) 3.0:
http://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.pdf

Section 4.4.2. Requirements:
`There must be no subdirectories in /usr/bin.`

Moved user case and sanity check tools to '/usr/libexec/lsm.d' folder
as that is suggested by FHS and Fedora.