### PR TITLE
C API: Add lsm_access_group_init_type_get

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt_accessgroups.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_accessgroups.h
@@ -176,6 +176,25 @@ const char LSM_DLL_EXPORT *
 lsm_string_list LSM_DLL_EXPORT *
     lsm_access_group_initiator_id_get(lsm_access_group * group);
 
+/**
+ * lsm_access_group_init_type_get - Retrieves the initiator type for specified
+ * access group.
+ *
+ * Version:
+ *      1.7
+ *
+ * Description:
+ *      Retrieves the initiator type for the specified access group.
+ *
+ * @group:
+ *      Access group to retrieve type of initiators present.
+ *
+ * Return: lsm_access_group_init_type
+ *
+ */
+lsm_access_group_init_type LSM_DLL_EXPORT
+    lsm_access_group_init_type_get(lsm_access_group * group);
+
 
 #ifdef  __cplusplus
 }

--- a/c_binding/lsm_datatypes.cpp
+++ b/c_binding/lsm_datatypes.cpp
@@ -1100,6 +1100,10 @@ MEMBER_FUNC_GET(const char *, lsm_access_group, LSM_IS_ACCESS_GROUP, name,
 MEMBER_FUNC_GET(const char *, lsm_access_group, LSM_IS_ACCESS_GROUP, system_id,
                 NULL);
 
+MEMBER_FUNC_GET(lsm_access_group_init_type, lsm_access_group,
+                LSM_IS_ACCESS_GROUP, init_type,
+                LSM_ACCESS_GROUP_INIT_TYPE_UNKNOWN);
+
 lsm_string_list *lsm_access_group_initiator_id_get(lsm_access_group * group)
 {
     if (LSM_IS_ACCESS_GROUP(group)) {

--- a/test/tester.c
+++ b/test/tester.c
@@ -683,12 +683,14 @@ START_TEST(test_access_groups)
         fail_unless(NULL != lsm_access_group_id_get(group));
         fail_unless(NULL != lsm_access_group_name_get(group));
         fail_unless(NULL != lsm_access_group_system_id_get(group));
+        fail_unless(LSM_ACCESS_GROUP_INIT_TYPE_ISCSI_IQN == lsm_access_group_init_type_get(group));
 
         lsm_access_group *copy = lsm_access_group_record_copy(group);
         if( copy ) {
             fail_unless( strcmp(lsm_access_group_id_get(group), lsm_access_group_id_get(copy)) == 0);
             fail_unless( strcmp(lsm_access_group_name_get(group), lsm_access_group_name_get(copy)) == 0) ;
             fail_unless( strcmp(lsm_access_group_system_id_get(group), lsm_access_group_system_id_get(copy)) == 0);
+            fail_unless( lsm_access_group_init_type_get(group) == lsm_access_group_init_type_get(copy));
 
             G(rc, lsm_access_group_record_free, copy);
             copy = NULL;


### PR DESCRIPTION
This data was always available, just not exposed in C API.  It
was available in python API.

Signed-off-by: Tony Asleson <tasleson@redhat.com>

Fixes: https://github.com/libstorage/libstoragemgmt/issues/320