### PR TITLE
New release: 1.7.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl Copyright (C) 2011-2016 Red Hat, Inc.
 dnl See COPYING.LIB for the License of this software
 
 AC_INIT(
-    [libstoragemgmt], [1.6.2], [libstoragemgmt-devel@lists.fedorahosted.org],
+    [libstoragemgmt], [1.7.0], [libstoragemgmt-devel@lists.fedorahosted.org],
     [], [https://github.com/libstorage/libstoragemgmt/])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
Changes:
  * Replace yajl with nlohmann/json for JSON handling.
  * Bug fixes:
    - Fix the file path of lsmd.conf manpage.
    - HPSA plugin: Support ssacli version 3.25+.
    - Filesystem Hierarchy Standard: Move tools to
          /usr/libexec/lsm.d folder.
    - scan-scsi-target: Fix compiling on gcc 8.2.
    - Fix lsmcli on python 3.7.
    - Handle 'Warning:' message in hpsa plugin
  * Enhancements
    - Add configure options for not including specified plugins
    - Add lsm_access_group_init_type_get to C API

Signed-off-by: Tony Asleson <tasleson@redhat.com>