### PR TITLE
Update json.hpp for GCC 4.8 support

### DIFF
--- a/c_binding/json.hpp
+++ b/c_binding/json.hpp
@@ -123,7 +123,7 @@ using json = basic_json<>;
         #error "unsupported Clang version - see https://github.com/nlohmann/json#supported-compilers"
     #endif
 #elif defined(__GNUC__) && !(defined(__ICC) || defined(__INTEL_COMPILER))
-    #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
+    #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40800
         #error "unsupported GCC version - see https://github.com/nlohmann/json#supported-compilers"
     #endif
 #endif


### PR DESCRIPTION
On RHEL 7.6 with GCC 'gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-36)' make command fails with "./json.hpp:127:10: error: #error "unsupported GCC version - see https://github.com/nlohmann/json#supported-compilers"" error.
changed gcc version check condition from 40900 to 40800