### PR TITLE
Make nfs-plugin rpm require nfs-utils as per bz 1657407

### DIFF
--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -217,6 +217,7 @@ Summary:        Files for NFS local filesystem support for %{name}
 Group:          System Environment/Libraries
 Requires:       python3-%{name} = %{version}
 Requires:       %{name}-nfs-plugin-clibs = %{version}
+Requires:       nfs-utils
 Requires(post): python3-%{name} = %{version}
 Requires(postun): python3-%{name} = %{version}
 BuildArch:      noarch


### PR DESCRIPTION
The plugin requires the /etc/exports.d directory that nfs-utils provides, it also requires the exportfs command provided by that package.