### PR TITLE
Patch for Arcconf plugin

### DIFF
--- a/c_binding/json.hpp
+++ b/c_binding/json.hpp
@@ -123,7 +123,7 @@ using json = basic_json<>;
         #error "unsupported Clang version - see https://github.com/nlohmann/json#supported-compilers"
     #endif
 #elif defined(__GNUC__) && !(defined(__ICC) || defined(__INTEL_COMPILER))
-    #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
+    #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40800
         #error "unsupported GCC version - see https://github.com/nlohmann/json#supported-compilers"
     #endif
 #endif


### PR DESCRIPTION
Fix for below commands/APIs
arcconf:// list --type systems
arcconf:// list --type volumes
arcconf:// list --type pools
arcconf:// list --type disks
arcconf:// volume-delete --vol <id>
arcconf:// volume-raid-create --name <name> --disk <id> --raid-type <RAID TYPE>

support for below commands/APIs
cmd: lsmcli -u arcconf:// volume-raid-info --vol
cmd: lsmcli -u arcconf:// pool-member-info --pool
cmd: lsmcli -u arcconf:// volume-enable --vol
cmd: lsmcli -u arcconf:// volume-ident-led-on --vol
cmd: lsmcli -u arcconf:// volume-ident-led-off --vol
cmd: lsmcli -u arcconf:// list --type batteries