### PR TITLE
man: Remove SNAPSHOTS from optional --sys constraint

### DIFF
--- a/doc/man/lsmcli.1.in
+++ b/doc/man/lsmcli.1.in
@@ -157,9 +157,10 @@ Required. Valid values are (case insensitive):
 
 .TP
 \fB--fs\fR \fI<FS_ID>\fR
-Required for \fB--type\fR=\fBSNAPSHOTS\fR, list the snapshots of certain
+Required for \fB--type\fR=\fBSNAPSHOTS\fR, list the snapshots of specific
 filesystem.
-Optional for type \fBEXPORTS\fR, list the NFS export for certain filesystem.
+Optional for type \fBEXPORTS\fR, list the NFS export for specific filesystem.
+Optional for type \fBFS\fR, list specific filesystem.
 .TP
 \fB--sys\fR \fI<SYS_ID>\fR
 Optional.
@@ -364,7 +365,7 @@ Required. The ID of volume to query access.
 
 .SS volume-mask
 .TP 15
-Grant access group RW access to certain volume. Like LUN masking
+Grant access group RW access to specific volume. Like LUN masking
 or NFS export.
 .TP
 \fB--vol\fR \fI<VOL_ID>\fR
@@ -646,7 +647,7 @@ Query RAM cache information for the desired volume.
 Required. ID of the volume to query cache information.
 
 .SS volume-phy-disk-cache-update
-Disable or enable RAM physical disk cache of certain volume.
+Disable or enable RAM physical disk cache of specific volume.
 .TP 15
 \fB--vol\fR \fI<VOL_ID>\fR
 Required. ID of the volume to change.
@@ -655,7 +656,7 @@ Required. ID of the volume to change.
 Required. \fBEnable\fR or \fBDisable\fR.
 
 .SS volume-read-cache-policy-update
-Disable or enable RAM read cache of certain volume.
+Disable or enable RAM read cache of specific volume.
 .TP 15
 \fB--vol\fR \fI<VOL_ID>\fR
 Required. ID of the volume to change.

--- a/doc/man/lsmcli.1.in
+++ b/doc/man/lsmcli.1.in
@@ -165,7 +165,7 @@ Optional for type \fBEXPORTS\fR, list the NFS export for certain filesystem.
 Optional.
 Search resources from system with SYS_ID. Only supported when querying these
 types of resources: \fBVOLUMES\fR, \fBPOOLS\fR, \fBFS\fR,
-\fBSNAPSHOTS\fR, \fBDISKS\fR, \fBACCESS_GROUPS\fR, \fBTARGET_PORTS\r,
+\fBDISKS\fR, \fBACCESS_GROUPS\fR, \fBTARGET_PORTS\r,
 \fBBATTERIES\fR.
 .TP
 \fB--pool\fR \fI<POOL_ID>\fR

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -422,21 +422,34 @@ size_help = 'Can use B, KiB, MiB, GiB, TiB, PiB postfix (IEC sizing)'
 
 sys_id_opt = dict(name='--sys', metavar='<SYS_ID>', help='System ID')
 sys_id_filter_opt = sys_id_opt.copy()
-sys_id_filter_opt['help'] = 'Search by System ID'
+sys_id_filter_opt['help'] = \
+    'Search by System ID. Only supported for: \n' \
+    '(VOLUMES, POOLS, FS, DISKS, ACCESS_GROUPS,\n' \
+    'TARGET_PORTS, BATTERIES)'
 
 pool_id_opt = dict(name='--pool', metavar='<POOL_ID>', help='Pool ID')
 pool_id_filter_opt = pool_id_opt.copy()
-pool_id_filter_opt['help'] = 'Search by Pool ID'
+pool_id_filter_opt['help'] = \
+    'Search by Pool ID. Only supported for:\n' \
+    '(VOLUMES, POOLS, FS)'
 
 vol_id_opt = dict(name='--vol', metavar='<VOL_ID>', help='Volume ID')
 vol_id_filter_opt = vol_id_opt.copy()
-vol_id_filter_opt['help'] = 'Search by Volume ID'
+vol_id_filter_opt['help'] = \
+    'Search by Volume ID. Only supported for:\n' \
+    '(VOLUMES, ACCESS_GROUPS)'
 
 fs_id_opt = dict(name='--fs', metavar='<FS_ID>', help='File System ID')
+fs_id_filter_opt = fs_id_opt.copy()
+fs_id_filter_opt['help'] = \
+    'Search by FS ID. Only supported for:\n' \
+    '(FS, SNAPSHOTS, EXPORTS)'
 
 ag_id_opt = dict(name='--ag', metavar='<AG_ID>', help='Access Group ID')
 ag_id_filter_opt = ag_id_opt.copy()
-ag_id_filter_opt['help'] = 'Search by Access Group ID'
+ag_id_filter_opt['help'] = \
+    'Search by Access Group ID. Only supported for:\n' \
+    '(ACCESS_GROUPS, VOLUMES)'
 
 init_id_opt = dict(name='--init', metavar='<INIT_ID>', help='Initiator ID',
                    type=_check_init)
@@ -445,15 +458,19 @@ export_id_opt = dict(name='--export', metavar='<EXPORT_ID>', help='Export ID')
 
 nfs_export_id_filter_opt = dict(
     name='--nfs-export', metavar='<NFS_EXPORT_ID>',
-    help='Search by NFS Export ID')
+    help=
+    'Search by NFS Export ID. Only supported for:\n'
+    '(EXPORTS)')
 
 disk_id_filter_opt = dict(name='--disk', metavar='<DISK_ID>',
-                          help='Search by Disk ID')
+                          help='Search by Disk ID. Only supported for:\n'
+                               '(DISKS)')
 
 size_opt = dict(name='--size', metavar='<SIZE>', help=size_help)
 
-tgt_id_opt = dict(name="--tgt", help="Search by target port ID",
-                  metavar='<TGT_ID>')
+tgt_id_filter_opt = dict(name="--tgt", metavar='<TGT_ID>',
+                         help="Search by target port ID.  Only supported for:\n"
+                              "(TARGET_PORTS)")
 
 local_disk_path_opt = dict(name='--path', help="Local disk path",
                            metavar='<DISK_PATH>')
@@ -477,9 +494,9 @@ cmds = (
             dict(vol_id_filter_opt),
             dict(disk_id_filter_opt),
             dict(ag_id_filter_opt),
-            dict(fs_id_opt),
+            dict(fs_id_filter_opt),
             dict(nfs_export_id_filter_opt),
-            dict(tgt_id_opt),
+            dict(tgt_id_filter_opt),
         ],
     ),
 


### PR DESCRIPTION
When a user lists snapshots it is required that they supply a
filesystem.  A filesystem is specific to a given system, thus
allowing the user to constrain the search to a specific system
with --sys <sys_id> is redundant.

Signed-off-by: Tony Asleson <tasleson@redhat.com>

CI redo