### PR TITLE
megaraid: avoid INVALID_ARGUMENT error when disk WNN is NA

### DIFF
--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -609,6 +609,8 @@ class MegaRAID(IPlugin):
                 plugin_data = "%s:%s" % (
                     ctrl_num, disk_show_basic_dict['EID:Slt'])
                 vpd83 = disk_show_attr_dict["WWN"].lower()
+                if vpd83 == 'na':
+                    vpd = ''
                 rpm = _disk_rpm_of(disk_show_basic_dict)
                 link_type = _disk_link_type_of(disk_show_basic_dict)
 


### PR DESCRIPTION
Old MegaRAID cards can show disks with WWN==NA. It causes INVALID_ARGUMENT like below:

$ export LSMCLI_URI=megaraid://
$ sudo -E lsmcli ld
INVALID_ARGUMENT(101): Incorrect format of VPD 0x83 NAA(3) string: 'na', expecting 32 or 16 lower case hex characters

This patch overwrites VPD 0x83 value with an empty string if it has 'NA'.