### PR TITLE
debian: fix duplicate files in packages

### DIFF
--- a/debian/libstoragemgmt-tools.install
+++ b/debian/libstoragemgmt-tools.install
@@ -1,4 +1,2 @@
 usr/bin/lsmcli
 usr/share/man/man1/lsmcli.1
-usr/libexec/lsm.d/find_unused_lun.py
-usr/libexec/lsm.d/local_sanity_check.py


### PR DESCRIPTION
/usr/libexec/lsm.d/*.py was included in both python-libstoragemgmt and libstoragemgmt-tools, removing from libstoremgmt-tools as it depends on python-libstoragemgmt.