### PR TITLE
System id update in disks function

### DIFF
--- a/plugin/arcconf/arcconf.py
+++ b/plugin/arcconf/arcconf.py
@@ -582,7 +582,7 @@ class Arcconf(IPlugin):
         cntrl = 0
 
         for decoded_json in getconfig_cntrls_info:
-            sys_id = cntrl + 1
+            sys_id = decoded_json['Controller']['serialNumber']
             cntrl_num = int(cntrl + 1)
             cntrl += 1
 


### PR DESCRIPTION
As part of https://github.com/libstorage/libstoragemgmt/issues/374 . system id in disks was left out in previous PR.