### PR TITLE
lsmd: optimization when execute lsmd help generate a process

### DIFF
--- a/daemon/lsm_daemon.c
+++ b/daemon/lsm_daemon.c
@@ -846,7 +846,7 @@ int main(int argc, char *argv[])
 
         case 'h':
             usage();
-            break;
+            return EXIT_SUCCESS;
 
         case 'v':
             verbose_flag = 1;


### PR DESCRIPTION
Execute lsmd --help every time, The command will generate a process.
As a help I think that should not produce a process.

[root@localhost ~]# lsmd --help
libStorageMgmt plug-in daemon.
lsmd [--plugindir <directory>] [--socketdir <dir>] [-v] [-d]
     --plugindir = The directory where the plugins are located
     --socketdir = The directory where the Unix domain sockets will be created
     --confdir   = The directory where the config files are located
     -v          = Verbose logging
     -d          = New style daemon (systemd)

[root@localhost ~]# ps -ef | grep lsmd
libstor+  3854     1  0 Oct21 ?        00:00:02 /usr/bin/lsmd -d
libstor+  6112     1  0 21:18 ?        00:00:00 lsmd --help
libstor+  6305     1  0 21:18 ?        00:00:00 lsmd --help
libstor+  6340     1  0 21:18 ?        00:00:00 lsmd --help
libstor+  6373     1  0 21:18 ?        00:00:00 lsmd --help

Optimization is modified as follows:
Return EXIT_SUCCESS when executing lsmd --help

Signed-off-by: Bo wu <wubo40@huawei.com>
Reviewed-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>