### PR TITLE
megaraid: correctly override vpd83 when WWN is NA

### DIFF
--- a/plugin/megaraid/megaraid.py
+++ b/plugin/megaraid/megaraid.py
@@ -610,7 +610,7 @@ class MegaRAID(IPlugin):
                     ctrl_num, disk_show_basic_dict['EID:Slt'])
                 vpd83 = disk_show_attr_dict["WWN"].lower()
                 if vpd83 == 'na':
-                    vpd = ''
+                    vpd83 = ''
                 rpm = _disk_rpm_of(disk_show_basic_dict)
                 link_type = _disk_link_type_of(disk_show_basic_dict)
 


### PR DESCRIPTION
this fixes a small bug in the implementation of #375