### PR TITLE
travis: Remove ubuntu:latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
         - OS_TYPE=centos:8
         - OS_TYPE=centos:7
         - OS_TYPE=centos:6
-        - OS_TYPE=ubuntu:latest
         - OS_TYPE=ubuntu:18.04
 
 services:


### PR DESCRIPTION
Getting the following error:

```
Package python-pywbem is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

However the following packages replace it:
  sblim-wbemcli
```

Signed-off-by: Tony Asleson <tasleson@redhat.com>