### PR TITLE
Change service err msg

### DIFF
--- a/python_binding/lsm/_client.py
+++ b/python_binding/lsm/_client.py
@@ -51,7 +51,7 @@ def _check_search_key(search_key, supported_keys):
 def _raise_no_daemon():
     raise LsmError(ErrorNumber.DAEMON_NOT_RUNNING,
                    "The libStorageMgmt daemon is not running (process "
-                   "name lsmd), try 'service libstoragemgmt start'")
+                   "name lsmd), please start service")
 
 
 # Main client class for library.


### PR DESCRIPTION
When the client detects that the service isn't running, instead
of stating try 'service libstoragemgmt start'  we will simply
state to start the service.  This avoids any confusion depending
on if the system uses systemd or other for service management.

Signed-off-by: Tony Asleson <tasleson@redhat.com>