### PR TITLE
Use smaller default length for inquiry

### DIFF
--- a/c_binding/libsg.h
+++ b/c_binding/libsg.h
@@ -62,6 +62,9 @@
 
 /* SPC-5 rev 7, Table 142 - INQUIRY command */
 #define _SG_T10_SPC_INQUIRY_MAX_LEN 0xffff
+
+/* Some Areca RAID cards take issue with inquiry data length */
+#define _DEFAULT_INQUIRY_MAX_LEN 0x4000
 /* VPD is a INQUIRY */
 #define _SG_T10_SPC_VPD_MAX_LEN _SG_T10_SPC_INQUIRY_MAX_LEN
 


### PR DESCRIPTION
Some Areca RAID controllers take issue with an inquiry command
issued with a length > 0x4000.  We will use this as a max
default length and provide the ability to override it if needed
at runtime with an env variable "LSM_MAX_INQUIRY_LEN".

ref.

https://tracker.ceph.com/issues/48270
https://github.com/libstorage/libstoragemgmt/issues/442

Signed-off-by: Tony Asleson <tasleson@redhat.com>