### PR TITLE
Use one-byte length for VPD inquiry commands

### DIFF
--- a/c_binding/libsg.c
+++ b/c_binding/libsg.c
@@ -479,6 +479,11 @@ int _sg_io_vpd(char *err_msg, int fd, uint8_t page_code, uint8_t *data) {
     case _SG_T10_SBC_VPD_BLK_DEV_CHA:
         data_len = _T10_SBC_VPD_BLK_DEV_CHA_MAX_LEN;
         break;
+    case _SG_T10_SPC_VPD_SUP_VPD_PGS:
+    case _SG_T10_SPC_VPD_UNIT_SN:
+    case _SG_T10_SPC_VPD_DI:
+        data_len = _SG_T10_SPC_VPD_SMALL_MAX_LEN;
+        break;
     default:
         data_len = _SG_T10_SPC_VPD_MAX_LEN;
     }

--- a/c_binding/libsg.h
+++ b/c_binding/libsg.h
@@ -64,6 +64,8 @@
 #define _SG_T10_SPC_INQUIRY_MAX_LEN 0xffff
 /* VPD is a INQUIRY */
 #define _SG_T10_SPC_VPD_MAX_LEN _SG_T10_SPC_INQUIRY_MAX_LEN
+/* some controller/drives don't like a two-byte length for VPD pages 0, 0x80, 0x83 */
+#define _SG_T10_SPC_VPD_SMALL_MAX_LEN 0xfc
 
 /* SPC-5 Table 444 - PROTOCOL IDENTIFIER field values */
 #define _SG_T10_SPC_PROTOCOL_ID_OBSOLETE 1


### PR DESCRIPTION
Idea from sg3_utils; it's turned out that certain controllers
(Areca ARC-1680 series) cause timeouts and bus resets with longer
requested lengths in these commands.

Signed-off-by: Dan Mick <dmick@redhat.com>

CI Kick