### PR TITLE
lsm_local_disk_health_status_get: Add NVMe health check

### DIFF
--- a/c_binding/Makefile.am
+++ b/c_binding/Makefile.am
@@ -17,6 +17,6 @@ libstoragemgmt_la_SOURCES= \
 	lsm_plugin_ipc.cpp util/qparams.c util/qparams.h \
 	utils.c utils.h libsg.c libsg.h lsm_local_disk.c libses.c libses.h \
 	libata.c libata.h libsas.c libsas.h libfc.c libfc.h \
-	libiscsi.c libiscsi.h
+	libiscsi.c libiscsi.h libnvme.c libnvme.h
 
 EXTRA_DIST = jsmn.h lsm_value_jsmn.hpp

--- a/c_binding/libnvme.c
+++ b/c_binding/libnvme.c
@@ -88,9 +88,15 @@ int _nvme_health_status(char *err_msg, int fd, int32_t *health_status) {
                              ? LSM_DISK_HEALTH_STATUS_GOOD
                              : LSM_DISK_HEALTH_STATUS_FAIL;
         return LSM_ERR_OK;
+    } else if (-1 == rc) {
+        int errno_cpy = errno;
+        snprintf(err_msg, _LSM_ERR_MSG_LEN,
+                 "Unexpected return from ioctl %d (%s)", rc,
+                 strerror(errno_cpy));
+    } else {
+        /* We got a nvme status code */
+        snprintf(err_msg, _LSM_ERR_MSG_LEN,
+                 "Unexpected return from ioctl, nvme status code 0x%X", rc);
     }
-    int errno_cpy = errno;
-    snprintf(err_msg, _LSM_ERR_MSG_LEN, "Unexpected return from ioctl %d (%s)",
-             rc, strerror(errno_cpy));
     return LSM_ERR_LIB_BUG;
 }

--- a/c_binding/libnvme.c
+++ b/c_binding/libnvme.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2021 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Tony Asleson <tasleson@redhat.com>
+ */
+
+#include <errno.h>
+#include <linux/nvme_ioctl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+
+#include "libstoragemgmt/libstoragemgmt_error.h"
+#include "utils.h"
+
+/*
+ * Note:
+ * When libnvme gets released we will switch all of this code over to using it!
+ */
+
+struct smart_data {
+    uint8_t critical_warning;
+    uint8_t unused_rsvd[511];
+};
+
+int _nvme_health_status(char *err_msg, int fd, int32_t *health_status) {
+
+    /*
+     * Code based on NVMe Revision 1.4 June 10, 2019
+     * 5.14 Get Log Page Command
+     *
+     * Command dwords 10, 11, 12, 13, 14 are applicable for get log page command
+     *
+     *         Bits
+     * cdw10 = 31:16 - Number of dwords lower
+     *         15    - Retain Asynchronous Event (RAE)
+     *         14:12 - Reserved
+     *         11: 8 - Log Specific Field (LSP)
+     *          7: 0 - Log Page Idenfifier (LID)
+     * cdw11 = 31:16 - Log Specific Identifier, Not using
+     *         15: 0 - Number of dwords upper
+     * cdw12 = 31: 0 - Log Page Offset Lower (LPOL) Not using
+     * cdw13 = 31: 0 - Log Page Offset Upper (LPOU) Not using
+     * cdw14 = 31: 7 - Reserved
+     *          6: 0 - UUID index, Not using
+     */
+
+    /* Number of dwords is ZERO based! */
+    uint32_t number_dwords = (sizeof(struct smart_data) >> 2) - 1;
+    uint16_t number_dword_upper = number_dwords >> 16;
+    uint16_t number_dword_lower = number_dwords & 0xffff;
+
+    /* LSP == 0, RAE == 0, LID = 2 (Smart/Health information) */
+    uint32_t cdw10 = number_dword_lower << 16 | 0x02;
+
+    struct smart_data data;
+
+    struct nvme_admin_cmd cmd = {
+        .opcode = 0x02,     // nvme admin get log page
+        .nsid = 0xffffffff, // All namespaces
+        .addr = (uint64_t)&data,
+        .data_len = sizeof(data),
+        .cdw10 = cdw10,
+        .cdw11 = number_dword_upper,
+        // 12 - 14 == are zero
+    };
+
+    errno = 0;
+    int rc = ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd);
+    if (0 == rc) {
+        /* If any bits are set we are calling this a fail */
+        *health_status = (data.critical_warning == 0)
+                             ? LSM_DISK_HEALTH_STATUS_GOOD
+                             : LSM_DISK_HEALTH_STATUS_FAIL;
+        return LSM_ERR_OK;
+    }
+    int errno_cpy = errno;
+    snprintf(err_msg, _LSM_ERR_MSG_LEN, "Unexpected return from ioctl %d (%s)",
+             rc, strerror(errno_cpy));
+    return LSM_ERR_LIB_BUG;
+}

--- a/c_binding/libnvme.c
+++ b/c_binding/libnvme.c
@@ -75,7 +75,9 @@ int _nvme_health_status(char *err_msg, int fd, int32_t *health_status) {
         .data_len = sizeof(data),
         .cdw10 = cdw10,
         .cdw11 = number_dword_upper,
-        // 12 - 14 == are zero
+        .cdw12 = 0,
+        .cdw13 = 0,
+        .cdw14 = 0,
     };
 
     errno = 0;

--- a/c_binding/libnvme.c
+++ b/c_binding/libnvme.c
@@ -71,7 +71,7 @@ int _nvme_health_status(char *err_msg, int fd, int32_t *health_status) {
     struct nvme_admin_cmd cmd = {
         .opcode = 0x02,     // nvme admin get log page
         .nsid = 0xffffffff, // All namespaces
-        .addr = (uint64_t)&data,
+        .addr = (uint64_t)(uintptr_t)&data,
         .data_len = sizeof(data),
         .cdw10 = cdw10,
         .cdw11 = number_dword_upper,

--- a/c_binding/libnvme.h
+++ b/c_binding/libnvme.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2021 Red Hat, Inc.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Tony Asleson <tasleson@redhat.com>
+ */
+
+#include "libstoragemgmt/libstoragemgmt_common.h"
+
+LSM_DLL_LOCAL int _nvme_health_status(char *err_msg, int fd,
+                                      int32_t *health_status);

--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,7 @@ AM_PROG_LIBTOOL
 AM_PROG_CC_C_O
 AM_PROG_LD
 
-AC_CHECK_HEADERS([stdint.h stdlib.h string.h sys/socket.h syslog.h unistd.h])
+AC_CHECK_HEADERS([stdint.h stdlib.h string.h sys/socket.h syslog.h unistd.h linux/nvme_ioctl.h])
 
 AC_LANG_PUSH([C++])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([int i;])],

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -33,6 +33,7 @@ BuildRequires:  systemd
 BuildRequires:  bash-completion
 BuildRequires:  libconfig-devel
 BuildRequires:  systemd-devel
+BuildRequires:  kernel-headers
 %if %{with python2}
 BuildRequires:  python2-six
 BuildRequires:  python2-devel


### PR DESCRIPTION
Add ability to check the health status for NVMe devices.
We are using the get log page admin command with log page
2 (smart/health information) and checking the critical warning
return byte.

Signed-off-by: Tony Asleson <tasleson@redhat.com>