### PR TITLE
Correct simulator plugin location

### DIFF
--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -436,11 +436,11 @@ fi
 %{python3_sitearch}/lsm/lsmcli/cmdline.*
 %{python3_sitearch}/lsm/_clib.*
 
-%dir %{python3_sitelib}/sim_plugin
-%{python3_sitelib}/sim_plugin/__pycache__/
-%{python3_sitelib}/sim_plugin/__init__.*
-%{python3_sitelib}/sim_plugin/simulator.*
-%{python3_sitelib}/sim_plugin/simarray.*
+%dir %{python3_sitearch}/sim_plugin
+%{python3_sitearch}/sim_plugin/__pycache__/
+%{python3_sitearch}/sim_plugin/__init__.*
+%{python3_sitearch}/sim_plugin/simulator.*
+%{python3_sitearch}/sim_plugin/simarray.*
 
 %{_bindir}/sim_lsmplugin
 %dir %{_libexecdir}/lsm.d

--- a/plugin/sim_plugin/Makefile.am
+++ b/plugin/sim_plugin/Makefile.am
@@ -1,6 +1,6 @@
 if WITH_SIM
 
-simdir = $(pythondir)/sim_plugin
+simdir = $(LSM_PYSO_DIR)/sim_plugin
 
 sim_PYTHON = \
 	__init__.py \


### PR DESCRIPTION
When commit 63a9ec054ad4d00069aec76fb3aaba13aecec0f7 was done we
placed the python files in the arch specific python location. As
we package the simulator with the files that are in the arch
specific directory, these should be placed in that directory
structure too.

Signed-off-by: Tony Asleson <tasleson@redhat.com>