### PR TITLE
Debian-like OS fixes for python3 builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,7 +240,9 @@ if test "x$with_python3" = "xyes"; then
 
     if test -e "/etc/debian_version"; then
         new_py_dir=`echo $pythondir| sed -e 's/site-packages$/dist-packages/'`
+        new_pyexec_dir=`echo $pyexecdir| sed -e 's/site-packages$/dist-packages/'`
         AC_SUBST([pythondir], [$new_py_dir])
+        AC_SUBST([pyexecdir], [$new_pyexec_dir])
         AC_MSG_NOTICE(["Applying workaround for debian bug 839064: $pythondir"])
     fi
     AC_SUBST(PY_VERSION, 3)

--- a/debian/python-libstoragemgmt.install
+++ b/debian/python-libstoragemgmt.install
@@ -1,5 +1,4 @@
-usr/lib/python*/dist-packages/lsm/*.py
-usr/lib/python*/dist-packages/lsm/*.pyc
+usr/lib/python*/dist-packages/lsm/*.py{,c}
 usr/lib/python*/dist-packages/lsm/_clib.so
 usr/lib/python*/dist-packages/lsm/lsmcli/*.py
 usr/libexec/lsm.d/*.py


### PR DESCRIPTION
Python2.x is deprecated, thus it's a good idea to finally move to Python3.

I suggest these 2 initial fixes that still let you build 'as is' (i.e. don't break Python2 compatibility for Debian-like OS) but let you build for Python3, if you make some additional changes.  
I'd also like to suggest changes to build on Python3 by default but that should be in another PR, I think.
