### PR TITLE
lsm_local_disk_rpm_get: Return not supported, not library error

### DIFF
--- a/c_binding/lsm_local_disk.c
+++ b/c_binding/lsm_local_disk.c
@@ -696,7 +696,7 @@ int lsm_local_disk_rpm_get(const char *disk_path, int32_t *rpm,
 
     bdc = (struct t10_sbc_vpd_bdc *)vpd_data;
     if (bdc->pg_code != _SG_T10_SBC_VPD_BLK_DEV_CHA) {
-        rc = LSM_ERR_LIB_BUG;
+        rc = LSM_ERR_NO_SUPPORT;
         _lsm_err_msg_set(err_msg,
                          "Got corrupted SCSI SBC "
                          "Device Characteristics VPD page, expected page code "


### PR DESCRIPTION
Some devices will incorrectly return good status when we request
vpd page 0xb1.  However, the returned data is incorrect.  Instead
of reporting this as a library issue, we will report it as
not supported.

Signed-off-by: Tony Asleson <tasleson@redhat.com>