### PR TITLE
Add ability to fork plugin directly from lsmcli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
          no_output_timeout: 20m
   el8:
     docker:
-      - image: centos:8
+      - image: oraclelinux:8
     steps:
       - checkout
       - run:

--- a/python_binding/lsm/_client.py
+++ b/python_binding/lsm/_client.py
@@ -15,6 +15,7 @@
 # Author: tasleson
 import os
 import sys
+import socket
 from stat import S_ISSOCK
 from lsm import (Volume, NfsExport, Capabilities, Pool, System, Battery, Disk,
                  AccessGroup, FileSystem, FsSnapshot, uri_parse, LsmError,
@@ -152,19 +153,28 @@ class Client(INetworkAttachedStorage):
             (plug, proto) = scheme.split("+")
             scheme = plug
 
-        self.plugin_path = os.path.join(self._uds_path, scheme)
-
-        if os.path.exists(self.plugin_path):
-            self._tp = _TransPort(_TransPort.get_socket(self.plugin_path))
+        # See if the user of the library is the command line inteface which is wanting to
+        # locally fork & exec the plugin for development
+        debug_fd = os.getenv('LSMCLI_DEBUG_FD')
+        if debug_fd:
+            try:
+                self._tp = _TransPort(
+                    socket.fromfd(int(debug_fd), socket.AF_UNIX, socket.SOCK_STREAM))
+            except Exception as e:
+                raise LsmError(ErrorNumber.INVALID_ARGUMENT, "LSMCLI_DEBUG_FD: %s" % str(e))
         else:
-            # At this point we don't know if the user specified an incorrect
-            # plug-in in the URI or the daemon isn't started.  We will check
-            # the directory for other unix domain sockets.
-            if Client._check_daemon_exists():
-                raise LsmError(ErrorNumber.PLUGIN_NOT_EXIST,
-                               "Plug-in %s not found!" % self.plugin_path)
+            self.plugin_path = os.path.join(self._uds_path, scheme)
+            if os.path.exists(self.plugin_path):
+                self._tp = _TransPort(_TransPort.get_socket(self.plugin_path))
             else:
-                _raise_no_daemon()
+                # At this point we don't know if the user specified an incorrect
+                # plug-in in the URI or the daemon isn't started.  We will check
+                # the directory for other unix domain sockets.
+                if Client._check_daemon_exists():
+                    raise LsmError(ErrorNumber.PLUGIN_NOT_EXIST,
+                                   "Plug-in %s not found!" % self.plugin_path)
+                else:
+                    _raise_no_daemon()
 
         self.__start(uri, plain_text_password, timeout_ms, flags)
 

--- a/python_binding/lsm/_client.py
+++ b/python_binding/lsm/_client.py
@@ -159,9 +159,11 @@ class Client(INetworkAttachedStorage):
         if debug_fd:
             try:
                 self._tp = _TransPort(
-                    socket.fromfd(int(debug_fd), socket.AF_UNIX, socket.SOCK_STREAM))
+                    socket.fromfd(int(debug_fd), socket.AF_UNIX,
+                                  socket.SOCK_STREAM))
             except Exception as e:
-                raise LsmError(ErrorNumber.INVALID_ARGUMENT, "LSMCLI_DEBUG_FD: %s" % str(e))
+                raise LsmError(ErrorNumber.INVALID_ARGUMENT,
+                               "LSMCLI_DEBUG_FD: %s" % str(e))
         else:
             self.plugin_path = os.path.join(self._uds_path, scheme)
             if os.path.exists(self.plugin_path):

--- a/python_binding/lsm/_transport.py
+++ b/python_binding/lsm/_transport.py
@@ -90,8 +90,9 @@ class TransPort(object):
                            "Error while reading a message from the plug-in",
                            str(e))
         except _SocketEOF:
-            raise LsmError(ErrorNumber.TRANSPORT_COMMUNICATION,
-                           "Error while reading a message from the plug-in, EOF")
+            raise LsmError(
+                ErrorNumber.TRANSPORT_COMMUNICATION,
+                "Error while reading a message from the plug-in, EOF")
         return msg
 
     def __init__(self, socket_descriptor):

--- a/python_binding/lsm/_transport.py
+++ b/python_binding/lsm/_transport.py
@@ -21,6 +21,7 @@ import os
 import unittest
 import threading
 
+import lsm._common
 from lsm._common import LsmError, ErrorNumber
 from lsm._common import SocketEOF as _SocketEOF
 from lsm._data import DataDecoder as _DataDecoder
@@ -88,6 +89,9 @@ class TransPort(object):
             raise LsmError(ErrorNumber.TRANSPORT_COMMUNICATION,
                            "Error while reading a message from the plug-in",
                            str(e))
+        except _SocketEOF:
+            raise LsmError(ErrorNumber.TRANSPORT_COMMUNICATION,
+                           "Error while reading a message from the plug-in, EOF")
         return msg
 
     def __init__(self, socket_descriptor):

--- a/test/docker_ci_test.sh
+++ b/test/docker_ci_test.sh
@@ -38,11 +38,10 @@ getent passwd libstoragemgmt >/dev/null || \
     -c "daemon account for libstoragemgmt" libstoragemgmt || exit 1
 
 
-# libconfig-devel is located in "PowerTools", add the plugin-core
-# to allow enabling.
+# libconfig-devel is located in code ready builder
 if [ "CHK$IS_RHEL8" == "CHK1" ];then
     dnf install dnf-plugins-core -y || exit 1
-    dnf config-manager --set-enabled powertools -y || exit 1
+    dnf config-manager --set-enabled ol8_codeready_builder -y || exit 1
 fi
 
 

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -504,6 +504,10 @@ class PluginFork:
             else:
                 print("PLUGIN>> %s" % (line.decode("utf-8").rstrip("\n")))
 
+        if instance.plugin_process.poll() is not None:
+            # Output plugin exit code.
+            print("PLUGIN EC>> %d" % instance.plugin_process.wait())
+
     def close(self):
         if self.client:
             self.client.close()

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -481,7 +481,7 @@ class PluginFork:
             sys.exit(8)
 
         # Accept the connection from the plugin
-        self.client, addr = server.accept()
+        self.client, _ = server.accept()
 
         # No longer need these, the FD for the plugin was passed to the plugin and is open there, close
         # our copy so that when the client closes socket we are aware.  The server listening socket is

--- a/tools/lsmcli/cmdline.py
+++ b/tools/lsmcli/cmdline.py
@@ -473,8 +473,12 @@ class PluginFork:
         plugin_fd = plugin.fileno()
 
         try:
-            self.plugin_process = subprocess.Popen([plugin_exe, "%d" % plugin_fd], pass_fds=[plugin_fd], env=os.environ,
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            self.plugin_process = subprocess.Popen(
+                [plugin_exe, "%d" % plugin_fd],
+                pass_fds=[plugin_fd],
+                env=os.environ,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT)
         except Exception as e:
             print("File: %s issue: %s" % (plugin_exe, str(e)))
             self.close()
@@ -489,7 +493,9 @@ class PluginFork:
         plugin.close()
         server.close()
 
-        self.thread = threading.Thread(target=PluginFork.read_stdout, args=(self,), name="plugin stdout reader")
+        self.thread = threading.Thread(target=PluginFork.read_stdout,
+                                       args=(self, ),
+                                       name="plugin stdout reader")
         self.thread.start()
 
         server = None

--- a/tools/smisping/smisping.py
+++ b/tools/smisping/smisping.py
@@ -13,6 +13,7 @@
 from pywbem import Uint16, CIMError
 import pywbem
 import sys
+
 DEFAULT_NAMESPACE = 'interop'
 INTEROP_NAMESPACES = ['interop', 'root/interop', 'root/PG_Interop']
 


### PR DESCRIPTION
When developing a new plugin it's helpful to not require the daemon to be
running.  Add a hidden argument  `--fork_plugin` that when specified allows the command line
to exec. the plugin directly.  Historically python plugins were easier
to develop as you can execute a python plugin directly from the command
line.  With this functionality it allows plugin developers an easier
time developing in other languages too.