### PR TITLE
Update fedora container to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   fedora:
     docker:
-      - image: fedora:33
+      - image: fedora
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Circle CI has updated their base container kernel which supports
what we need to run fedora.

Signed-off-by: Tony Asleson <tasleson@redhat.com>