### PR TITLE
Handle udev events on SCSI vports

### DIFF
--- a/tools/udev/scan-scsi-target.c
+++ b/tools/udev/scan-scsi-target.c
@@ -131,6 +131,9 @@ int main(int argc, char **argv) {
      */
     if ((host_str = strstr(devpath, "/host")) == NULL)
         invalid(argv, devpath);
+    if (strstr(devpath, "/vport"))
+        if ((host_str = strstr(host_str + 1, "/host")) == NULL)
+            invalid(argv, devpath);
     host_pos = strlen(devpath) - strlen(host_str);
 
     if ((host_next_str = strstr(&devpath[host_pos + 1], "/")) == NULL)


### PR DESCRIPTION
If SCSI vports are used by adding them via NPIV by using the
vport_create file for an FC port:
```
 # pwd
 # /sys/class/fc_host/host6
 # echo '1111222233334444:5555666677778888' > vport_create
```

This will create a virtual host at a higher index number than the
existing FC hosts. You can assign LUNs to these hosts just as you
would to the actual FC hosts. Assigning LUNs will result in a
unit attention of reported LUNs data has changed, which will have
this path from udev as the devpath.

/devices/pci0000:00/0000:00:03.0/0000:04:00.0/host6/vport-6:0-0/
host10/rport-10:0-2/target10:0:0/10:0:0:1

The existing scan-scsi-target will find the first instance of '/host'
and cause a rescan on host6 which is not where the ACL has actually
changed. The rescan should happen on the virtual host, host10 to get
the expected result.