### PR TITLE
coverity: Correct TOCTOU

### DIFF
--- a/c_binding/libses.c
+++ b/c_binding/libses.c
@@ -475,7 +475,7 @@ static int16_t _ses_find_sas_addr(const char *sas_addr, uint8_t *add_st_data,
             continue;
         if (dp_sas->phy_count == 0)
             continue;
-        if (&dp_sas->phy_list + sizeof(struct _ses_add_st_sas_phy) > end_p)
+        if ((uint8_t *)(&dp_sas->phy_list + sizeof(struct _ses_add_st_sas_phy)) > end_p)
             goto out;
         for (i = 0; i < dp_sas->phy_count; ++i) {
             phy =

--- a/c_binding/libses.c
+++ b/c_binding/libses.c
@@ -475,7 +475,8 @@ static int16_t _ses_find_sas_addr(const char *sas_addr, uint8_t *add_st_data,
             continue;
         if (dp_sas->phy_count == 0)
             continue;
-        if ((uint8_t *)(&dp_sas->phy_list + sizeof(struct _ses_add_st_sas_phy)) > end_p)
+        if ((uint8_t *)(&dp_sas->phy_list +
+                        sizeof(struct _ses_add_st_sas_phy)) > end_p)
             goto out;
         for (i = 0; i < dp_sas->phy_count; ++i) {
             phy =

--- a/tools/udev/scan-scsi-target.c
+++ b/tools/udev/scan-scsi-target.c
@@ -56,6 +56,7 @@ int main(int argc, char **argv) {
     int c;
     char *devpath;
 
+    char *sysfs_dir_check = NULL;
     char *sysfs_path;
     char *sysfs_data;
     struct stat sysfs_stat;
@@ -108,23 +109,25 @@ int main(int argc, char **argv) {
         usage(argv, 1);
     }
 
-    sysfs_path = malloc(strlen("/sys") + strlen(devpath) + 1);
-    if (!sysfs_path) {
+    sysfs_dir_check = malloc(strlen("/sys") + strlen(devpath) + 1);
+    if (!sysfs_dir_check) {
         fprintf(stderr, "Memory allocation failure!");
         return 1;
     }
 
-    strcpy(sysfs_path, "/sys");
-    strcat(sysfs_path, devpath);
+    strcpy(sysfs_dir_check, "/sys");
+    strcat(sysfs_dir_check, devpath);
 
-    if (stat(sysfs_path, &sysfs_stat) < 0) {
-        fprintf(stderr, "Cannot stat '%s': %s\n", sysfs_path, strerror(errno));
+    if (stat(sysfs_dir_check, &sysfs_stat) < 0) {
+        fprintf(stderr, "Cannot stat '%s': %s\n", sysfs_dir_check,
+                strerror(errno));
         usage(argv, 1);
     }
     if (!S_ISDIR(sysfs_stat.st_mode))
         invalid(argv, devpath);
 
-    free(sysfs_path);
+    free(sysfs_dir_check);
+    sysfs_dir_check = NULL;
 
     /*
      * Construct the path to the "scan" entry in the Scsi_Host sysfs object.


### PR DESCRIPTION
In the function delete_socket we check to see if the file in question
is a socket before we delete it.  Thus there is a race condition
between the checks.  Open the directory that contains the file and
use the functions that use the directory file descriptor to remove
this race condition.

Signed-off-by: Tony Asleson <tasleson@redhat.com>

CI REDO