### PR TITLE
Correct failure to build on i386

### DIFF
--- a/c_binding/lsm_local_disk.c
+++ b/c_binding/lsm_local_disk.c
@@ -1093,13 +1093,12 @@ static void _sysfs_sas_addr_get(const char *blk_name, char *tp_sas_addr) {
     memset(sysfs_sas_addr, 0, _SYSFS_SAS_ADDR_LEN);
     memset(tp_sas_addr, 0, _SG_T10_SPL_SAS_ADDR_LEN);
 
-    sysfs_sas_path = (char *)malloc(sizeof(char) *
-                                    (strlen("/sys/block//device/sas_address") +
-                                     strlen(blk_name) + 1 /* trailing \0 */));
+    sysfs_sas_path = (char *)malloc(PATH_MAX);
     if (sysfs_sas_path == NULL)
         goto out;
 
-    sprintf(sysfs_sas_path, "/sys/block/%s/device/sas_address", blk_name);
+    snprintf(sysfs_sas_path, PATH_MAX, "/sys/block/%s/device/sas_address",
+             blk_name);
     if (!_file_exists(sysfs_sas_path))
         goto out;
 


### PR DESCRIPTION
Newer versions of gcc apparently don't like string lengths that
are determined at runtime and will emit a warning when they occur.

lsm_local_disk.c:1102:41: error: '%s' directive writing up to 2147483641
bytes into a region of size 2147483636 [-Werror=format-overflow=]
1102 |     sprintf(sysfs_sas_path, "/sys/block/%s/device/sas_address", blk_name);

A discussion:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104746

In our case we know that the string length will safely be smaller than
PATH_MAX, so we are simply replacing an unknown at compile time with
a known, so that we don't encounter this warning.

At the moment I'm not sure why this is only raised on i386.

Signed-off-by: Tony Asleson <tasleson@redhat.com>