### PR TITLE
Add a udev rule entry for ALUA state changes

### DIFF
--- a/tools/udev/90-scsi-ua.rules
+++ b/tools/udev/90-scsi-ua.rules
@@ -3,3 +3,4 @@
 #ACTION=="change", SUBSYSTEM=="scsi", ENV{SDEV_UA}=="THIN_PROVISIONING_SOFT_THRESHOLD_REACHED", TEST=="rescan", ATTR{rescan}="x"
 #ACTION=="change", SUBSYSTEM=="scsi", ENV{SDEV_UA}=="MODE_PARAMETERS_CHANGED", TEST=="rescan", ATTR{rescan}="x"
 ACTION=="change", SUBSYSTEM=="scsi", ENV{SDEV_UA}=="REPORTED_LUNS_DATA_HAS_CHANGED", RUN+="scan-scsi-target $env{DEVPATH}"
+#ACTION=="change", SUBSYSTEM=="scsi", ENV{SDEV_UA}=="ALUA_STATE_CHANGE_REPORTED", TEST=="rescan", ATTR{rescan}="x"


### PR DESCRIPTION
The Linux kernel has support for this event and will emit an event if a target returns this unit attention.

Add it commented out to match the others in the file.