### PR TITLE
Update configuration

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,8 +1,8 @@
 Installation Instructions
 *************************
 
-   Copyright (C) 1994-1996, 1999-2002, 2004-2016 Free Software
-Foundation, Inc.
+   Copyright (C) 1994-1996, 1999-2002, 2004-2017, 2020-2021 Free
+Software Foundation, Inc.
 
    Copying and distribution of this file, with or without modification,
 are permitted in any medium without royalty provided the copyright
@@ -225,7 +225,7 @@ order to use an ANSI C compiler:
 
 and if that doesn't work, install pre-built binaries of GCC for HP-UX.
 
-   HP-UX 'make' updates targets which have the same time stamps as their
+   HP-UX 'make' updates targets which have the same timestamps as their
 prerequisites, which makes it generally unusable when shipped generated
 files such as 'configure' are involved.  Use GNU 'make' instead.
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,9 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 dnl Copyright (C) 2011-2016 Red Hat, Inc.
 dnl See COPYING.LIB for the License of this software
 
-AC_INIT(
-    [libstoragemgmt], [1.9.6], [libstoragemgmt-devel@lists.fedorahosted.org],
-    [], [https://github.com/libstorage/libstoragemgmt/])
+AC_INIT([libstoragemgmt],[1.9.6],[libstoragemgmt-devel@lists.fedorahosted.org],[],[https://github.com/libstorage/libstoragemgmt/])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
@@ -67,11 +65,11 @@ AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_CPP
-AM_PROG_CC_STDC
+AC_PROG_CC
 
-AM_PROG_LIBTOOL
+LT_INIT
 AM_PROG_CC_C_O
-AM_PROG_LD
+LT_PATH_LD
 
 AC_CHECK_HEADERS([stdint.h stdlib.h string.h sys/socket.h syslog.h unistd.h linux/nvme_ioctl.h])
 
@@ -120,8 +118,7 @@ fi
 PKG_CHECK_MODULES([LIBGLIB], [glib-2.0 >= 2.22.5])
 
 AC_ARG_WITH([test],
-    [AC_HELP_STRING([--without-test],
-                    [disable all test case])],
+    [AS_HELP_STRING([--without-test],[disable all test case])],
     [], [with_test=yes])
 
 AM_CONDITIONAL([WITH_TEST], [test "x$with_test" = "xyes"])
@@ -213,10 +210,10 @@ if test "x$with_python3" = "xyes"; then
     AM_PATH_PYTHON([3], [], AC_MSG_ERROR([Python interpreter 3 required]))
 
     if test "x$with_smispy" = "xyes"; then
-        AC_PYTHON_MODULE([pywbem], [Required], [python3])
+        AX_PYTHON_MODULE([pywbem],[Required],[python3])
     fi
 
-    AC_PYTHON_MODULE([six], [Required], [python3])
+    AX_PYTHON_MODULE([six],[Required],[python3])
     PKG_CHECK_MODULES([PYTHON], [python3], [], [not_found_py_pkg=yes])
 
     if test "x$not_found_py_pkg" == "xyes"; then
@@ -256,11 +253,11 @@ but found $PYTHON_MAJOR_VERSION.x]) ;;
                    AC_MSG_ERROR([Python interpreter 2.6 or 2.7 required]) )
 
     if test "x$with_smispy" = "xyes"; then
-        AC_PYTHON_MODULE([pywbem], [Required])
+        AX_PYTHON_MODULE([pywbem],[Required])
     fi
 
-    AC_PYTHON_MODULE([argparse], [Required])
-    AC_PYTHON_MODULE([six], [Required])
+    AX_PYTHON_MODULE([argparse],[Required])
+    AX_PYTHON_MODULE([six],[Required])
     PKG_CHECK_MODULES([PYTHON], [python2], [], [not_found_py_pkg=yes])
 
     if test "x$not_found_py_pkg" == "xyes"; then


### PR DESCRIPTION
When running `autoreconf -f -i` via autogen.sh we were seeing the following:
```
...
configure.ac:70: warning: 'AM_PROG_CC_STDC': this macro is obsolete. configure.ac:70: You should simply use the 'AC_PROG_CC' macro instead. configure.ac:70: Also, your code should no longer depend upon 'am_cv_prog_cc_stdc', configure.ac:70: but upon 'ac_cv_prog_cc_stdc'.
./lib/autoconf/general.m4:2434: AC_DIAGNOSE is expanded from... aclocal.m4:1131: AM_PROG_CC_STDC is expanded from... configure.ac:70: the top level
configure.ac:72: warning: The macro `AM_PROG_LIBTOOL' is obsolete. configure.ac:72: You should run autoupdate.
m4/libtool.m4:101: AM_PROG_LIBTOOL is expanded from... configure.ac:72: the top level
configure.ac:74: warning: The macro `AM_PROG_LD' is obsolete. configure.ac:74: You should run autoupdate.
m4/libtool.m4:3352: AM_PROG_LD is expanded from... configure.ac:74: the top level
configure.ac:122: warning: The macro `AC_HELP_STRING' is obsolete. configure.ac:122: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from... ./lib/autoconf/general.m4:1553: AC_ARG_WITH is expanded from... configure.ac:122: the top level
configure.ac:216: warning: The macro `AC_PYTHON_MODULE' is obsolete. configure.ac:216: You should run autoupdate.
m4/ax_python_module.m4:28: AC_PYTHON_MODULE is expanded from... configure.ac:216: the top level
configure.ac:219: warning: The macro `AC_PYTHON_MODULE' is obsolete. configure.ac:219: You should run autoupdate.
m4/ax_python_module.m4:28: AC_PYTHON_MODULE is expanded from... configure.ac:219: the top level
configure.ac:259: warning: The macro `AC_PYTHON_MODULE' is obsolete. configure.ac:259: You should run autoupdate.
m4/ax_python_module.m4:28: AC_PYTHON_MODULE is expanded from... configure.ac:259: the top level
configure.ac:262: warning: The macro `AC_PYTHON_MODULE' is obsolete. configure.ac:262: You should run autoupdate.
m4/ax_python_module.m4:28: AC_PYTHON_MODULE is expanded from... configure.ac:262: the top level
configure.ac:263: warning: The macro `AC_PYTHON_MODULE' is obsolete. configure.ac:263: You should run autoupdate.
m4/ax_python_module.m4:28: AC_PYTHON_MODULE is expanded from...
```

autoupdate was run and AC_PROG_CC was used to replace AM_PROG_CC_STDC.

Signed-off-by: Tony Asleson <tasleson@redhat.com>