### PR TITLE
Correction for fips error

### DIFF
--- a/plugin/nfs_plugin/nfs.py
+++ b/plugin/nfs_plugin/nfs.py
@@ -55,7 +55,13 @@ class NFSPlugin(INfs, IStorageAreaNetwork):
         if auth_type is None:
             auth_type = 'sec'
 
-        hsh = hashlib.md5()
+        try:
+            # The use of md5 is not used for security, indicate
+            # this to hashlib so that we can run when fips is enabled
+            hsh = hashlib.md5(usedforsecurity=False)
+        except Exception:
+            hsh = hashlib.md5()
+
         hsh.update(path.encode('utf-8'))
         hsh.update(auth_type.encode('utf-8'))
         if anon_uid is not None and anon_uid != NfsExport.ANON_UID_GID_NA:

--- a/python_binding/lsm/_common.py
+++ b/python_binding/lsm/_common.py
@@ -345,7 +345,12 @@ def uri_parameters(uri):
 # @param    t   Item to generate signature on.
 # @returns  md5 hex digest.
 def md5(t):
-    h = hashlib.md5()
+    try:
+        # The use of md5 is not used for security, indicate
+        # this to hashlib so that we can run when fips is enabled
+        h = hashlib.md5(usedforsecurity=False)
+    except Exception:
+        h = hashlib.md5()
     h.update(t.encode("utf-8"))
     return h.hexdigest()
 


### PR DESCRIPTION
When running on a fips enabled system we encounter the following error:

```
PLUGIN_BUG(2): [digital envelope routines] unsupported Data: Traceback (most recent call last): ...
  File "/usr/lib64/python3.9/site-packages/lsm/_common.py", line 348, in md5
    h = hashlib.md5()
ValueError: [digital envelope routines] unsupported
```

Utilize the `usedforsecurity=False`parameter to md5 to indicate that our use is not for security related purposes.