### PR TITLE
Add needed cargo paths for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,29 +16,9 @@ jobs:
       - run:
          command: cd libstoragemgmt && git checkout $GHBR && ./test/docker_ci_test.sh
          no_output_timeout: 20m
-  el8:
-    docker:
-      - image: oraclelinux:8
-    environment:
-      GHURL: << pipeline.project.git_url >>
-      GHBR: << pipeline.git.branch >>
-    steps:
-      - run:
-         command:  dnf install -y git dnf-plugins-core
-         no_output_timeout: 5m
-      - run:
-         command:  dnf copr enable -y tasleson/ledmon-upstream
-         no_output_timeout: 5m
-      - run:
-         command: git clone $GHURL
-         no_output_timeout: 5m
-      - run:
-         command: cd libstoragemgmt && git checkout $GHBR && ./test/docker_ci_test.sh
-         no_output_timeout: 20m
 
 workflows:
   version: 2
   workflow:
     jobs:
     - fedora
-    - el8

--- a/packaging/libstoragemgmt.spec.in
+++ b/packaging/libstoragemgmt.spec.in
@@ -31,6 +31,7 @@ BuildRequires:  autoconf automake libtool check-devel perl-interpreter
 BuildRequires:  glib2-devel
 BuildRequires:  systemd
 BuildRequires:  bash-completion
+BuildRequires:  pkgconfig(bash-completion)
 BuildRequires:  libconfig-devel
 BuildRequires:  systemd-devel
 BuildRequires:  kernel-headers

--- a/rh_py3_rpm_dependency
+++ b/rh_py3_rpm_dependency
@@ -1,6 +1,7 @@
 autoconf
 automake
 bash-completion
+bash-completion-devel
 check-devel
 chrpath
 file

--- a/test/docker_ci_test.sh
+++ b/test/docker_ci_test.sh
@@ -82,6 +82,7 @@ V=1 make || exit 1
 V=1 make check || { cat test-suite.log; exit 1; }
 
 if [ "CHK$IS_PY3" == "CHK1" ];then
+    echo "Testing 'make rpm'"
     make rpm || exit 1
 fi
 

--- a/test/runtests.sh.in
+++ b/test/runtests.sh.in
@@ -76,6 +76,17 @@ if [ "CHK${arch}" != "CHKppc64" ] && [ "${src_dir}" == "${build_dir}" ] && [ "$E
     STARTING_POINT=$(pwd)
     _good cd "${src_dir}"/
 
+    # We need to setup directory where the shared library has been built as we are linking to it
+    # in the rust-binding via FFI
+    export RUSTFLAGS="-L$LD_LIBRARY_PATH"
+    export RUSTDOCFLAGS=$RUSTFLAGS
+
+    echo "RUSTFLAGS=$RUSTFLAGS"
+    echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+
+    echo "Directory listing of .libs directory"
+    _good ls -l $LD_LIBRARY_PATH
+
     #fetch the module
     if [ ! -d libstoragemgmt-rust ]; then
         _good git clone https://github.com/libstorage/libstoragemgmt-rust


### PR DESCRIPTION
When we added FFI to `libstoragemgm-rust` we broke our verification test when building & testing in a container.  We also stumbled upon an issue where we don't have `pkconfig-devel` which we should investigate into more as I believe there is a simpler solution that simplying adding `pkconfig-devel` to spec file.