### PR TITLE
Use sysusers.d for adding user/group

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -445,6 +445,14 @@ if test "x$with_systemdsystemunitdir" != xno; then
         AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 fi
 
+#Setup the sysusersdir for systemd stuff
+AC_ARG_WITH([systemd-sysusersdir],
+        AS_HELP_STRING([--with-systemd-sysusersdir=DIR], [Directory for systemd sysusers files]),
+        [], [with_systemdsysusersdir=$($PKG_CONFIG --variable=sysusersdir systemd)])
+if test "x$with_systemdsysusersdir" != xno; then
+        AC_SUBST([systemdsysusersdir], [$with_systemdsysusersdir])
+fi
+
 #Setup the tmpfilesdir for systemd stuff
 AC_ARG_WITH([systemd-tmpfilesdir],
         AS_HELP_STRING([--with-systemd-tmpfilesdir=DIR], [Directory for systemd temporary files]),
@@ -502,6 +510,7 @@ AC_CONFIG_FILES([
     tools/bash_completion/Makefile
     packaging/Makefile
     packaging/daemon/Makefile
+    packaging/daemon/user_group/Makefile
     packaging/libstoragemgmt.spec
     doc/man/Makefile
     test/Makefile])

--- a/packaging/daemon/Makefile.am
+++ b/packaging/daemon/Makefile.am
@@ -7,3 +7,5 @@ systemdtmpfiles_DATA = libstoragemgmt.conf
 endif
 
 EXTRA_DIST = libstoragemgmt.service libstoragemgmt.conf libstoragemgmtd
+
+SUBDIRS = user_group

--- a/packaging/daemon/user_group/Makefile.am
+++ b/packaging/daemon/user_group/Makefile.am
@@ -1,0 +1,9 @@
+
+if HAVE_SYSTEMD
+
+systemdsysusers_DATA = libstoragemgmt.conf
+
+endif
+
+EXTRA_DIST = libstoragemgmt.conf
+

--- a/packaging/daemon/user_group/libstoragemgmt.conf
+++ b/packaging/daemon/user_group/libstoragemgmt.conf
@@ -1,0 +1,2 @@
+#Type Name            ID               GECOS                                HomeDir Shell
+u!    libstoragemgmt  -                "daemon account for libstoragemgmt"


### PR DESCRIPTION
Systemd includes the ability to add user/group using a <name>.config file in `/usr/lib/sysusers.d`

The syntax of that file
https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html