### PR TITLE
Improve unique identifier support to include NVMe devices

### DIFF
--- a/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
+++ b/c_binding/include/libstoragemgmt/libstoragemgmt_local_disk.h
@@ -23,12 +23,15 @@ extern "C" {
  *      1.3
  *
  * Description:
- *      Search all the disk paths of specified SCSI VPD 0x83 page NAA type ID.
- *      For any ATA and other non-SCSI protocol disks supporting VPD 0x83 pages
- *      NAA ID, their disk path will also be included.
+ *      Search all the disk paths of specified VPD 0x83 page ID.
+ *      Supported ID formats:
+ *          * SCSI NAA type ID (16 or 32 hex characters)
+ *          * SCSI EUI-64 type ID (16, 24, or 32 hex characters)
+ *          * NVMe NGUID (32 hex characters)
+ *          * NVMe EUI-64 (16 hex characters)
  *
  * @vpd83:
- *      String. The SCSI VPD 0x83 page NAA type ID.
+ *      String. The VPD 0x83 page ID.
  * @disk_path_list:
  *      Output pointer of &lsm_string_list. The format of
  *      disk path will be like "/dev/sdb" for SCSI or ATA disk.
@@ -94,19 +97,26 @@ int LSM_DLL_EXPORT lsm_local_disk_serial_num_get(const char *disk_path,
                                                  lsm_error **lsm_err);
 
 /**
- * lsm_local_disk_vpd83_get - Query scsi VPD 0x83 NAA ID.
+ * lsm_local_disk_vpd83_get - Query disk VPD 0x83 ID.
  *
  * Version:
  *      1.3
  *
  * Description:
- *      Query the SCSI VPD 0x83 page NAA type ID of specified disk path.
+ *      Query the VPD 0x83 page ID of specified disk path.
+ *      For SCSI/SAS/ATA disks, returns the NAA type ID if available,
+ *      falling back to EUI-64 type ID.
+ *      For NVMe disks, returns the namespace NGUID or EUI-64.
  *
  * @disk_path:
- *      String. The path of disk path, example "/dev/sdb".
+ *      String. The path of disk, example: "/dev/sdb", "/dev/nvme0n1".
  * @vpd83:
- *      Output pointer of SCSI VPD83 NAA ID. The format is:
- *          (?:^6[0-9a-f]{31})|(?:^[235][0-9a-f]{15})$
+ *      Output pointer of VPD83 ID. The format is one of:
+ *          * SCSI NAA:    (?:^6[0-9a-f]{31})|(?:^[235][0-9a-f]{15})$
+ *          * EUI-64:      ^[0-9a-f]{16}$  (8 bytes)
+ *          * EUI-64 (12): ^[0-9a-f]{24}$  (12 bytes)
+ *          * EUI-64 (16): ^[0-9a-f]{32}$  (16 bytes)
+ *          * NVMe NGUID:  ^[0-9a-f]{32}$
  *      Set to NULL when error. Memory should be freed by free().
  * @lsm_err:
  *      Output pointer of lsm_error. Error message could be retrieved via

--- a/c_binding/libsg.h
+++ b/c_binding/libsg.h
@@ -23,7 +23,8 @@ extern "C" {
 /* SPC-5 rev 7, Table 487 - ASSOCIATION field */
 #define _SG_T10_SPC_ASSOCIATION_TGT_PORT 1
 
-#define _SG_T10_SPC_VPD_DI_DESIGNATOR_TYPE_NAA 0x3
+#define _SG_T10_SPC_VPD_DI_DESIGNATOR_TYPE_EUI64 0x2
+#define _SG_T10_SPC_VPD_DI_DESIGNATOR_TYPE_NAA   0x3
 
 /* SPL-4 rev5 4.2.4 SAS address. With trailing \0. */
 #define _SG_T10_SPL_SAS_ADDR_LEN 17

--- a/c_binding/lsm_datatypes.cpp
+++ b/c_binding/lsm_datatypes.cpp
@@ -544,10 +544,6 @@ lsm_volume *lsm_volume_record_alloc(const char *id, const char *name,
                                     uint64_t numberOfBlocks, uint32_t status,
                                     const char *system_id, const char *pool_id,
                                     const char *plugin_data) {
-    if (vpd83 && (LSM_ERR_OK != lsm_volume_vpd83_verify(vpd83))) {
-        return NULL;
-    }
-
     lsm_volume *rc = (lsm_volume *)calloc(1, sizeof(lsm_volume));
     if (rc) {
         rc->magic = LSM_VOL_MAGIC;

--- a/c_binding/lsm_local_disk.cpp
+++ b/c_binding/lsm_local_disk.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <assert.h>
+#include <ctype.h>
 #include <dirent.h>
 #include <endian.h>
 #include <errno.h>
@@ -61,7 +62,14 @@
 
 #define _SYSFS_BLK_PATH_FORMAT      "/sys/block/%s"
 #define _MAX_SYSFS_BLK_PATH_STR_LEN (128 + _MAX_SD_NAME_STR_LEN)
-#define _SYSFS_SAS_ADDR_LEN         (_SG_T10_SPL_SAS_ADDR_LEN + 2)
+
+#define _SYSFS_NGUID_PATH_FORMAT            "/sys/block/%s/nguid"
+#define _MAX_SYSFS_NGUID_PATH_STR_LEN       (128 + _MAX_SD_NAME_STR_LEN)
+#define _SYSFS_EUI_PATH_FORMAT              "/sys/block/%s/eui"
+#define _MAX_SYSFS_EUI_PATH_STR_LEN         (128 + _MAX_SD_NAME_STR_LEN)
+#define _SYSFS_NVME_SERIAL_PATH_FORMAT      "/sys/block/%s/device/serial"
+#define _MAX_SYSFS_NVME_SERIAL_PATH_STR_LEN (128 + _MAX_SD_NAME_STR_LEN)
+#define _SYSFS_SAS_ADDR_LEN                 (_SG_T10_SPL_SAS_ADDR_LEN + 2)
 /* ^ Only Linux sysfs entry /sys/block/sdx/device/sas_address which
  *   format is '0x<hex_addr>\0'
  */
@@ -131,6 +139,10 @@ static int _udev_vpd83_of_sd_name(char *err_msg, const char *sd_name,
                                   char *vpd83);
 static int _sysfs_vpd_pg83_data_get(char *err_msg, const char *sd_name,
                                     uint8_t *vpd_data, ssize_t *read_size);
+static int _nvme_nguid_get(char *err_msg, const char *blk_name, char *vpd83);
+static int _nvme_eui_get(char *err_msg, const char *blk_name, char *vpd83);
+static int _nvme_serial_get(char *err_msg, const char *blk_name,
+                            char **serial_num);
 /*
  * Use /sys/block/sdx/device/sas_address to retrieve sas address of certain
  * disk.
@@ -311,10 +323,27 @@ static int _sysfs_vpd83_naa_of_sd_name(char *err_msg, const char *sd_name,
             }
         }
     }
+    /* Fall back to EUI-64 (designator type 2) if no NAA was found */
+    if (vpd83[0] == '\0') {
+        for (i = 0; i < dp_count; ++i) {
+            if ((dps[i]->header.designator_type ==
+                 _SG_T10_SPC_VPD_DI_DESIGNATOR_TYPE_EUI64) &&
+                (dps[i]->header.association ==
+                 _SG_T10_SPC_VPD_DI_ASSOCIATION_LUN) &&
+                ((dps[i]->header.designator_len == 8) ||
+                 (dps[i]->header.designator_len == 12) ||
+                 (dps[i]->header.designator_len == 16))) {
+                _be_raw_to_hex(dps[i]->designator,
+                               dps[i]->header.designator_len, vpd83);
+                break;
+            }
+        }
+    }
+
     if (vpd83[0] == '\0') {
         rc = LSM_ERR_NO_SUPPORT;
-        _lsm_err_msg_set(err_msg,
-                         "SCSI VPD 83 NAA logical unit ID is not supported");
+        _lsm_err_msg_set(err_msg, "SCSI VPD 83 NAA or EUI-64 logical unit ID "
+                                  "is not supported");
     }
 
 out:
@@ -423,6 +452,120 @@ out:
     return rc;
 }
 
+static bool _is_all_zeros(const char *s) {
+    for (; *s != '\0'; ++s) {
+        if (*s != '0')
+            return false;
+    }
+    return true;
+}
+
+static int _nvme_nguid_get(char *err_msg, const char *blk_name, char *vpd83) {
+    char sysfs_path[_MAX_SYSFS_NGUID_PATH_STR_LEN];
+    uint8_t buf[128];
+    ssize_t read_size = 0;
+    int file_rc = 0;
+    size_t j = 0;
+
+    memset(vpd83, 0, _LSM_MAX_VPD83_ID_LEN);
+
+    snprintf(sysfs_path, sizeof(sysfs_path), _SYSFS_NGUID_PATH_FORMAT,
+             blk_name);
+
+    file_rc = _read_file(sysfs_path, buf, &read_size, sizeof(buf));
+    if (file_rc != 0) {
+        _lsm_err_msg_set(err_msg, "Failed to read '%s'", sysfs_path);
+        return LSM_ERR_NO_SUPPORT;
+    }
+
+    for (ssize_t i = 0; i < read_size; ++i) {
+        if (buf[i] != '-' && buf[i] != '\n' && buf[i] != ' ') {
+            if (j >= _LSM_MAX_VPD83_ID_LEN - 1)
+                break;
+            vpd83[j++] = (char)tolower(buf[i]);
+        }
+    }
+    vpd83[j] = '\0';
+
+    if (j == 0 || _is_all_zeros(vpd83)) {
+        memset(vpd83, 0, _LSM_MAX_VPD83_ID_LEN);
+        _lsm_err_msg_set(err_msg, "NVMe nguid is not set");
+        return LSM_ERR_NO_SUPPORT;
+    }
+
+    return LSM_ERR_OK;
+}
+
+static int _nvme_eui_get(char *err_msg, const char *blk_name, char *vpd83) {
+    char sysfs_path[_MAX_SYSFS_EUI_PATH_STR_LEN];
+    uint8_t buf[128];
+    ssize_t read_size = 0;
+    int file_rc = 0;
+    size_t j = 0;
+
+    memset(vpd83, 0, _LSM_MAX_VPD83_ID_LEN);
+
+    snprintf(sysfs_path, sizeof(sysfs_path), _SYSFS_EUI_PATH_FORMAT, blk_name);
+
+    file_rc = _read_file(sysfs_path, buf, &read_size, sizeof(buf));
+    if (file_rc != 0) {
+        _lsm_err_msg_set(err_msg, "Failed to read '%s'", sysfs_path);
+        return LSM_ERR_NO_SUPPORT;
+    }
+
+    for (ssize_t i = 0; i < read_size; ++i) {
+        if (buf[i] != ' ' && buf[i] != '\n') {
+            if (j >= _LSM_MAX_VPD83_ID_LEN - 1)
+                break;
+            vpd83[j++] = (char)tolower(buf[i]);
+        }
+    }
+    vpd83[j] = '\0';
+
+    if (j == 0 || _is_all_zeros(vpd83)) {
+        memset(vpd83, 0, _LSM_MAX_VPD83_ID_LEN);
+        _lsm_err_msg_set(err_msg, "NVMe eui is not set");
+        return LSM_ERR_NO_SUPPORT;
+    }
+
+    return LSM_ERR_OK;
+}
+
+static int _nvme_serial_get(char *err_msg, const char *blk_name,
+                            char **serial_num) {
+    char sysfs_path[_MAX_SYSFS_NVME_SERIAL_PATH_STR_LEN];
+    uint8_t buf[_LSM_MAX_SERIAL_NUM_LEN];
+    ssize_t read_size = 0;
+    int file_rc = 0;
+    char *trimmed = NULL;
+
+    snprintf(sysfs_path, sizeof(sysfs_path), _SYSFS_NVME_SERIAL_PATH_FORMAT,
+             blk_name);
+
+    file_rc = _read_file(sysfs_path, buf, &read_size, sizeof(buf));
+    if (file_rc != 0) {
+        _lsm_err_msg_set(err_msg, "Failed to read '%s'", sysfs_path);
+        return LSM_ERR_NO_SUPPORT;
+    }
+
+    /* Strip trailing newline */
+    if (read_size > 0 && buf[read_size - 1] == '\n')
+        buf[read_size - 1] = '\0';
+
+    buf[_LSM_MAX_SERIAL_NUM_LEN - 1] = '\0';
+    trimmed = _trim_spaces((char *)buf);
+    if (trimmed == NULL) {
+        _lsm_err_msg_set(err_msg, "NVMe serial number is empty");
+        return LSM_ERR_NO_SUPPORT;
+    }
+
+    *serial_num = strdup(trimmed);
+    if (*serial_num == NULL)
+        return LSM_ERR_NO_MEMORY;
+
+    return LSM_ERR_OK;
+}
+
 int lsm_local_disk_vpd83_search(const char *vpd83,
                                 lsm_string_list **disk_path_list,
                                 lsm_error **lsm_err) {
@@ -528,7 +671,7 @@ int lsm_local_disk_serial_num_get(const char *disk_path, char **serial_num,
                                   lsm_error **lsm_err) {
     uint8_t tmp_serial_num[_LSM_MAX_SERIAL_NUM_LEN];
     char *trimmed_serial_num = NULL;
-    const char *sd_name = NULL;
+    const char *blk_name = NULL;
     int rc = LSM_ERR_OK;
     char err_msg[_LSM_ERR_MSG_LEN];
 
@@ -553,16 +696,21 @@ int lsm_local_disk_serial_num_get(const char *disk_path, char **serial_num,
         goto out;
     }
 
-    if (strncmp(disk_path, "/dev/sd", strlen("/dev/sd")) != 0) {
-        rc = LSM_ERR_NO_SUPPORT;
-        _lsm_err_msg_set(err_msg, "we only support disk path start with "
-                                  "'/dev/sd' today");
+    blk_name = disk_path + strlen("/dev/");
+
+    if (strncmp(disk_path, "/dev/nvme", strlen("/dev/nvme")) == 0) {
+        rc = _nvme_serial_get(err_msg, blk_name, serial_num);
         goto out;
     }
 
-    sd_name = disk_path + strlen("/dev/");
+    if (strncmp(disk_path, "/dev/sd", strlen("/dev/sd")) != 0) {
+        rc = LSM_ERR_NO_SUPPORT;
+        _lsm_err_msg_set(err_msg, "Only support disk paths starting with "
+                                  "'/dev/sd' or '/dev/nvme'");
+        goto out;
+    }
 
-    rc = _sysfs_serial_num_of_sd_name(err_msg, sd_name, tmp_serial_num);
+    rc = _sysfs_serial_num_of_sd_name(err_msg, blk_name, tmp_serial_num);
     if (rc != LSM_ERR_OK)
         goto out;
 
@@ -604,7 +752,7 @@ out:
 int lsm_local_disk_vpd83_get(const char *disk_path, char **vpd83,
                              lsm_error **lsm_err) {
     char tmp_vpd83[_LSM_MAX_VPD83_ID_LEN];
-    const char *sd_name = NULL;
+    const char *blk_name = NULL;
     int rc = LSM_ERR_OK;
     char err_msg[_LSM_ERR_MSG_LEN];
 
@@ -628,19 +776,22 @@ int lsm_local_disk_vpd83_get(const char *disk_path, char **vpd83,
         goto out;
     }
 
-    if (strncmp(disk_path, "/dev/sd", strlen("/dev/sd")) != 0) {
+    blk_name = disk_path + strlen("/dev/");
+
+    if (strncmp(disk_path, "/dev/nvme", strlen("/dev/nvme")) == 0) {
+        rc = _nvme_nguid_get(err_msg, blk_name, tmp_vpd83);
+        if (rc == LSM_ERR_NO_SUPPORT)
+            rc = _nvme_eui_get(err_msg, blk_name, tmp_vpd83);
+    } else if (strncmp(disk_path, "/dev/sd", strlen("/dev/sd")) == 0) {
+        rc = _sysfs_vpd83_naa_of_sd_name(err_msg, blk_name, tmp_vpd83);
+        if (rc == LSM_ERR_NO_SUPPORT)
+            rc = _udev_vpd83_of_sd_name(err_msg, blk_name, tmp_vpd83);
+    } else {
         rc = LSM_ERR_NO_SUPPORT;
-        _lsm_err_msg_set(err_msg, "Only support disk path start with "
-                                  "'/dev/sd' yet");
+        _lsm_err_msg_set(err_msg, "Only support disk paths starting with "
+                                  "'/dev/sd' or '/dev/nvme'");
         goto out;
     }
-
-    sd_name = disk_path + strlen("/dev/");
-
-    rc = _sysfs_vpd83_naa_of_sd_name(err_msg, sd_name, tmp_vpd83);
-    if (rc == LSM_ERR_NO_SUPPORT)
-        /* Try udev if kernel does not expose vpd83 */
-        rc = _udev_vpd83_of_sd_name(err_msg, sd_name, tmp_vpd83);
 
     if (rc != LSM_ERR_OK)
         goto out;
@@ -679,6 +830,18 @@ int lsm_local_disk_rpm_get(const char *disk_path, int32_t *rpm,
     }
 
     _lsm_err_msg_clear(err_msg);
+
+    *lsm_err = NULL;
+
+    if (strncmp(disk_path, "/dev/nvme", strlen("/dev/nvme")) == 0) {
+        if (!_file_exists(disk_path)) {
+            rc = LSM_ERR_NOT_FOUND_DISK;
+            _lsm_err_msg_set(err_msg, "Disk %s not found", disk_path);
+            goto out;
+        }
+        *rpm = LSM_DISK_RPM_NON_ROTATING_MEDIUM;
+        goto out;
+    }
 
     _good(_sg_io_open_ro(err_msg, disk_path, &fd), rc, out);
     _good(_sg_io_vpd(err_msg, fd, _SG_T10_SBC_VPD_BLK_DEV_CHA, vpd_data), rc,
@@ -941,6 +1104,16 @@ int lsm_local_disk_link_type_get(const char *disk_path,
     *link_type = LSM_DISK_LINK_TYPE_NO_SUPPORT;
     *lsm_err = NULL;
 
+    if (strncmp(disk_path, "/dev/nvme", strlen("/dev/nvme")) == 0) {
+        if (!_file_exists(disk_path)) {
+            rc = LSM_ERR_NOT_FOUND_DISK;
+            _lsm_err_msg_set(err_msg, "Disk %s not found", disk_path);
+            goto out;
+        }
+        *link_type = LSM_DISK_LINK_TYPE_PCIE;
+        goto out;
+    }
+
     _good(_sg_io_open_ro(err_msg, disk_path, &fd), rc, out);
     _good(_sg_io_vpd(err_msg, fd, _SG_T10_SPC_VPD_SUP_VPD_PGS, vpd_sup_data),
           rc, out);
@@ -1202,7 +1375,8 @@ int lsm_local_disk_ident_led_on(const char *disk_path, lsm_error **lsm_err) {
 #ifdef HAVE_LEDMON
     return ledlib_set(disk_path, lsm_err, LSM_DISK_LED_STATUS_IDENT_ON);
 #else
-    (void)disk_path; (void)lsm_err;
+    (void)disk_path;
+    (void)lsm_err;
     return LSM_ERR_NO_SUPPORT;
 #endif
 }
@@ -1211,7 +1385,8 @@ int lsm_local_disk_ident_led_off(const char *disk_path, lsm_error **lsm_err) {
 #ifdef HAVE_LEDMON
     return ledlib_set(disk_path, lsm_err, LSM_DISK_LED_STATUS_IDENT_OFF);
 #else
-    (void)disk_path; (void)lsm_err;
+    (void)disk_path;
+    (void)lsm_err;
     return LSM_ERR_NO_SUPPORT;
 #endif
 }
@@ -1220,7 +1395,8 @@ int lsm_local_disk_fault_led_on(const char *disk_path, lsm_error **lsm_err) {
 #ifdef HAVE_LEDMON
     return ledlib_set(disk_path, lsm_err, LSM_DISK_LED_STATUS_FAULT_ON);
 #else
-    (void)disk_path; (void)lsm_err;
+    (void)disk_path;
+    (void)lsm_err;
     return LSM_ERR_NO_SUPPORT;
 #endif
 }
@@ -1229,7 +1405,8 @@ int lsm_local_disk_fault_led_off(const char *disk_path, lsm_error **lsm_err) {
 #ifdef HAVE_LEDMON
     return ledlib_set(disk_path, lsm_err, LSM_DISK_LED_STATUS_FAULT_OFF);
 #else
-    (void)disk_path; (void)lsm_err;
+    (void)disk_path;
+    (void)lsm_err;
     return LSM_ERR_NO_SUPPORT;
 #endif
 }
@@ -1750,48 +1927,67 @@ int lsm_led_slot_status_set(lsm_led_handle *handle, lsm_led_slot *slot,
 
     return rc;
 }
-#else /* !HAVE_LEDMON */
+#else  /* !HAVE_LEDMON */
 int LSM_DLL_EXPORT lsm_led_handle_get(lsm_led_handle **handle, lsm_flag flags) {
     (void)flags;
-    if (handle) *handle = NULL;
+    if (handle)
+        *handle = NULL;
     return LSM_ERR_NO_SUPPORT;
 }
-void LSM_DLL_EXPORT lsm_led_handle_free(lsm_led_handle *handle) { (void)handle; }
+void LSM_DLL_EXPORT lsm_led_handle_free(lsm_led_handle *handle) {
+    (void)handle;
+}
 int LSM_DLL_EXPORT lsm_led_slot_iterator_get(lsm_led_handle *handle,
-                              lsm_led_slot_itr **slot_itr, lsm_error **lsm_err,
-                              lsm_flag flags) {
-    (void)handle; (void)flags;
-    if (slot_itr) *slot_itr = NULL;
-    if (lsm_err) *lsm_err = NULL;
+                                             lsm_led_slot_itr **slot_itr,
+                                             lsm_error **lsm_err,
+                                             lsm_flag flags) {
+    (void)handle;
+    (void)flags;
+    if (slot_itr)
+        *slot_itr = NULL;
+    if (lsm_err)
+        *lsm_err = NULL;
     return LSM_ERR_NO_SUPPORT;
 }
 void LSM_DLL_EXPORT lsm_led_slot_iterator_free(lsm_led_handle *handle,
                                                lsm_led_slot_itr *slot_itr) {
-    (void)handle; (void)slot_itr;
+    (void)handle;
+    (void)slot_itr;
 }
 void LSM_DLL_EXPORT lsm_led_slot_iterator_reset(lsm_led_handle *handle,
                                                 lsm_led_slot_itr *slot_itr) {
-    (void)handle; (void)slot_itr;
+    (void)handle;
+    (void)slot_itr;
 }
 lsm_led_slot LSM_DLL_EXPORT *lsm_led_slot_next(lsm_led_handle *handle,
-                                lsm_led_slot_itr *slot_itr) {
-    (void)handle; (void)slot_itr;
+                                               lsm_led_slot_itr *slot_itr) {
+    (void)handle;
+    (void)slot_itr;
     return NULL;
 }
 const char LSM_DLL_EXPORT *lsm_led_slot_id(lsm_led_slot *slot) {
-    (void)slot; return NULL;
+    (void)slot;
+    return NULL;
 }
 const char LSM_DLL_EXPORT *lsm_led_slot_device(lsm_led_slot *slot) {
-    (void)slot; return NULL;
+    (void)slot;
+    return NULL;
 }
 uint32_t LSM_DLL_EXPORT lsm_led_slot_status_get(lsm_led_slot *slot) {
-    (void)slot; return LSM_DISK_LED_STATUS_UNKNOWN;
+    (void)slot;
+    return LSM_DISK_LED_STATUS_UNKNOWN;
 }
-int LSM_DLL_EXPORT lsm_led_slot_status_set(lsm_led_handle *handle, lsm_led_slot *slot,
-                            uint32_t led_state, lsm_error **lsm_err,
-                            lsm_flag flags) {
-    (void)handle; (void)slot; (void)led_state; (void)flags;
-    if (lsm_err) *lsm_err = NULL;
+int LSM_DLL_EXPORT lsm_led_slot_status_set(lsm_led_handle *handle,
+                                           lsm_led_slot *slot,
+                                           uint32_t led_state,
+                                           lsm_error **lsm_err,
+                                           lsm_flag flags) {
+    (void)handle;
+    (void)slot;
+    (void)led_state;
+    (void)flags;
+    if (lsm_err)
+        *lsm_err = NULL;
     return LSM_ERR_NO_SUPPORT;
 }
 #endif /* HAVE_LEDMON */

--- a/c_binding/lsm_mgmt.cpp
+++ b/c_binding/lsm_mgmt.cpp
@@ -2387,13 +2387,11 @@ int lsm_volume_raid_create(lsm_connect *c, const char *name,
     }
     if (raid_type == LSM_VOLUME_RAID_TYPE_RAID50 && disk_count < 6) {
         return log_exception(c, LSM_ERR_INVALID_ARGUMENT,
-                             "RAID 50 requires 6 or more disks",
-                             NULL);
+                             "RAID 50 requires 6 or more disks", NULL);
     }
     if (raid_type == LSM_VOLUME_RAID_TYPE_RAID60 && disk_count < 8) {
         return log_exception(c, LSM_ERR_INVALID_ARGUMENT,
-                             "RAID 60 requires 8 or more disks",
-                             NULL);
+                             "RAID 60 requires 8 or more disks", NULL);
     }
 
     if (CHECK_RP(new_volume)) {

--- a/plugin/arcconf_plugin/arcconf.py
+++ b/plugin/arcconf_plugin/arcconf.py
@@ -106,7 +106,6 @@ def _lsm_size_bytes_to_arcconf_mb(lsm_size):
     return lsm_size // (1024 * 1024)
 
 
-
 def _pool_id_of(sys_id, array_name):
     return "%s:%s" % (sys_id, array_name.replace(' ', ''))
 

--- a/plugin/hpsa_plugin/hpsa.py
+++ b/plugin/hpsa_plugin/hpsa.py
@@ -760,7 +760,8 @@ class SmartArray(IPlugin):
         if disk_path:
             vpd83 = LocalDisk.vpd83_get(disk_path)
         else:
-            vpd83 = ''
+            unique_id = hp_disk.get('Drive Unique ID', '').strip()
+            vpd83 = unique_id.lower() if unique_id else ''
 
         # If we cannot retrieve the disk name, the RPM is missing.  However,
         # 'Rotational Speed' is also missing when we have a functional device

--- a/plugin/smispy_plugin/smis_vol.py
+++ b/plugin/smispy_plugin/smis_vol.py
@@ -156,10 +156,7 @@ def _vpd83_of_cim_vol(cim_vol):
     if vpd_83:
         vpd_83 = vpd_83.lower()
 
-    if vpd_83 and Volume.vpd83_verify(vpd_83):
-        return vpd_83
-    else:
-        return ''
+    return vpd_83 if vpd_83 else ''
 
 
 def cim_vol_to_lsm_vol(cim_vol, pool_id, sys_id):

--- a/python_binding/lsm/_data.py
+++ b/python_binding/lsm/_data.py
@@ -255,11 +255,6 @@ class Disk(IData):
         self._status = _status
         self._system_id = _system_id
         self._plugin_data = _plugin_data
-        if _vpd83 and not Volume.vpd83_verify(_vpd83):
-            raise LsmError(
-                ErrorNumber.INVALID_ARGUMENT,
-                "Incorrect format of VPD 0x83 NAA(3) string: '%s', "
-                "expecting 32 or 16 hex characters" % _vpd83)
         self._vpd83 = _vpd83
         self._location = _location
         self._rpm = _rpm
@@ -473,11 +468,6 @@ class Volume(IData):
                  _plugin_data=None):
         self._id = _id  # Identifier
         self._name = _name  # Human recognisable name
-        if _vpd83 and not Volume.vpd83_verify(_vpd83):
-            raise LsmError(
-                ErrorNumber.INVALID_ARGUMENT,
-                "Incorrect format of VPD 0x83 NAA(3) string: '%s', "
-                "expecting 32 or 16 hex characters" % _vpd83)
         self._vpd83 = _vpd83  # SCSI page 83 unique ID
         self._block_size = _block_size  # Block size
         self._num_of_blocks = _num_of_blocks  # Number of blocks


### PR DESCRIPTION
https://github.com/libstorage/libstoragemgmt/issues/135 discussed the lack of NVMe support.  This pull request addresses this need.

Additionally, a small update to hpsa plugin was done, so that we could have this information available when it's not available once the storage devices are part of a RAID group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced NVMe device support with improved serial number and VPD 0x83 identification, including NVMe-specific probing and conversion.
  * Added SPC-5 VPD designation descriptor type support for EUI-64.
* **Bug Fixes**
  * Improved VPD 0x83 handling: broadened accepted hex lengths (16/24/32) and reduced over-restrictive validation so provided values are preserved more consistently across bindings/plugins.
  * Improved SCSI/NVMe VPD 0x83 resolution (including EUI-64 fallback) and corrected NVMe RPM/link type classification.
  * Improved HPSa disk identification when Disk Name is missing.
* **Documentation**
  * Updated installation guide bootstrapping guidance and expanded VPD 0x83 API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


CI Kick