### PR TITLE
Misc. corrections for plugin_test.py.in and megaraid plugin

### DIFF
--- a/plugin/megaraid_plugin/megaraid.py
+++ b/plugin/megaraid_plugin/megaraid.py
@@ -870,8 +870,10 @@ class MegaRAID(IPlugin):
         cap_output = self._storcli_exec([mega_sys_path, "show",
                                          "all"])['Capabilities']
 
-        mega_raid_types = \
+        mega_raid_types = [
+            t.split('(')[0] for t in
             cap_output['RAID Level Supported'].replace(', \n', '').split(', ')
+        ]
 
         supported_raid_types = []
         for cur_mega_raid_type in list(_RAID_TYPE_MAP.keys()):

--- a/test/plugin_test.py.in
+++ b/test/plugin_test.py.in
@@ -532,10 +532,9 @@ class TestPlugin(unittest.TestCase):
                     len(volumes) > 0, "We need at least 1 volume to test")
                 for v in volumes:
 
-                    # Don't test this on HDS as VPD is empty
-                    if '10.1.134.227' not in TestPlugin.URI:
+                    if v.vpd83:
                         self.assertTrue(
-                            lsm.Volume.vpd83_verify(v.vpd83),
+                            lsm.Volume.vpd83_verify(v.vpd83.lower()),
                             "VPD is not as expected '%s' for volume id: '%s'" %
                             (v.vpd83, v.id))
                 if flag_created:

--- a/test/plugin_test.py.in
+++ b/test/plugin_test.py.in
@@ -490,6 +490,21 @@ class TestPlugin(unittest.TestCase):
                     self._volume_create(s.id)
                     flag_created = True
                     break
+                if supported(cap, [Cap.VOLUME_RAID_CREATE, Cap.VOLUME_DELETE]):
+                    free_disks = [
+                        d for d in self.c.disks()
+                        if d.status & lsm.Disk.STATUS_FREE
+                    ]
+                    if free_disks:
+                        supported_raid_types, _ = \
+                            self.c.volume_raid_create_cap_get(s)
+                        if supported_raid_types:
+                            raid_type = supported_raid_types[0]
+                            _, new_vol = self._create_raid_vol(
+                                raid_type, free_disks, rs('v'))
+                            if new_vol is not None:
+                                flag_created = True
+                                break
             volumes = self.c.volumes()
 
         return volumes, flag_created
@@ -1561,44 +1576,35 @@ class TestPlugin(unittest.TestCase):
     def test_volume_raid_create(self):
         for s in self.systems:
             cap = self.c.capabilities(s)
-            # TODO(Gris Ge): Add test code for other RAID type and strip size
             if supported(cap, [Cap.VOLUME_RAID_CREATE]):
                 supported_raid_types, supported_strip_sizes = \
                     self.c.volume_raid_create_cap_get(s)
-                if lsm.Volume.RAID_TYPE_RAID1 not in supported_raid_types:
-                    self._skip_current_test(
-                        "Skip test: current system does not support "
-                        "creating RAID1 volume")
 
-                # Find two free disks
-                free_disks = []
-                for disk in self.c.disks():
-                    if len(free_disks) == 2:
+                free_disks = [
+                    d for d in self.c.disks()
+                    if d.status & lsm.Disk.STATUS_FREE
+                ]
+
+                new_vol = None
+                for rt in supported_raid_types:
+                    had_enough, new_vol = self._create_raid_vol(
+                        rt, free_disks, rs('v'))
+                    if had_enough:
                         break
-                    if disk.status & lsm.Disk.STATUS_FREE:
-                        free_disks.append(disk)
 
-                if len(free_disks) != 2:
+                if new_vol is None:
                     self._skip_current_test(
-                        "Skip test: Failed to find two free disks for RAID 1")
+                        "Skip test: not enough free disks for any "
+                        "supported RAID type")
                     return
 
-                new_vol = self.c.volume_raid_create(
-                    rs('v'), lsm.Volume.RAID_TYPE_RAID1, free_disks,
-                    lsm.Volume.VCR_STRIP_SIZE_DEFAULT)
-
-                self.assertTrue(new_vol is not None)
-
-                # TODO(Gris Ge): Use volume_raid_info() and pool_member_info()
-                # to verify size, raid_type, member type, member ids.
-
                 if supported(cap, [Cap.VOLUME_DELETE]):
+                    free_disk_ids = [d.id for d in free_disks]
                     self._volume_delete(new_vol)
 
                     updated_disks = []
-                    # Check whether disks are been set back to free mode.
                     for disk in self.c.disks():
-                        if disk.id in list(d.id for d in free_disks):
+                        if disk.id in free_disk_ids:
                             updated_disks.append(disk)
                             self.assertTrue(
                                 disk.status & lsm.Disk.STATUS_FREE,
@@ -1607,7 +1613,7 @@ class TestPlugin(unittest.TestCase):
                                 disk.id)
 
                     self.assertTrue(
-                        len(updated_disks) == 2,
+                        len(updated_disks) == len(free_disks),
                         "Disk missing after volume_delete() on "
                         "a raid volume")
 


### PR DESCRIPTION
### MegaRAID plugin changes

* Some MegaRAID adapters (e.g. SAS 3808) report RAID types with
    parenthetical qualifiers like "RAID1(2 or more drives)" and
    "RAID10(2 or more drives per span)" in the storcli "RAID Level
    Supported" output. The existing exact-match parsing only matched
    bare names like "RAID0", silently dropping RAID1/RAID10 support.
    
* Strip the "(..." suffix before matching against _RAID_TYPE_MAP.
 This is backwards compatible: split('(')[0] on a string without
 parentheses returns the original string unchanged.

### plugin_test.py.in

*  _find_or_create_volumes assumed VOLUME_CREATE (pool-based) was available, but hardware RAID controllers like MegaRAID only support VOLUME_RAID_CREATE (creating from free disks). Add a fallback path that uses volume_raid_create when no pools exist.
* Remove hard coded IP address, we will check of the vpd contains something.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization for RAID configuration handling.

* **Tests**
  * Enhanced storage volume creation testing to dynamically select from supported RAID configurations based on available disks.
  * Improved storage validation testing with more flexible verification.
  * Strengthened post-deletion disk status recovery validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->