### PR TITLE
configure.ac: make ledmon optional, fix systemd variable name mismatch

### DIFF
--- a/c_binding/Makefile.am
+++ b/c_binding/Makefile.am
@@ -3,12 +3,19 @@ SUBDIRS = include
 AM_CPPFLAGS = 	-I$(top_srcdir)/c_binding/include \
 				-I$(top_builddir)/c_binding/include \
 				$(LIBGLIB_CFLAGS) \
-				$(LIBUDEV_CFLAGS) \
-				$(LIBLED_CFLAGS)
+				$(LIBUDEV_CFLAGS)
+
+if WITH_LEDMON
+AM_CPPFLAGS += $(LIBLED_CFLAGS)
+endif
 
 lib_LTLIBRARIES = libstoragemgmt.la
 
-libstoragemgmt_la_LIBADD=$(LIBXML_LIBS) $(LIBGLIB_LIBS) $(LIBUDEV_LIBS) $(LIBLED_LIBS)
+libstoragemgmt_la_LIBADD=$(LIBXML_LIBS) $(LIBGLIB_LIBS) $(LIBUDEV_LIBS)
+
+if WITH_LEDMON
+libstoragemgmt_la_LIBADD += $(LIBLED_LIBS)
+endif
 
 libstoragemgmt_la_LDFLAGS= -version-info $(LIBSM_LIBTOOL_VERSION)
 libstoragemgmt_la_SOURCES= \

--- a/c_binding/lsm_datatypes.hpp
+++ b/c_binding/lsm_datatypes.hpp
@@ -16,7 +16,9 @@
 #include "libstoragemgmt/libstoragemgmt_plug_interface.h"
 #include "lsm_ipc.hpp"
 #include <glib.h>
+#ifdef HAVE_LEDMON
 #include <led/libled.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -313,21 +315,33 @@ struct LSM_DLL_LOCAL _lsm_battery {
 #define LSM_IS_LED_HANDLE(obj) MAGIC_CHECK(obj, LSM_LED_HANDLE_MAGIC)
 struct LSM_DLL_LOCAL _lsm_led_handle {
     uint32_t magic;
+#ifdef HAVE_LEDMON
     struct led_ctx *ctx;
+#else
+    void *ctx;
+#endif
 };
 
 #define LSM_LED_SLOT_MAGIC         0xAA7A0016
 #define LSM_IS_LED_SLOT_ENTRY(obj) MAGIC_CHECK(obj, LSM_LED_SLOT_MAGIC)
 struct LSM_DLL_LOCAL _lsm_led_slot {
     uint32_t magic;
+#ifdef HAVE_LEDMON
     struct led_slot_list_entry *slot;
+#else
+    void *slot;
+#endif
 };
 
 #define LSM_LED_SLOT_ITR_MAGIC   0xAA7A0015
 #define LSM_IS_LED_SLOT_ITR(obj) MAGIC_CHECK(obj, LSM_LED_SLOT_ITR_MAGIC)
 struct LSM_DLL_LOCAL _lsm_led_slot_itr {
     uint32_t magic;
+#ifdef HAVE_LEDMON
     struct led_slot_list *sl;
+#else
+    void *sl;
+#endif
     struct _lsm_led_slot entry;
 };
 

--- a/c_binding/lsm_local_disk.cpp
+++ b/c_binding/lsm_local_disk.cpp
@@ -12,7 +12,9 @@
 #include <endian.h>
 #include <errno.h>
 #include <fcntl.h>
+#ifdef HAVE_LEDMON
 #include <led/libled.h>
+#endif
 #include <libudev.h>
 #include <limits.h>
 #include <math.h> /* For log10() */
@@ -1021,6 +1023,7 @@ out:
     return rc;
 }
 
+#ifdef HAVE_LEDMON
 int led_ctx_slot_entry_get(const char *disk_path, struct led_ctx **ctx,
                            struct led_slot_list_entry **se,
                            lsm_error **lsm_err) {
@@ -1193,21 +1196,42 @@ out:
     led_free(ctx);
     return rc;
 }
+#endif /* HAVE_LEDMON */
 
 int lsm_local_disk_ident_led_on(const char *disk_path, lsm_error **lsm_err) {
+#ifdef HAVE_LEDMON
     return ledlib_set(disk_path, lsm_err, LSM_DISK_LED_STATUS_IDENT_ON);
+#else
+    (void)disk_path; (void)lsm_err;
+    return LSM_ERR_NO_SUPPORT;
+#endif
 }
 
 int lsm_local_disk_ident_led_off(const char *disk_path, lsm_error **lsm_err) {
+#ifdef HAVE_LEDMON
     return ledlib_set(disk_path, lsm_err, LSM_DISK_LED_STATUS_IDENT_OFF);
+#else
+    (void)disk_path; (void)lsm_err;
+    return LSM_ERR_NO_SUPPORT;
+#endif
 }
 
 int lsm_local_disk_fault_led_on(const char *disk_path, lsm_error **lsm_err) {
+#ifdef HAVE_LEDMON
     return ledlib_set(disk_path, lsm_err, LSM_DISK_LED_STATUS_FAULT_ON);
+#else
+    (void)disk_path; (void)lsm_err;
+    return LSM_ERR_NO_SUPPORT;
+#endif
 }
 
 int lsm_local_disk_fault_led_off(const char *disk_path, lsm_error **lsm_err) {
+#ifdef HAVE_LEDMON
     return ledlib_set(disk_path, lsm_err, LSM_DISK_LED_STATUS_FAULT_OFF);
+#else
+    (void)disk_path; (void)lsm_err;
+    return LSM_ERR_NO_SUPPORT;
+#endif
 }
 
 static void _sysfs_sas_addr_get(const char *blk_name, char *tp_sas_addr) {
@@ -1283,6 +1307,7 @@ out:
 int LSM_DLL_EXPORT lsm_local_disk_led_status_get(const char *disk_path,
                                                  uint32_t *led_status,
                                                  lsm_error **lsm_err) {
+#ifdef HAVE_LEDMON
     int rc = LSM_ERR_OK;
     char err_msg[_LSM_ERR_MSG_LEN];
     struct led_ctx *ctx = NULL;
@@ -1334,6 +1359,10 @@ out:
     led_slot_list_entry_free(slot_entry);
     led_free(ctx);
     return rc;
+#else
+    (void)disk_path; (void)led_status; (void)lsm_err;
+    return LSM_ERR_NO_SUPPORT;
+#endif
 }
 
 int lsm_local_disk_link_speed_get(const char *disk_path, uint32_t *link_speed,
@@ -1439,6 +1468,7 @@ out:
     return rc;
 }
 
+#ifdef HAVE_LEDMON
 lsm_error *translate_led_to_lsm(led_status_t led_error, const char *msg) {
     lsm_error_number rc = LSM_ERR_OK;
 
@@ -1481,7 +1511,9 @@ lsm_error *translate_led_to_lsm(led_status_t led_error, const char *msg) {
     }
     return NULL;
 }
+#endif /* HAVE_LEDMON (translate_led_to_lsm) */
 
+#ifdef HAVE_LEDMON
 int lsm_led_handle_get(lsm_led_handle **handle, lsm_flag flags) {
     led_ctx *ctx = NULL;
 
@@ -1624,7 +1656,6 @@ uint32_t lsm_led_slot_status_get(lsm_led_slot *slot) {
         }
 
         if (cntrl != LED_CNTRL_TYPE_SCSI) {
-            // Mask off fault LED (clear any FAULT_* state)
             translated &=
                 ~(LSM_DISK_LED_STATUS_FAULT_ON | LSM_DISK_LED_STATUS_FAULT_OFF |
                   LSM_DISK_LED_STATUS_FAULT_UNKNOWN);
@@ -1633,6 +1664,7 @@ uint32_t lsm_led_slot_status_get(lsm_led_slot *slot) {
 
     return translated;
 }
+
 int lsm_led_slot_status_set(lsm_led_handle *handle, lsm_led_slot *slot,
                             uint32_t led_state, lsm_error **lsm_err,
                             lsm_flag flags) {
@@ -1697,3 +1729,48 @@ int lsm_led_slot_status_set(lsm_led_handle *handle, lsm_led_slot *slot,
 
     return rc;
 }
+#else /* !HAVE_LEDMON */
+int LSM_DLL_EXPORT lsm_led_handle_get(lsm_led_handle **handle, lsm_flag flags) {
+    (void)flags;
+    if (handle) *handle = NULL;
+    return LSM_ERR_NO_SUPPORT;
+}
+void LSM_DLL_EXPORT lsm_led_handle_free(lsm_led_handle *handle) { (void)handle; }
+int LSM_DLL_EXPORT lsm_led_slot_iterator_get(lsm_led_handle *handle,
+                              lsm_led_slot_itr **slot_itr, lsm_error **lsm_err,
+                              lsm_flag flags) {
+    (void)handle; (void)flags;
+    if (slot_itr) *slot_itr = NULL;
+    if (lsm_err) *lsm_err = NULL;
+    return LSM_ERR_NO_SUPPORT;
+}
+void LSM_DLL_EXPORT lsm_led_slot_iterator_free(lsm_led_handle *handle,
+                                               lsm_led_slot_itr *slot_itr) {
+    (void)handle; (void)slot_itr;
+}
+void LSM_DLL_EXPORT lsm_led_slot_iterator_reset(lsm_led_handle *handle,
+                                                lsm_led_slot_itr *slot_itr) {
+    (void)handle; (void)slot_itr;
+}
+lsm_led_slot LSM_DLL_EXPORT *lsm_led_slot_next(lsm_led_handle *handle,
+                                lsm_led_slot_itr *slot_itr) {
+    (void)handle; (void)slot_itr;
+    return NULL;
+}
+const char LSM_DLL_EXPORT *lsm_led_slot_id(lsm_led_slot *slot) {
+    (void)slot; return NULL;
+}
+const char LSM_DLL_EXPORT *lsm_led_slot_device(lsm_led_slot *slot) {
+    (void)slot; return NULL;
+}
+uint32_t LSM_DLL_EXPORT lsm_led_slot_status_get(lsm_led_slot *slot) {
+    (void)slot; return LSM_DISK_LED_STATUS_UNKNOWN;
+}
+int LSM_DLL_EXPORT lsm_led_slot_status_set(lsm_led_handle *handle, lsm_led_slot *slot,
+                            uint32_t led_state, lsm_error **lsm_err,
+                            lsm_flag flags) {
+    (void)handle; (void)slot; (void)led_state; (void)flags;
+    if (lsm_err) *lsm_err = NULL;
+    return LSM_ERR_NO_SUPPORT;
+}
+#endif /* HAVE_LEDMON */

--- a/configure.ac
+++ b/configure.ac
@@ -375,7 +375,11 @@ AC_SUBST([bashcompletiondir], [$with_bash_completion_dir])
 PKG_PROG_PKG_CONFIG
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
-        [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+        [with_systemdsystemunitdir=$withval],
+        [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd 2>/dev/null)
+         if test -z "$with_systemdsystemunitdir" && $PKG_CONFIG --exists systemd 2>/dev/null; then
+             with_systemdsystemunitdir=/lib/systemd/system
+         fi])
 if test "x$with_systemdsystemunitdir" != xno; then
         AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 fi
@@ -383,7 +387,11 @@ fi
 #Setup the sysusersdir for systemd stuff
 AC_ARG_WITH([systemd-sysusersdir],
         AS_HELP_STRING([--with-systemd-sysusersdir=DIR], [Directory for systemd sysusers files]),
-        [], [with_systemdsysusersdir=$($PKG_CONFIG --variable=sysusersdir systemd)])
+        [with_systemdsysusersdir=$withval],
+        [with_systemdsysusersdir=$($PKG_CONFIG --variable=sysusersdir systemd 2>/dev/null)
+         if test -z "$with_systemdsysusersdir" && $PKG_CONFIG --exists systemd 2>/dev/null; then
+             with_systemdsysusersdir=/usr/lib/sysusers.d
+         fi])
 if test "x$with_systemdsysusersdir" != xno; then
         AC_SUBST([systemdsysusersdir], [$with_systemdsysusersdir])
 fi
@@ -391,7 +399,11 @@ fi
 #Setup the tmpfilesdir for systemd stuff
 AC_ARG_WITH([systemd-tmpfilesdir],
         AS_HELP_STRING([--with-systemd-tmpfilesdir=DIR], [Directory for systemd temporary files]),
-        [], [with_systemdtmpfilesdir=$($PKG_CONFIG --variable=tmpfilesdir systemd)])
+        [with_systemdtmpfilesdir=$withval],
+        [with_systemdtmpfilesdir=$($PKG_CONFIG --variable=tmpfilesdir systemd 2>/dev/null)
+         if test -z "$with_systemdtmpfilesdir" && $PKG_CONFIG --exists systemd 2>/dev/null; then
+             with_systemdtmpfilesdir=/usr/lib/tmpfiles.d
+         fi])
 if test "x$with_systemdtmpfilesdir" != xno; then
         AC_SUBST([systemdtmpfilesdir], [$with_systemdtmpfilesdir])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,18 @@ fi
 PKG_CHECK_MODULES([SQLITE3], [sqlite3])
 
 # Check for lib led
-PKG_CHECK_MODULES([LIBLED], [ledmon])
+AC_ARG_WITH([ledmon],
+    [AS_HELP_STRING([--without-ledmon],
+        [Disable LED slot management support (requires ledmon library)])],
+    [],
+    [with_ledmon=yes])
+
+AM_CONDITIONAL([WITH_LEDMON], [test "x$with_ledmon" = "xyes"])
+
+if test "x$with_ledmon" = "xyes"; then
+    PKG_CHECK_MODULES([LIBLED], [ledmon])
+    AC_DEFINE([HAVE_LEDMON], [1], [Define if the ledmon library is available])
+fi
 
 dnl if --prefix is /usr, don't use /usr/var for localstatedir
 dnl or /usr/etc for sysconfdir


### PR DESCRIPTION
## Summary

Two fixes to `configure.ac` to improve portability across distributions:

- **Make ledmon optional**: `libled` (ledmon) was a hard build requirement via `PKG_CHECK_MODULES`, preventing builds on distributions that do not package libled as a development library (e.g. Debian, Ubuntu). This adds `--with-ledmon` / `--without-ledmon` configure flags. When ledmon is absent or disabled, all LED API functions return `LSM_ERR_NO_SUPPORT` cleanly, matching the behaviour of other optional features in the library.

- **Fix systemd `AC_ARG_WITH` variable name mismatch**: `AC_ARG_WITH` converts hyphens to underscores in shell variable names, so `--with-systemd-systemunitdir` sets `$with_systemd_systemunitdir`. The three systemd `AC_ARG_WITH` blocks were missing `ACTION-IF-GIVEN` clauses, so the intended variables were never assigned and `HAVE_SYSTEMD` was always false even when systemd was present. Also adds `pkg-config` fallback defaults for environments where `pkg-config systemd` returns an empty path.

## Test plan

- [ ] Build with ledmon present (`--with-ledmon`): LED API functions work as before
- [ ] Build without ledmon (`--without-ledmon`): library builds cleanly; LED API functions return `LSM_ERR_NO_SUPPORT`
- [ ] Build on Debian bookworm (no libled-dev): builds successfully with `--without-ledmon`
- [ ] Verify systemd service/sysusers/tmpfiles files install correctly when libsystemd-dev is present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a `--without-ledmon` build option to optionally disable LED monitoring support during installation.

* **Improvements**
  * LED operations now gracefully report unavailability when LED monitoring is disabled.
  * LED status/behavior is adjusted for non-SCSI controllers.
  * Enhanced systemd installation path configuration with improved fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

CI-KICK