### PR TITLE
ci: add Debian bookworm CI and fix !HAVE_LEDMON argument validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,21 @@ jobs:
          command: ./test/docker_ci_test.sh
          no_output_timeout: 20m
 
+  debian:
+    docker:
+      - image: debian:bookworm
+    steps:
+      - run:
+         command: apt-get update -q && apt-get install -y git
+         no_output_timeout: 5m
+      - checkout
+      - run:
+         command: ./test/docker_ci_test.sh
+         no_output_timeout: 20m
+
 workflows:
   version: 2
   workflow:
     jobs:
     - fedora
+    - debian

--- a/c_binding/lsm_local_disk.cpp
+++ b/c_binding/lsm_local_disk.cpp
@@ -1360,8 +1360,29 @@ out:
     led_free(ctx);
     return rc;
 #else
-    (void)disk_path; (void)led_status; (void)lsm_err;
-    return LSM_ERR_NO_SUPPORT;
+    char err_msg[_LSM_ERR_MSG_LEN];
+    int rc = LSM_ERR_OK;
+    _lsm_err_msg_clear(err_msg);
+    if (lsm_err != NULL)
+        *lsm_err = NULL;
+    _good(_check_null_ptr(err_msg, 3 /* arg_count */, disk_path, led_status,
+                          lsm_err),
+          rc, out);
+    *led_status = LSM_DISK_LED_STATUS_UNKNOWN;
+    if (!_file_exists(disk_path)) {
+        rc = LSM_ERR_NOT_FOUND_DISK;
+        _lsm_err_msg_set(err_msg, "Disk %s not found", disk_path);
+        goto out;
+    }
+    rc = LSM_ERR_NO_SUPPORT;
+out:
+    if (rc != LSM_ERR_OK) {
+        if (led_status != NULL)
+            *led_status = LSM_DISK_LED_STATUS_UNKNOWN;
+        if (lsm_err != NULL && *lsm_err == NULL)
+            *lsm_err = LSM_ERROR_CREATE_PLUGIN_MSG(rc, err_msg);
+    }
+    return rc;
 #endif
 }
 

--- a/deb_dependency
+++ b/deb_dependency
@@ -12,6 +12,8 @@ libglib2.0-dev
 libssl-dev
 libconfig-dev
 libudev-dev
+libsystemd-dev
+pkg-config
 python3-dev
 perl
 valgrind

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,10 @@ override_dh_auto_configure:
 		--disable-static \
 		--without-test \
 		--without-smispy \
-		--without-ledmon
+		--without-ledmon \
+		--with-systemdsystemunitdir=/usr/lib/systemd/system \
+		--with-systemd-sysusersdir=/usr/lib/sysusers.d \
+		--with-systemd-tmpfilesdir=/usr/lib/tmpfiles.d
 
 override_dh_auto_install:
 	dh_auto_install

--- a/test/docker_ci_test.sh
+++ b/test/docker_ci_test.sh
@@ -73,7 +73,7 @@ fi
 # Configure is almost doing the "right thing" by default in most cases,
 # but not for all.
 if [ "CHK$IS_DEB" = "CHK1" ];then
-    ./configure --with-python3 --without-mem-leak-test --without-smispy  || exit 1
+    ./configure --without-mem-leak-test --without-smispy --without-ledmon || exit 1
 else
     ./configure --without-mem-leak-test || exit 1
 fi


### PR DESCRIPTION
## Summary

- Adds Debian bookworm to the CircleCI matrix alongside the existing Fedora job
- Fixes `docker_ci_test.sh` configure flags for Debian (`--without-mem-leak-test --without-smispy --without-ledmon`)
- Adds `libsystemd-dev` and `pkg-config` to `deb_dependency` for the build container
- Runs `make deb` at the end of the Debian CI job to validate package builds
- Fixes the `!HAVE_LEDMON` stub in `lsm_local_disk_led_status_get`: the stub was silently discarding NULL arguments and returning `LSM_ERR_NO_SUPPORT`; it now validates arguments (`LSM_ERR_INVALID_ARGUMENT`) and checks disk existence (`LSM_ERR_NOT_FOUND_DISK`), matching what the test suite expects

## Test plan

- [ ] CircleCI Debian job passes `make check` and `make deb`
- [ ] CircleCI Fedora job continues to pass (no regression)
- [ ] `test_local_disk_led_status_get` passes on a build without ledmon support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Debian-based CI coverage alongside the existing Fedora job.
  * Expanded Debian packaging support with additional required build dependencies.

* **Bug Fixes**
  * Improved disk LED status handling so missing disks now report a clear “not found” error instead of only a generic unsupported result.
  * Set sensible default LED status values when the feature is unavailable.

* **Chores**
  * Updated Debian build and CI configuration for the new platform-specific setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->