### PR TITLE
megaraid: fix NVMe JSON key

### DIFF
--- a/deb_dependency
+++ b/deb_dependency
@@ -15,6 +15,7 @@ libudev-dev
 libsystemd-dev
 pkg-config
 python3-dev
+python3-pytest
 perl
 valgrind
 chrpath

--- a/plugin/megaraid_plugin/megaraid.py
+++ b/plugin/megaraid_plugin/megaraid.py
@@ -16,7 +16,7 @@ from lsm import (uri_parse, search_property, size_human_2_size_bytes,
                  Capabilities, LsmError, ErrorNumber, System, Client, Disk,
                  VERSION, IPlugin, Pool, Volume, Battery, int_div)
 
-from megaraid_plugin.utils import cmd_exec, ExecError
+from megaraid_plugin.utils import cmd_exec, ExecError, select_disk_model
 
 # Naming scheme
 #   mega_sys_path   /c0
@@ -599,10 +599,10 @@ class MegaRAID(IPlugin):
                     'Drive %s State' % mega_disk_path]
 
                 disk_id = disk_show_attr_dict['SN'].strip()
+                disk_model = select_disk_model(disk_show_attr_dict)
                 disk_name = "Disk %s %s %s" % (
                     disk_show_basic_dict['DID'],
-                    disk_show_attr_dict['Manufacturer Id'].strip(),
-                    disk_show_attr_dict['Model Number'])
+                    disk_show_attr_dict['Manufacturer Id'].strip(), disk_model)
                 disk_type = _disk_type_of(disk_show_basic_dict)
                 blk_size = size_human_2_size_bytes(
                     disk_show_basic_dict['SeSz'])

--- a/plugin/megaraid_plugin/utils.py
+++ b/plugin/megaraid_plugin/utils.py
@@ -26,6 +26,14 @@ def cmd_exec(cmds):
     return str_stdout
 
 
+def select_disk_model(attr_dict):
+    """Select disk model from storcli device attributes.
+
+    NVMe drives use 'Model Number'; SAS/SATA use 'Model'.
+    """
+    return (attr_dict.get('Model Number') or attr_dict.get('Model', ''))
+
+
 class ExecError(Exception):
 
     def __init__(self, cmd, errno, stdout, stderr, *args, **kwargs):

--- a/rh_py3_rpm_dependency
+++ b/rh_py3_rpm_dependency
@@ -16,6 +16,7 @@ make
 perl
 procps-ng
 python3-devel
+python3-pytest
 python3-pywbem
 python3-six
 sqlite-devel

--- a/test/runtests.sh.in
+++ b/test/runtests.sh.in
@@ -36,6 +36,10 @@ echo "src_dir = ${src_dir}"
 echo "Starting in dir =  $(pwd)"
 
 
+# Standalone Python unit tests (no daemon, no C extension required)
+echo "Running standalone Python unit tests"
+_good python3 -m pytest "${src_dir}/test/test_megaraid.py" -v
+
 # Fetch and test the golang module to ensure we didn't break it
 arch=$(uname -m)
 if [ "CHK${arch}" != "CHKppc64" ] && [ "${src_dir}" == "${build_dir}" ] && [ "$EUID" -eq 0 ] ; then

--- a/test/test_megaraid.py
+++ b/test/test_megaraid.py
@@ -1,0 +1,43 @@
+import importlib.util
+import os
+import unittest
+
+# Import utils directly to avoid megaraid_plugin.__init__ pulling in lsm (C extension).
+_utils_path = os.path.join(
+    os.path.dirname(__file__), '..', 'plugin', 'megaraid_plugin', 'utils.py')
+_spec = importlib.util.spec_from_file_location("megaraid_utils", _utils_path)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+select_disk_model = _mod.select_disk_model
+
+
+class TestDiskModelSelection(unittest.TestCase):
+    """Test the disk model fallback logic used in MegaRAID disk discovery."""
+
+    def test_model_number_populated(self):
+        attr = {'Model Number': 'Samsung SSD 990', 'Model': 'old-model'}
+        self.assertEqual(select_disk_model(attr), 'Samsung SSD 990')
+
+    def test_model_number_empty_falls_back_to_model(self):
+        attr = {'Model Number': '', 'Model': 'Seagate ST8000'}
+        self.assertEqual(select_disk_model(attr), 'Seagate ST8000')
+
+    def test_model_number_none_falls_back_to_model(self):
+        attr = {'Model Number': None, 'Model': 'WDC WD4003'}
+        self.assertEqual(select_disk_model(attr), 'WDC WD4003')
+
+    def test_model_number_absent_falls_back_to_model(self):
+        attr = {'Model': 'HGST HUH72'}
+        self.assertEqual(select_disk_model(attr), 'HGST HUH72')
+
+    def test_both_absent(self):
+        attr = {}
+        self.assertEqual(select_disk_model(attr), '')
+
+    def test_model_number_only(self):
+        attr = {'Model Number': 'Intel SSDPE2'}
+        self.assertEqual(select_disk_model(attr), 'Intel SSDPE2')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When a megaraid controller has NVMe devices, it appears that "Model Number" becomes "Model".  I checked the last 8 versions of storecli and they had the same behavior, so it's been this way for a long time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MegaRAID disk name detection across supported StorCLI output formats.
  * Added fallback handling when the primary model information is empty, unavailable, or missing.
  * Prevented incomplete model data from producing invalid disk names.
* **Tests**
  * Added coverage for model selection, fallback behavior, and missing disk attributes.
  * Enabled standalone MegaRAID validation without requiring the full daemon environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->